### PR TITLE
fix: node env variable not being inherited on viper

### DIFF
--- a/cmd/provider-services/cmd/helpers.go
+++ b/cmd/provider-services/cmd/helpers.go
@@ -329,14 +329,12 @@ func setupProviderClient(ctx context.Context, cctx sdkclient.Context, flags *pfl
 	return pcl, nil
 }
 
-// addNodeFlagToTxCmd adds the node flag with environment variable binding to tx commands
+// addNodeFlagToTxCmd ensures tx commands respect AKASH_NODE and AP_NODE environment variables.
+// Cosmos SDK tx commands add their own --node flags via flags.AddTxFlagsToCmd().
+// Those local flags override persistent flags and have no environment variable binding.
+// This function binds the flag name globally in viper so any --node flag gets env vars.
 func addNodeFlagToTxCmd(txCmd *cobra.Command) *cobra.Command {
-	// Add node flag that respects AKASH_NODE and AP_NODE environment variables
-	txCmd.PersistentFlags().String(flags.FlagNode, "http://localhost:26657", "The node address")
-
-	// Bind environment variables: AP_NODE and AKASH_NODE
 	viper.BindEnv(flags.FlagNode, "AP_NODE", "AKASH_NODE")
-	viper.BindPFlag(flags.FlagNode, txCmd.PersistentFlags().Lookup(flags.FlagNode))
 
 	return txCmd
 }

--- a/cmd/provider-services/cmd/helpers.go
+++ b/cmd/provider-services/cmd/helpers.go
@@ -328,3 +328,15 @@ func setupProviderClient(ctx context.Context, cctx sdkclient.Context, flags *pfl
 
 	return pcl, nil
 }
+
+// addNodeFlagToTxCmd adds the node flag with environment variable binding to tx commands
+func addNodeFlagToTxCmd(txCmd *cobra.Command) *cobra.Command {
+	// Add node flag that respects AKASH_NODE and AP_NODE environment variables
+	txCmd.PersistentFlags().String(flags.FlagNode, "http://localhost:26657", "The node address")
+
+	// Bind environment variables: AP_NODE and AKASH_NODE
+	viper.BindEnv(flags.FlagNode, "AP_NODE", "AKASH_NODE")
+	viper.BindPFlag(flags.FlagNode, txCmd.PersistentFlags().Lookup(flags.FlagNode))
+
+	return txCmd
+}

--- a/cmd/provider-services/cmd/root.go
+++ b/cmd/provider-services/cmd/root.go
@@ -61,7 +61,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(version.NewVersionCommand())
 
 	cmd.AddCommand(acmd.QueryCmd())
-	cmd.AddCommand(acmd.TxCmd())
+	cmd.AddCommand(addNodeFlagToTxCmd(acmd.TxCmd()))
 
 	cmd.AddCommand(nodeCmd())
 


### PR DESCRIPTION
Both `AP_NODE` and `AKASH_NODE` environment variables were not being parsed through viper to be used with the `provider-services` CLI. This prevented using `AKASH_NODE` to configure the node when creating a deployment.

This PR configures the CLI to accept both `AP_` and `AKASH_`.