### PR TITLE
fix(lease/shell): command with multiple arguments/flag to be properly processed by cobra

### DIFF
--- a/gateway/rest/client.go
+++ b/gateway/rest/client.go
@@ -52,7 +52,7 @@ type Client interface {
 	LeaseLogs(ctx context.Context, id mtypes.LeaseID, services string, follow bool, tailLines int64) (*ServiceLogs, error)
 	ServiceStatus(ctx context.Context, id mtypes.LeaseID, service string) (*cltypes.ServiceStatus, error)
 	LeaseShell(ctx context.Context, id mtypes.LeaseID, service string, podIndex uint, cmd []string,
-		stdin io.ReadCloser,
+		stdin io.Reader,
 		stdout io.Writer,
 		stderr io.Writer,
 		tty bool,

--- a/gateway/rest/client_shell.go
+++ b/gateway/rest/client_shell.go
@@ -24,7 +24,7 @@ var (
 )
 
 func (c *client) LeaseShell(ctx context.Context, lID mtypes.LeaseID, service string, podIndex uint, cmd []string,
-	stdin io.ReadCloser,
+	stdin io.Reader,
 	stdout io.Writer,
 	stderr io.Writer,
 	tty bool,
@@ -154,13 +154,6 @@ loop:
 	}
 
 	subcancel()
-
-	if stdin != nil {
-		err := stdin.Close()
-		if err != nil {
-			saveError("closing stdin", err)
-		}
-	}
 
 	// Check to see if the remote end returned an error
 	if remoteErrorData != nil {


### PR DESCRIPTION
if lease shell command contains flags, cobra will treat them as own flags and mostly likely will fail. enclosing lease command into double brackets prevents it. in command itself it will be properly tokenized and honor inner double quotes if any