### PR TITLE
docs(contributing): Update installation steps to remove missing/unused commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,19 +109,11 @@ The Akash Network Provider is a Go-based implementation that enables providers t
    git clone https://github.com/akash-network/provider.git
    cd provider
    ```
-3. Install required tools:
+3. Activate direnv:
    ```bash
-   make cache
+   direnv allow
    ```
-4. Set up your development environment:
-   ```bash
-   make setup
-   ```
-5. Configure your environment variables:
-   ```bash
-   cp .env.example .env
-   # Edit .env with your configuration
-   ```
+   Some packages may be installed after this
 
 ## Project Structure
 


### PR DESCRIPTION
Related to https://github.com/akash-network/support/issues/359

There are some steps that are seemingly not needed any more when setting up the repository in dev.

- `make cache` does nothing, `.cache` directory is created on activating `direnv`
- `make setup` is missing
- `.env` file is tracked by default in the repo

Someone setting up the repo first time may therefore be confused by this.

This PR updates the CONTRIBUTING.md file to reflect the changes.