### PR TITLE
feat(common): lower gas and minimum gas prices to average gas price

### DIFF
--- a/_run/common.mk
+++ b/_run/common.mk
@@ -12,7 +12,7 @@ export AKASH_KEYRING_BACKEND    = test
 export AKASH_GAS_ADJUSTMENT     = 2
 export AKASH_CHAIN_ID           = local
 export AKASH_YES                = true
-export AKASH_GAS_PRICES         = 0.025uakt
+export AKASH_GAS_PRICES         = 0.0025uakt
 export AKASH_GAS                = auto
 export AKASH_NODE               = http://localhost:26657
 


### PR DESCRIPTION
[Majority](https://discord.com/channels/747885925232672829/1111749461593575605/1331341752849666078) seem to be running with the `average_gas_price` (`0.0025uakt`) minimum gas prices.
![image](https://github.com/user-attachments/assets/75bb0068-6cda-45de-938e-f4e0745393f9)


Refs.
https://github.com/akash-network/website/pull/508
https://github.com/akash-network/helm-charts/pull/300