### PR TITLE
Add dynamic ingress hostname and NodePort env vars

### DIFF
--- a/cluster/kube/builder/builder.go
+++ b/cluster/kube/builder/builder.go
@@ -55,6 +55,9 @@ const (
 	envVarAkashOwner                 = "AKASH_OWNER"
 	envVarAkashProvider              = "AKASH_PROVIDER"
 	envVarAkashClusterPublicHostname = "AKASH_CLUSTER_PUBLIC_HOSTNAME"
+	envVarAkashIngressHostname       = "AKASH_INGRESS_HOST"
+	envVarAkashIngressCustomHostname = "AKASH_INGRESS_CUSTOM_HOST"
+	envVarAkashExternalPort          = "AKASH_EXTERNAL_PORT"
 )
 
 var (

--- a/cluster/kube/builder/deployment.go
+++ b/cluster/kube/builder/deployment.go
@@ -18,12 +18,15 @@ type deployment struct {
 
 var _ Deployment = (*deployment)(nil)
 
-func NewDeployment(workload Workload) Deployment {
+func NewDeployment(workload Workload, svc Service) Deployment {
 	ss := &deployment{
 		Workload: workload,
 	}
 
 	ss.Workload.log = ss.Workload.log.With("object", "deployment", "service-name", ss.deployment.ManifestGroup().Services[ss.serviceIdx].Name)
+	if svc != nil {
+		ss.setService(svc.(*service))
+	}
 
 	return ss
 }

--- a/cluster/kube/builder/statefulset.go
+++ b/cluster/kube/builder/statefulset.go
@@ -18,12 +18,15 @@ type statefulSet struct {
 
 var _ StatefulSet = (*statefulSet)(nil)
 
-func BuildStatefulSet(workload Workload) StatefulSet {
+func BuildStatefulSet(workload Workload, svc Service) StatefulSet {
 	ss := &statefulSet{
 		Workload: workload,
 	}
 
 	ss.Workload.log = ss.Workload.log.With("object", "statefulset", "service-name", ss.deployment.ManifestGroup().Services[ss.serviceIdx].Name)
+	if svc != nil {
+		ss.setService(svc.(*service))
+	}
 
 	return ss
 }

--- a/cluster/kube/builder/workload.go
+++ b/cluster/kube/builder/workload.go
@@ -13,6 +13,7 @@ import (
 	"github.com/akash-network/node/sdl"
 	sdlutil "github.com/akash-network/node/sdl/util"
 
+	pmanifest "github.com/akash-network/provider/manifest"
 	crd "github.com/akash-network/provider/pkg/apis/akash.network/v2beta2"
 )
 
@@ -392,6 +393,30 @@ func (b *Workload) addEnvVarsForDeployment(envVarsAlreadyAdded map[string]int, e
 	env = addIfNotPresent(envVarsAlreadyAdded, env, envVarAkashOwner, lid.Owner)
 	env = addIfNotPresent(envVarsAlreadyAdded, env, envVarAkashProvider, lid.Provider)
 	env = addIfNotPresent(envVarsAlreadyAdded, env, envVarAkashClusterPublicHostname, b.settings.ClusterPublicHostname)
+
+	ingressHost := pmanifest.IngressHost(lid, b.Name())
+	env = addIfNotPresent(envVarsAlreadyAdded, env, envVarAkashIngressHostname, fmt.Sprintf("%s.%s", ingressHost, b.settings.DeploymentIngressDomain))
+
+	svc := &b.deployment.ManifestGroup().Services[b.serviceIdx]
+
+	// Add hostnames from service expose configurations
+	for _, expose := range svc.Expose {
+		if expose.IsIngress() {
+			// Add custom hostnames if specified
+			for idx, hostname := range expose.Hosts {
+				env = addIfNotPresent(envVarsAlreadyAdded, env,
+					fmt.Sprintf("%s_%d_%d", envVarAkashIngressCustomHostname, expose.Port, idx),
+					hostname)
+			}
+		}
+
+		if expose.Global {
+			// Add external port mappings
+			env = addIfNotPresent(envVarsAlreadyAdded, env,
+				fmt.Sprintf("%s_%d", envVarAkashExternalPort, expose.Port),
+				expose.ExternalPort)
+		}
+	}
 
 	return env
 }


### PR DESCRIPTION
Hello.

So this PR might be over-complicated/over engineered. I have not messed with k8 and spent several days it feels figuring this out, and had a lot of AI help.

The key things it adds are

```
ingressHost := pmanifest.IngressHost(lid, b.Name())
	env = addIfNotPresent(envVarsAlreadyAdded, env, envVarAkashIngressHostname, fmt.Sprintf("%s.%s", ingressHost, b.settings.DeploymentIngressDomain))

	svc := &b.deployment.ManifestGroup().Services[b.serviceIdx]

	// Add hostnames from service expose configurations
	for _, expose := range svc.Expose {
		if expose.IsIngress() {
			// Add custom hostnames if specified
			for idx, hostname := range expose.Hosts {
				env = addIfNotPresent(envVarsAlreadyAdded, env,
					fmt.Sprintf("%s_%d_%d", envVarAkashIngressCustomHostname, expose.Port, idx),
					hostname)
			}
		}

		if expose.Global {
			// Add external port mappings
			if svc := b.service; svc != nil {
				if nodePort, exists := svc.portMap[int32(expose.Port)]; exists {
					env = addIfNotPresent(envVarsAlreadyAdded, env,
						fmt.Sprintf("%s_%d", envVarAkashExternalPort, expose.Port),
						fmt.Sprintf("%d", nodePort))
				}
			}
		}
	}
```

Now the hostnames are much easier to deal with overall. However the ports put me through rabbit hole hell.

* I am not sure if a service can or should be moved to be created before a statefulset/deployment.
* Ports are only assigned AFTER creation of the service, so we have to run service apply twice.
* We have to ALSO re-apply the  statefulset/deployment to use the generated env vars.
* We have to do a hack on the builder factories due to the weird struct embedding of workload? So we pass an optional service pointer to the stateful/deployment builder factory and have it call a new `setService` helper. Found also it has to be called direct and not on the workload reference, using go's pass through on struct embedding.
* `waitForProcessedVersion` was created along with k8 retry helper imported because I was concerned about cached data  being returned as it seems some stuff is processed async, and i got a conflict error at-least 1 time.

This PR is currently a draft to get feedback on how this should be best implemented vs what I have done. I also generally don't do unit tests in most cases so if they are needed, will need to be advised where at.

This is what has currently worked for me and I will be deploying this to prod for my projects workloads.

The use case for me is I have mysql master & slave servers that has to self identify themselves (host and port) and register with etcd. I have a docker image im building that acts as one side of the cluster at https://github.com/LumeWeb/akash-mysql with https://github.com/LumeWeb/akash-proxysql being the other.

Kudos.