### PR TITLE
ci(k8s): run integration tests every 12h

### DIFF
--- a/.github/workflows/k8s-integration.yaml
+++ b/.github/workflows/k8s-integration.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+   - cron: '* */12 * * *'
 
 jobs:
   crd-e2e:


### PR DESCRIPTION
ref ovrclk/engineering#418

Signed-off-by: Artur Troian <troian.ap@gmail.com>