### PR TITLE
fix: Dockerfile environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,17 @@ LABEL "org.opencontainers.image.source"="https://github.com/akash-network/provid
 
 COPY provider-services /usr/bin/
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN \
-    apt-get update \
- && apt-get install -y --no-install-recommends \
+RUN apt -qq update \
+ && DEBIAN_FRONTEND=noninteractive apt -qq -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --no-install-recommends install \
     tini \
-    ca-certificates \
     pci.ids \
+    curl \
+    jq \
+    bc \
+    mawk \
+    ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-ENV DEBIAN_FRONTEND=
 
 # default port for provider API
 EXPOSE 8443

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ LABEL "org.opencontainers.image.source"="https://github.com/akash-network/provid
 
 COPY provider-services /usr/bin/
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN \
     apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -10,6 +12,8 @@ RUN \
     ca-certificates \
     pci.ids \
  && rm -rf /var/lib/apt/lists/*
+
+ENV DEBIAN_FRONTEND=
 
 # default port for provider API
 EXPOSE 8443


### PR DESCRIPTION
Fixes error when building bins

```
#7 25.46 debconf: unable to initialize frontend: Dialog
#7 25.46 debconf: (TERM is not set, so the dialog frontend is not usable.)
#7 25.46 debconf: falling back to frontend: Readline
#7 25.47 debconf: unable to initialize frontend: Readline
#7 25.47 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.32.1 /usr/local/share/perl/5.32.1 /usr/lib/aarch64-linux-gnu/perl5/5.32 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.32 /usr/share/perl/5.32 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
```