### PR TITLE
fix: use Sprintf to format metrics for log

### DIFF
--- a/cluster/inventory.go
+++ b/cluster/inventory.go
@@ -597,7 +597,7 @@ loop:
 			if fetchCount%is.config.InventoryResourceDebugFrequency == 0 {
 				data, err := json.Marshal(&metrics)
 				if err == nil {
-					is.log.Debug("cluster resources", "dump", data)
+					is.log.Debug(fmt.Sprintf("cluster resources dump=%s", string(data)))
 				} else {
 					is.log.Error("unable to dump cluster inventory", "error", err.Error())
 				}


### PR DESCRIPTION
zerolog escapes quotes within message

fixes akash-network/support#101

Signed-off-by: Artur Troian <troian.ap@gmail.com>
