### PR TITLE
fix: use cluster signal to exit service status runner

### DIFF
--- a/cluster/service.go
+++ b/cluster/service.go
@@ -332,8 +332,6 @@ func (s *service) run(ctx context.Context, deployments []ctypes.IDeployment) {
 		}
 	}
 
-	// var inv provider.Inventory
-
 	trySignal()
 
 loop:

--- a/service.go
+++ b/service.go
@@ -321,7 +321,7 @@ func (s *service) statusRun() {
 loop:
 	for {
 		select {
-		case <-s.lc.ShutdownRequest():
+		case <-s.cluster.Done():
 			return
 		case evt := <-events:
 			switch obj := evt.(type) {


### PR DESCRIPTION
TODO: refactor how service is started and shutdown