### PR TITLE
feat: implement HTTP Transport with Connection Pooling

### DIFF
--- a/cmd/provider-services/cmd/http_transport.go
+++ b/cmd/provider-services/cmd/http_transport.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
+)
+
+// configureHTTPTransportForConnectionPooling configures the Cosmos SDK client context
+// to use connection pooling to prevent ephemeral port exhaustion when making many
+// concurrent RPC calls to the blockchain node.
+func configureHTTPTransportForConnectionPooling(cctx client.Context) client.Context {
+	// Create a custom HTTP transport with connection pooling
+	transport := &http.Transport{
+		// Connection pooling settings
+		MaxIdleConns:        100,              // Maximum number of idle connections across all hosts
+		MaxIdleConnsPerHost: 10,               // Maximum number of idle connections per host
+		MaxConnsPerHost:     50,               // Maximum number of connections per host
+		IdleConnTimeout:     90 * time.Second, // How long idle connections are kept alive
+		
+		// Connection timeouts
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second, // Connection timeout
+			KeepAlive: 30 * time.Second, // Keep-alive period
+		}).DialContext,
+		
+		// TLS and HTTP/2 settings
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		
+		// Enable connection reuse
+		DisableKeepAlives: false,
+		
+		// Force HTTP/1.1 to ensure better connection pooling behavior
+		// Some RPC nodes may not handle HTTP/2 connection pooling optimally
+		ForceAttemptHTTP2: false,
+	}
+
+	// Create HTTP client with the pooled transport
+	httpClient := &http.Client{
+		Transport: transport,
+		Timeout:   60 * time.Second, // Overall request timeout
+	}
+
+	// If the client context already has an RPC client, replace it with one that uses our pooled transport
+	if cctx.Client != nil {
+		nodeURI := cctx.NodeURI
+		if nodeURI != "" {
+			// Create new RPC client with pooled HTTP transport
+			rpcClient, err := rpchttp.NewWithClient(nodeURI, "/websocket", httpClient)
+			if err == nil {
+				cctx = cctx.WithClient(rpcClient)
+			}
+		}
+	}
+
+	return cctx
+}
+
+// createPooledRPCClient creates an RPC client with connection pooling
+func createPooledRPCClient(nodeURI string) (rpcclient.Client, error) {
+	// Create the same pooled transport as above
+	transport := &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 10,
+		MaxConnsPerHost:     50,
+		IdleConnTimeout:     90 * time.Second,
+		
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DisableKeepAlives:     false,
+		ForceAttemptHTTP2:     false,
+	}
+
+	httpClient := &http.Client{
+		Transport: transport,
+		Timeout:   60 * time.Second,
+	}
+
+	return rpchttp.NewWithClient(nodeURI, "/websocket", httpClient)
+}

--- a/cmd/provider-services/cmd/run.go
+++ b/cmd/provider-services/cmd/run.go
@@ -434,6 +434,10 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 
 	cctx = cctx.WithSkipConfirmation(true)
 
+	// Configure HTTP transport with connection pooling to prevent ephemeral port exhaustion
+	// This addresses the issue where thousands of concurrent RPC calls exhaust available ports
+	cctx = configureHTTPTransportForConnectionPooling(cctx)
+
 	opts, err := cltypes.ClientOptionsFromFlags(cmd.Flags())
 	if err != nil {
 		return err


### PR DESCRIPTION
# Fix ephemeral port exhaustion in provider RPC connections

## Problem
Fixes [akash-network/support#293](https://github.com/akash-network/support/issues/293) - Provider experiencing ephemeral port exhaustion after upgrading to akash-node v12.0.3 (RPC v0.38.1).

**Symptoms:**
- `"Cannot assign requested address"` errors when connecting to RPC node on port 26657
- Provider liveness probe failures and continuous restarts
- Thousands of TCP connections in TIME_WAIT state consuming all ~28,000 available ephemeral ports

**Root Cause:**
The Cosmos SDK client context creates new HTTP connections for each RPC call without proper connection pooling. When RPC v0.38.1 improved pagination performance, the bidengine could process thousands of orders concurrently, each creating new TCP connections to the RPC node, exhausting available ephemeral ports.

## Solution
Implements HTTP connection pooling at the transport layer to prevent port exhaustion:

- **Connection Pooling**: Reuses existing connections instead of creating new ones for each RPC call
- **Resource Limits**: Controls maximum connections per host (50 concurrent, 10 idle) 
- **Connection Lifecycle**: 90-second idle timeout with proper keep-alive handling
- **Non-Invasive**: Only modifies HTTP transport configuration, no bidengine changes required

## Changes
- **`cmd/provider-services/cmd/http_transport.go`** - New connection pooling implementation
- **`cmd/provider-services/cmd/run.go`** - Apply pooled transport to SDK client context (3 lines)
