### PR TITLE
chore: remove redundant word in _run/single/README.md

### DIFF
--- a/_run/single/README.md
+++ b/_run/single/README.md
@@ -212,7 +212,7 @@ __t1__
 make query-bids
 ```
 
-You should now see "pending" inventory inventory in the provider status:
+You should now see "pending" inventory in the provider status:
 
 __t1__
 ```sh


### PR DESCRIPTION
 remove redundant word in _run/single/README.md