### PR TITLE
feat: make monitor params configurable via flags

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -13,6 +13,11 @@ type Config struct {
 	BlockedHostnames                []string
 	DeploymentIngressStaticHosts    bool
 	DeploymentIngressDomain         string
+	MonitorMaxRetries               uint
+	MonitorRetryPeriod              time.Duration
+	MonitorRetryPeriodJitter        time.Duration
+	MonitorHealthcheckPeriod        time.Duration
+	MonitorHealthcheckPeriodJitter  time.Duration
 	ClusterSettings                 map[interface{}]interface{}
 }
 
@@ -20,5 +25,10 @@ func NewDefaultConfig() Config {
 	return Config{
 		InventoryResourcePollPeriod:     time.Second * 5,
 		InventoryResourceDebugFrequency: 10,
+		MonitorMaxRetries:               40,
+		MonitorRetryPeriod:              time.Second * 4, // nolint revive
+		MonitorRetryPeriodJitter:        time.Second * 15,
+		MonitorHealthcheckPeriod:        time.Second * 10, // nolint revive
+		MonitorHealthcheckPeriodJitter:  time.Second * 5,
 	}
 }

--- a/cluster/monitor_test.go
+++ b/cluster/monitor_test.go
@@ -39,6 +39,7 @@ func TestMonitorInstantiate(t *testing.T) {
 		deployment: deployment,
 		log:        myLog,
 		lc:         lc,
+		config:     NewDefaultConfig(),
 	}
 	monitor := newDeploymentMonitor(myDeploymentManager)
 	require.NotNil(t, monitor)
@@ -78,6 +79,7 @@ func TestMonitorSendsClusterDeploymentPending(t *testing.T) {
 		deployment: deployment,
 		log:        myLog,
 		lc:         lc,
+		config:     NewDefaultConfig(),
 	}
 	monitor := newDeploymentMonitor(myDeploymentManager)
 	require.NotNil(t, monitor)
@@ -134,6 +136,7 @@ func TestMonitorSendsClusterDeploymentDeployed(t *testing.T) {
 		deployment: deployment,
 		log:        myLog,
 		lc:         lc,
+		config:     NewDefaultConfig(),
 	}
 	monitor := newDeploymentMonitor(myDeploymentManager)
 	require.NotNil(t, monitor)

--- a/config.go
+++ b/config.go
@@ -10,30 +10,23 @@ import (
 	types "github.com/akash-network/akash-api/go/node/types/v1beta3"
 
 	"github.com/akash-network/provider/bidengine"
+	"github.com/akash-network/provider/cluster"
 )
 
 type Config struct {
-	ClusterWaitReadyDuration        time.Duration
-	ClusterPublicHostname           string
-	ClusterExternalPortQuantity     uint
-	InventoryResourcePollPeriod     time.Duration
-	InventoryResourceDebugFrequency uint
-	BidPricingStrategy              bidengine.BidPricingStrategy
-	BidDeposit                      sdk.Coin
-	CPUCommitLevel                  float64
-	MemoryCommitLevel               float64
-	StorageCommitLevel              float64
-	MaxGroupVolumes                 int
-	BlockedHostnames                []string
-	BidTimeout                      time.Duration
-	ManifestTimeout                 time.Duration
-	BalanceCheckerCfg               BalanceCheckerConfig
-	Attributes                      types.Attributes
-	DeploymentIngressStaticHosts    bool
-	DeploymentIngressDomain         string
-	ClusterSettings                 map[interface{}]interface{}
-	RPCQueryTimeout                 time.Duration
-	CachedResultMaxAge              time.Duration
+	ClusterWaitReadyDuration    time.Duration
+	ClusterPublicHostname       string
+	ClusterExternalPortQuantity uint
+	BidPricingStrategy          bidengine.BidPricingStrategy
+	BidDeposit                  sdk.Coin
+	BidTimeout                  time.Duration
+	ManifestTimeout             time.Duration
+	BalanceCheckerCfg           BalanceCheckerConfig
+	Attributes                  types.Attributes
+	MaxGroupVolumes             int
+	RPCQueryTimeout             time.Duration
+	CachedResultMaxAge          time.Duration
+	cluster.Config
 }
 
 func NewDefaultConfig() Config {
@@ -45,5 +38,6 @@ func NewDefaultConfig() Config {
 			WithdrawalPeriod:        24 * time.Hour,
 		},
 		MaxGroupVolumes: constants.DefaultMaxGroupVolumes,
+		Config:          cluster.NewDefaultConfig(),
 	}
 }

--- a/service.go
+++ b/service.go
@@ -74,18 +74,6 @@ func NewService(ctx context.Context,
 
 	session = session.ForModule("provider-service")
 
-	clusterConfig := cluster.NewDefaultConfig()
-	clusterConfig.InventoryResourcePollPeriod = cfg.InventoryResourcePollPeriod
-	clusterConfig.InventoryResourceDebugFrequency = cfg.InventoryResourceDebugFrequency
-	clusterConfig.InventoryExternalPortQuantity = cfg.ClusterExternalPortQuantity
-	clusterConfig.CPUCommitLevel = cfg.CPUCommitLevel
-	clusterConfig.MemoryCommitLevel = cfg.MemoryCommitLevel
-	clusterConfig.StorageCommitLevel = cfg.StorageCommitLevel
-	clusterConfig.BlockedHostnames = cfg.BlockedHostnames
-	clusterConfig.DeploymentIngressStaticHosts = cfg.DeploymentIngressStaticHosts
-	clusterConfig.DeploymentIngressDomain = cfg.DeploymentIngressDomain
-	clusterConfig.ClusterSettings = cfg.ClusterSettings
-
 	cl, err := aclient.DiscoverQueryClient(ctx, cctx)
 	if err != nil {
 		cancel()
@@ -99,7 +87,7 @@ func NewService(ctx context.Context,
 		return nil, err
 	}
 
-	cluster, err := cluster.NewService(ctx, session, bus, cclient, waiter, clusterConfig)
+	cluster, err := cluster.NewService(ctx, session, bus, cclient, waiter, cfg.Config)
 	if err != nil {
 		cancel()
 		<-bc.lc.Done()


### PR DESCRIPTION
--monitor-max-retries - max count of status retries before closing the lease. defaults to 40
--monitor-retry-period - monitor status retry period. defaults to 4s (min value)
--monitor-retry-period-jitter - monitor status retry window. defaults to 15s
--monitor-healthcheck-period - monitor healthcheck period. defaults to 10s
--monitor-healthcheck-period-jitter - monitor healthcheck window. defaults to 5s