### PR TITLE
build(e2e): check node image exists in registry

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -6,6 +6,10 @@ on:
 env:
   KUBE_SSH_NODE_NAME: kind
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   crd-e2e:
     env:
@@ -25,6 +29,10 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - name: Go mod tidy
+        run: go mod tidy
+      - name: Make node scripts executable
+        run: make chmod-node-scripts
       - name: Prepare images
         run: make -s -C _run/kube kube-prepare-images
       - uses: engineerd/setup-kind@v0.5.0

--- a/make/init.mk
+++ b/make/init.mk
@@ -55,11 +55,7 @@ endif
 BINS                         := $(PROVIDER_SERVICES) akash
 
 GOWORK                       ?= on
-
-GO_MOD                       ?= vendor
-ifeq ($(GOWORK), on)
-GO_MOD                       := readonly
-endif
+GO_MOD                       ?= readonly
 
 export GO                    := GO111MODULE=$(GO111MODULE) go
 GO_BUILD                     := $(GO) build -mod=$(GO_MOD)
@@ -71,7 +67,7 @@ GO_MOD_NAME                  := $(shell go list -m 2>/dev/null)
 NODE_MODULE                  := github.com/akash-network/node
 REPLACED_MODULES             := $(shell go list -mod=readonly -m -f '{{ .Replace }}' all 2>/dev/null | grep -v -x -F "<nil>" | grep "^/")
 AKASH_SRC_IS_LOCAL           := $(shell $(ROOT_DIR)/script/is_local_gomod.sh "$(NODE_MODULE)")
-AKASH_LOCAL_PATH             := $(shell $(GO) list -mod=readonly -m -f '{{ .Replace }}' "$(NODE_MODULE)")
+AKASH_LOCAL_PATH             := $(shell $(GO) list -mod=readonly -m -f '{{ .Dir }}' "$(NODE_MODULE)")
 AKASH_VERSION                := $(shell $(GO) list -mod=readonly -m -f '{{ .Version }}' $(NODE_MODULE) | cut -c2-)
 GRPC_GATEWAY_VERSION         := $(shell $(GO) list -mod=readonly -m -f '{{ .Version }}' github.com/grpc-ecosystem/grpc-gateway)
 GOLANGCI_LINT_VERSION        ?= v1.51.2

--- a/make/releasing.mk
+++ b/make/releasing.mk
@@ -45,6 +45,10 @@ docgen: $(PROVIRER_DEVCACHE)
 install:
 	$(GO) install $(BUILD_FLAGS) ./cmd/provider-services
 
+.PHONY: chmod-node-scripts
+chmod-node-scripts:
+	find "$(AKASH_LOCAL_PATH)/script" -type f -name '*.sh' -exec echo "chmod +x {}" \; -exec chmod +x {} \;
+
 .PHONY: docker-image
 docker-image:
 	docker run \


### PR DESCRIPTION
node release might be on the way and e2e test will fail
as container is being built. to resolve the issue
we check if image exists remotely, and if not
build it locally

Signed-off-by: Artur Troian <troian.ap@gmail.com>
