### PR TITLE
fix: use StreamWithContext instead to avoid possible resource leaks

### DIFF
--- a/cluster/kube/client_exec.go
+++ b/cluster/kube/client_exec.go
@@ -164,7 +164,7 @@ loop:
 
 	// Run, passing in the streams and everything else. This runs until the remote end closes
 	// or the streams close
-	err = exec.Stream(remotecommand.StreamOptions{
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:             stdin,  // any reader
 		Stdout:            stdout, // any writer
 		Stderr:            stderr, // any writer


### PR DESCRIPTION
Signed-off-by: Artur Troian <troian.ap@gmail.com>
