### PR TITLE
feat(cmd): implement gateway auth options for cli

### DIFF
--- a/_run/common-commands.mk
+++ b/_run/common-commands.mk
@@ -14,9 +14,9 @@ PRICE          ?= 10uakt
 CERT_HOSTNAME  ?= localhost
 LEASE_SERVICES ?= web
 
-JWT_AUTH_HOSTNAME    ?= localhost
-JWT_AUTH_HOST        ?= $(JWT_AUTH_HOSTNAME):8444
 RESOURCE_SERVER_HOST ?= localhost:8445
+
+GW_AUTH_TYPE   ?= jwt
 
 .PHONY: multisig-send
 multisig-send:
@@ -80,14 +80,16 @@ send-manifest:
 	$(PROVIDER_SERVICES) send-manifest "$(SDL_PATH)" \
 		--dseq "$(DSEQ)"     \
 		--from "$(KEY_NAME)" \
-		--provider "$(PROVIDER_ADDRESS)"
+		--provider  "$(PROVIDER_ADDRESS)" \
+		--auth-type "$(GW_AUTH_TYPE)"
 
 .PHONY: get-manifest
 get-manifest:
 	$(PROVIDER_SERVICES) get-manifest \
 		--dseq "$(DSEQ)"     \
 		--from "$(KEY_NAME)" \
-		--provider "$(PROVIDER_ADDRESS)"
+		--provide   "$(PROVIDER_ADDRESS)" \
+		--auth-type "$(GW_AUTH_TYPE)"
 
 
 .PHONY: deployment-create
@@ -283,9 +285,10 @@ provider-lease-logs:
 	$(PROVIDER_SERVICES) lease-logs \
 		-f \
 		--service="$(LEASE_SERVICES)" \
-		--dseq "$(DSEQ)"     \
-		--from "$(KEY_NAME)" \
-		--provider "$(PROVIDER_ADDRESS)"
+		--dseq      "$(DSEQ)"     \
+		--from      "$(KEY_NAME)" \
+		--provider  "$(PROVIDER_ADDRESS)" \
+		--auth-type "$(GW_AUTH_TYPE)"
 
 .PHONY: provider-lease-events
 provider-lease-events:
@@ -293,7 +296,8 @@ provider-lease-events:
 		-f \
 		--dseq "$(DSEQ)"     \
 		--from "$(KEY_NAME)" \
-		--provider "$(PROVIDER_ADDRESS)"
+		--provider"$(PROVIDER_ADDRESS)" \
+		--auth-type "$(GW_AUTH_TYPE)"
 
 PHONY: provider-lease-status
 provider-lease-status:
@@ -302,7 +306,8 @@ provider-lease-status:
 		--gseq      "$(GSEQ)"        \
 		--oseq      "$(OSEQ)"        \
 		--from      "$(KEY_NAME)"    \
-		--provider  "$(PROVIDER_ADDRESS)"
+		--provider  "$(PROVIDER_ADDRESS)" \
+		--auth-type=$(GW_AUTH_TYPE)
 
 .PHONY: provider-service-status
 provider-service-status:
@@ -311,4 +316,5 @@ provider-service-status:
 		--gseq      "$(GSEQ)"        \
 		--oseq      "$(OSEQ)"        \
 		--from      "$(KEY_NAME)" \
-		--provider  "$(PROVIDER_ADDRESS)"
+		--provider  "$(PROVIDER_ADDRESS)" \
+		--auth-type "$(GW_AUTH_TYPE)"

--- a/cmd/provider-services/cmd/leaseStatus.go
+++ b/cmd/provider-services/cmd/leaseStatus.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	apclient "github.com/akash-network/akash-api/go/provider/client"
-	ajwt "github.com/akash-network/akash-api/go/util/jwt"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
@@ -25,6 +24,7 @@ func leaseStatusCmd() *cobra.Command {
 	}
 
 	addLeaseFlags(cmd)
+	addAuthFlags(cmd)
 
 	return cmd
 }
@@ -52,12 +52,17 @@ func doLeaseStatus(cmd *cobra.Command) error {
 		return err
 	}
 
-	gclient, err := apclient.NewClient(ctx, cl, prov, apclient.WithAuthJWTSigner(ajwt.NewSigner(cctx.Keyring, cctx.FromAddress)))
+	opts, err := loadAuthOpts(ctx, cctx, cmd.Flags())
 	if err != nil {
 		return err
 	}
 
-	result, err := gclient.LeaseStatus(cmd.Context(), bid.LeaseID())
+	gclient, err := apclient.NewClient(ctx, cl, prov, opts...)
+	if err != nil {
+		return err
+	}
+
+	result, err := gclient.LeaseStatus(ctx, bid.LeaseID())
 	if err != nil {
 		return showErrorToUser(err)
 	}

--- a/cmd/provider-services/cmd/migrate_endpoints.go
+++ b/cmd/provider-services/cmd/migrate_endpoints.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	apclient "github.com/akash-network/akash-api/go/provider/client"
-	ajwt "github.com/akash-network/akash-api/go/util/jwt"
 	"github.com/spf13/cobra"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
@@ -37,7 +36,12 @@ func migrateEndpoints(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	gclient, err := apclient.NewClient(ctx, cl, prov, apclient.WithAuthJWTSigner(ajwt.NewSigner(cctx.Keyring, cctx.FromAddress)))
+	opts, err := loadAuthOpts(ctx, cctx, cmd.Flags())
+	if err != nil {
+		return err
+	}
+
+	gclient, err := apclient.NewClient(ctx, cl, prov, opts...)
 	if err != nil {
 		return err
 	}
@@ -70,6 +74,8 @@ func MigrateEndpointsCmd() *cobra.Command {
 	}
 
 	addCmdFlags(cmd)
+	addAuthFlags(cmd)
+
 	cmd.Flags().Uint32(FlagGSeq, 1, "group sequence")
 
 	return cmd

--- a/cmd/provider-services/cmd/migrate_hostnames.go
+++ b/cmd/provider-services/cmd/migrate_hostnames.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	apclient "github.com/akash-network/akash-api/go/provider/client"
-	ajwt "github.com/akash-network/akash-api/go/util/jwt"
 	"github.com/spf13/cobra"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
@@ -36,7 +35,12 @@ func migrateHostnames(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	gclient, err := apclient.NewClient(ctx, cl, prov, apclient.WithAuthJWTSigner(ajwt.NewSigner(cctx.Keyring, cctx.FromAddress)))
+	opts, err := loadAuthOpts(ctx, cctx, cmd.Flags())
+	if err != nil {
+		return err
+	}
+
+	gclient, err := apclient.NewClient(ctx, cl, prov, opts...)
 	if err != nil {
 		return err
 	}
@@ -68,6 +72,8 @@ func MigrateHostnamesCmd() *cobra.Command {
 	}
 
 	addCmdFlags(cmd)
+	addAuthFlags(cmd)
+
 	cmd.Flags().Uint32(FlagGSeq, 1, "group sequence")
 
 	return cmd

--- a/cmd/provider-services/cmd/serviceStatus.go
+++ b/cmd/provider-services/cmd/serviceStatus.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	apclient "github.com/akash-network/akash-api/go/provider/client"
-	ajwt "github.com/akash-network/akash-api/go/util/jwt"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
@@ -25,6 +24,8 @@ func serviceStatusCmd() *cobra.Command {
 	}
 
 	addServiceFlags(cmd)
+	addAuthFlags(cmd)
+
 	if err := cmd.MarkFlagRequired(FlagService); err != nil {
 		panic(err.Error())
 	}
@@ -60,7 +61,12 @@ func doServiceStatus(cmd *cobra.Command) error {
 		return err
 	}
 
-	gclient, err := apclient.NewClient(ctx, cl, prov, apclient.WithAuthJWTSigner(ajwt.NewSigner(cctx.Keyring, cctx.FromAddress)))
+	opts, err := loadAuthOpts(ctx, cctx, cmd.Flags())
+	if err != nil {
+		return err
+	}
+
+	gclient, err := apclient.NewClient(ctx, cl, prov, opts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/provider-services/cmd/shell.go
+++ b/cmd/provider-services/cmd/shell.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 
 	apclient "github.com/akash-network/akash-api/go/provider/client"
-	ajwt "github.com/akash-network/akash-api/go/util/jwt"
 	"github.com/go-andiamo/splitter"
 	dockerterm "github.com/moby/term"
 	"github.com/spf13/cobra"
@@ -47,6 +46,8 @@ func LeaseShellCmd() *cobra.Command {
 	}
 
 	addLeaseFlags(cmd)
+	addAuthFlags(cmd)
+
 	cmd.Flags().Bool(FlagStdin, false, "connect stdin")
 	if err := viper.BindPFlag(FlagStdin, cmd.Flags().Lookup(FlagStdin)); err != nil {
 		return nil
@@ -123,7 +124,12 @@ func doLeaseShell(cmd *cobra.Command, args []string) error {
 	}
 	lID := bidID.LeaseID()
 
-	gclient, err := apclient.NewClient(ctx, cl, prov, apclient.WithAuthJWTSigner(ajwt.NewSigner(cctx.Keyring, cctx.FromAddress)))
+	opts, err := loadAuthOpts(ctx, cctx, cmd.Flags())
+	if err != nil {
+		return err
+	}
+
+	gclient, err := apclient.NewClient(ctx, cl, prov, opts...)
 	if err != nil {
 		return err
 	}

--- a/gateway/utils/utils.go
+++ b/gateway/utils/utils.go
@@ -30,6 +30,8 @@ type CertGetter interface {
 }
 
 func NewServerTLSConfig(ctx context.Context, cquery CertGetter, sni string) (*tls.Config, error) {
+	// todo ideally we want here configs to be cached to speed up tls handshake
+	// @troian to look at that
 	cfg := &tls.Config{
 		MinVersion: tls.VersionTLS13,
 		GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {


### PR DESCRIPTION
add flag --auth-type=jwt|mtls to allow clients
authenticate to gateway via either mtls or jwt