### PR TITLE
feat: allow cross-namespace communication to namespaces

### DIFF
--- a/cluster/kube/builder/builder.go
+++ b/cluster/kube/builder/builder.go
@@ -29,6 +29,7 @@ const (
 	AkashServiceCapabilityStorage = "akash.network/capabilities.storage"
 	AkashMetalLB                  = "metal-lb"
 	akashDeploymentPolicyName     = "akash-deployment-restrictions"
+	akashAllowSameOwner           = "akash-same-owner"
 	akashNetworkNamespace         = "akash.network/namespace"
 	AkashLeaseOwnerLabelName      = "akash.network/lease.id.owner"
 	AkashLeaseDSeqLabelName       = "akash.network/lease.id.dseq"


### PR DESCRIPTION
# Description

Currently, all namespaces on a provider are isolated from each other, regardless of whether they belong to the same tenant (lease.id.owner). This makes it impossible for tenants to deploy modular applications that span multiple namespaces within the same cluster.

This PR introduces a new NetworkPolicy called allow-same-owner, which allows ingress and egress traffic between namespaces that share the same lease.id.owner label. This enables intra-tenant communication while maintaining isolation from other tenants.

# My Solution

## Modify provider/cluster/kube/builder/netpol.go:
* Add logic in Create() to generate an additional NetworkPolicy named allow-same-owner.
* The policy applies to all pods in the namespace (podSelector: {}).
* Ingress from any namespace with the same lease.id.owner.
* Egress to any namespace with the same lease.id.owner.
* Leaves all existing policies (akash-deployment-restrictions, <service>-np, <service>-ip) untouched.

## Benefits:
* Enables tenants to build and run distributed, modular workloads within the same provider.
* Traffic stays internal to the cluster — no public IPs.
* No external scripts, no manual intervention.
* Maintains strong multi-tenant isolation.

# Future Updates
* Expose a provider-level configuration to enable/disable this feature if needed.
* Investigate supporting cross-provider (inter-cluster) secure communication (e.g., via mTLS or VPN).
* Enhance observability — e.g., log whenever same-owner traffic is allowed.

@ Author: Jesse Rohner