### PR TITLE
fix(_run): double default rollout timeout

### DIFF
--- a/_run/common-kube.mk
+++ b/_run/common-kube.mk
@@ -7,7 +7,7 @@ include ../common-kind.mk
 KUBE_SSH_NODE_NAME         ?= akash-gpu
 KUBE_UPLOAD_AKASH_IMAGE    ?= false
 KUBE_CLUSTER_CREATE_TARGET ?= default
-KUBE_ROLLOUT_TIMEOUT       ?= 90
+KUBE_ROLLOUT_TIMEOUT       ?= 180
 
 INGRESS_CONFIG_PATH       ?= ../ingress-nginx.yaml
 CALICO_MANIFEST           ?= https://github.com/projectcalico/calico/blob/v3.25.0/manifests/calico.yaml


### PR DESCRIPTION
in some circumstances like high CPU load
rollot of the service in kind cluster may
make a while

Signed-off-by: Artur Troian <troian.ap@gmail.com>
