### PR TITLE
refactor: using slices.Contains to simplify the code

### DIFF
--- a/operator/inventory/config.go
+++ b/operator/inventory/config.go
@@ -303,13 +303,7 @@ func (nd *Exclude) IsStorageNodeExcluded(name string, class string) bool {
 }
 
 func (cfg *Config) HasStorageClass(name string) bool {
-	for _, class := range cfg.ClusterStorage {
-		if class == name {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(cfg.ClusterStorage, name)
 }
 
 func (cfg *Config) StorageClassesForNode(name string) []string {


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.