### PR TITLE
fix: 295: Shell access to a SHM mounted workload

### DIFF
--- a/gateway/rest/router.go
+++ b/gateway/rest/router.go
@@ -372,7 +372,9 @@ func leaseShellHandler(log log.Logger, cclient cluster.Client) http.HandlerFunc 
 			if cluster.ErrorIsOkToSendToClient(err) || errors.Is(err, kubeclienterrors.ErrNoServiceForLease) {
 				responseData.Message = err.Error()
 			} else {
-				http.Error(rw, err.Error(), http.StatusInternalServerError)
+				resultWriter = wsutil.NewWsWriterWrapper(shellWs, LeaseShellCodeFailure, l)
+				encodeData = false
+				localLog.Error("service status check failed", "err", err)
 			}
 		}
 


### PR DESCRIPTION
Closes https://github.com/akash-network/support/issues/295

This commit addresses an issue with the provider when attempting to SSH to a lease with a shared memory mount. It also corrects a websocket protocol violation on error (encountered while debugging the SHM issue). The core issue essentially was when the lease-shell command attempted to connect, it would try to do so on a Statefulset due to detecting a volume on the deployment. Having it follow the convention of the Deploy() function let's it connect to the deployment properly.

1. StatefulSet Detection Fix:
   - Fixed incorrect logic in ServiceStatus that was checking for any mounted storage instead of persistent storage to determine workload type
   - The bug caused services with RAM volumes to incorrectly attempt StatefulSet operations, resulting in "statefulsets.apps not found" errors
   - Now correctly checks storage.Attributes.Find(sdl.StorageAttributePersistent) to match the deployment creation logic

2. WebSocket Error Handling in lease-shell:
   - Fixed improper error handling when ServiceStatus fails during shell operations
   - Previously used http.Error() on WebSocket connections, causing protocol violations
   - Now properly uses WebSocket writer with LeaseShellCodeFailure and logs errors
   - Prevents silent failures and improves debugging for shell access issues

Added comprehensive unit tests for StatefulSet detection logic covering:
- Services with persistent storage (should use StatefulSet)
- Services with non-persistent storage (should use Deployment)
- Services with no storage (should use Deployment)

These fixes ensure proper workload type detection and improve error visibility for lease-shell operations, resolving issues with shell access to deployments using RAM volumes.