### PR TITLE
fix(inventory): exclude non-running allocated pods from resource accounting

### DIFF
--- a/operator/inventory/node-discovery.go
+++ b/operator/inventory/node-discovery.go
@@ -354,6 +354,10 @@ func isPodAllocated(status corev1.PodStatus) bool {
 	return false
 }
 
+func isPodRunningAndAllocated(pod *corev1.Pod) bool {
+	return isPodAllocated(pod.Status) && pod.Status.Phase == corev1.PodRunning
+}
+
 func (dp *nodeDiscovery) monitor() error {
 	ctx := dp.ctx
 	log := fromctx.LogrFromCtx(ctx).WithName("node.monitor")
@@ -456,7 +460,7 @@ func (dp *nodeDiscovery) monitor() error {
 		for idx := range pods.Items {
 			pod := pods.Items[idx].DeepCopy()
 
-			if !isPodAllocated(pod.Status) {
+			if !isPodRunningAndAllocated(pod) {
 				continue
 			}
 


### PR DESCRIPTION
Previously, pods in a terminated state (e.g. Succeeded, Failed, OOMKilled) were included in inventory resource usage if they were marked as scheduled.

This caused `.allocated.*` values to be inflated in Akash inventory.

We now check that pods are both allocated and in Running phase before counting their resources.

Fixes akash-network/support#325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pod filtering to consider only pods that are both allocated and currently running, leading to more accurate monitoring and resource discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->