### PR TITLE
fix(bidengine): parse GPU interface

### DIFF
--- a/bidengine/pricing.go
+++ b/bidengine/pricing.go
@@ -327,8 +327,9 @@ type storageElement struct {
 }
 
 type gpuVendorAttributes struct {
-	Model string  `json:"model"`
-	RAM   *string `json:"ram,omitempty"`
+	Model     string  `json:"model"`
+	RAM       *string `json:"ram,omitempty"`
+	Interface *string `json:"interface,omitempty"`
 }
 
 type gpuAttributes struct {

--- a/bidengine/shellscript.go
+++ b/bidengine/shellscript.go
@@ -75,18 +75,30 @@ func parseGPU(resource *atypes.GPU) gpuElement {
 		case "vendor":
 			vendor := tokens[1]
 			model := tokens[3]
-			var ram *string
 
-			// vendor/nvidia/model/a100/ram/80Gi
-			if len(tokens) == 6 && tokens[4] == "ram" {
-				ram = new(string)
-				*ram = tokens[5]
-			}
+			tokens = tokens[4:]
 
-			res.Attributes.Vendor[vendor] = gpuVendorAttributes{
+			attrs := gpuVendorAttributes{
 				Model: model,
-				RAM:   ram,
 			}
+
+			for i := 0; i < len(tokens); i += 2 {
+				key := tokens[i]
+				val := tokens[i+1]
+
+				switch key {
+				case "ram":
+					attrs.RAM = new(string)
+					*attrs.RAM = val
+				case "interface":
+					attrs.Interface = new(string)
+					*attrs.Interface = val
+				default:
+					continue
+				}
+			}
+
+			res.Attributes.Vendor[vendor] = attrs
 		default:
 		}
 	}


### PR DESCRIPTION
- Update parseGPU function to handle 'interface' attribute for GPUs

fixes akash-network/support#216

----

## Tested on the Hurricane provider with NVIDIA T4

### SDL with `interface` only

- `interface` is present now! :heavy_check_mark:

![image](https://github.com/akash-network/provider/assets/107317698/ebd509c9-759c-41a1-b0d0-c09b2775af67)

```
D[2024-04-24|17:18:36.459] reservation requested. order=akash1z6ql9vzhsumpvumj4zs8juv7l5u2zyr5yax2ys/16019495/1/1, resources=[{"resource":{"id":1,"cpu":{"units":{"val":"1000"}},"memory":{"size":{"val":"4294967296"}},"storage":[{"name":"default","size":{"val":"10737418240"}}],"gpu":{"units":{"val":"1"},"attributes":[{"key":"vendor/nvidia/model/t4/interface/pcie","value":"true"}]},"endpoints":[{"kind":1,"sequence_number":0},{"sequence_number":0}]},"count":1,"price":{"denom":"uakt","amount":"1000000.000000000000000000"}}] module=provider-cluster cmp=provider cmp=service cmp=inventory-service
```

### SDL with `ram` only

- `ram` is present as before :heavy_check_mark: 

![image](https://github.com/akash-network/provider/assets/107317698/19c98a5a-d001-4c31-9454-1b21371d5e76)

```
D[2024-04-24|17:18:06.496] reservation requested. order=akash1z6ql9vzhsumpvumj4zs8juv7l5u2zyr5yax2ys/16019488/1/1, resources=[{"resource":{"id":1,"cpu":{"units":{"val":"1000"}},"memory":{"size":{"val":"4294967296"}},"storage":[{"name":"default","size":{"val":"10737418240"}}],"gpu":{"units":{"val":"1"},"attributes":[{"key":"vendor/nvidia/model/t4/ram/16Gi","value":"true"}]},"endpoints":[{"kind":1,"sequence_number":0},{"sequence_number":0}]},"count":1,"price":{"denom":"uakt","amount":"1000000.000000000000000000"}}] module=provider-cluster cmp=provider cmp=service cmp=inventory-service
```

### SDL with both `ram` & `interface`

![image](https://github.com/akash-network/provider/assets/107317698/d5094483-a9bb-461b-ba91-5795c538d034)

```
D[2024-04-24|17:32:30.358] reservation requested. order=akash1z6ql9vzhsumpvumj4zs8juv7l5u2zyr5yax2ys/16019634/1/1, resources=[{"resource":{"id":1,"cpu":{"units":{"val":"1000"}},"memory":{"size":{"val":"4294967296"}},"storage":[{"name":"default","size":{"val":"10737418240"}}],"gpu":{"units":{"val":"1"},"attributes":[{"key":"vendor/nvidia/model/t4/ram/16Gi/interface/pcie","value":"true"}]},"endpoints":[{"kind":1,"sequence_number":0},{"sequence_number":0}]},"count":1,"price":{"denom":"uakt","amount":"1000000.000000000000000000"}}] module=provider-cluster cmp=provider cmp=service cmp=inventory-service
```
