### PR TITLE
build: fix goreleaser warning

### DIFF
--- a/.goreleaser-docker.yaml
+++ b/.goreleaser-docker.yaml
@@ -1,3 +1,4 @@
+version: 2
 project_name: provider
 env:
   - GO111MODULE=on
@@ -35,7 +36,7 @@ dockers:
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
     image_templates:
-      - '{{ .Env.DOCKER_IMAGE }}:latest-amd64'
+      - "{{ .Env.DOCKER_IMAGE }}:latest-amd64"
   - dockerfile: Dockerfile
     use: buildx
     goos: linux
@@ -50,4 +51,4 @@ dockers:
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
     image_templates:
-      - '{{ .Env.DOCKER_IMAGE }}:latest-arm64'
+      - "{{ .Env.DOCKER_IMAGE }}:latest-arm64"


### PR DESCRIPTION
It needs the `version: 2` marker to validate the config properly.