### PR TITLE
fix: bid is not closed after the manifest timeout

### DIFF
--- a/bidengine/order.go
+++ b/bidengine/order.go
@@ -142,7 +142,17 @@ func newOrderInternal(svc *service, oid mtypes.OrderID, cfg Config, pass Provide
 	return order, nil
 }
 
-var matchBidNotFound = regexp.MustCompile("^.+bid not found.+$")
+type existingBidQueryResult struct {
+	bidFound   bool
+	bid        mvbeta.Bid
+	leaseFound bool
+	lease      mtypes.Lease
+}
+
+var (
+	matchBidNotFound   = regexp.MustCompile("^.+bid not found.+$")
+	matchLeaseNotFound = regexp.MustCompile("^.+lease not found.+$")
+)
 
 func (o *order) bidTimeoutEnabled() bool {
 	return o.cfg.BidTimeout > time.Duration(0)
@@ -165,10 +175,61 @@ func (o *order) isStaleBid(bid mvbeta.Bid) bool {
 	// do not try anything clever here like asking the RPC node for the current height
 	// just use the height from when the session is created
 	createdAtBlock := bid.GetCreatedAt()
-	blockAge := createdAtBlock - o.session.CreatedAtBlockHeight()
+	blockAge := o.session.CreatedAtBlockHeight() - createdAtBlock
 	const minTimePerBlock = 5 * time.Second
 	atLeastThisOld := time.Duration(blockAge) * minTimePerBlock
 	return atLeastThisOld > o.cfg.BidTimeout
+}
+
+func (o *order) queryExistingBidAndLease(ctx context.Context) (existingBidQueryResult, error) {
+	result := existingBidQueryResult{}
+	bidResponse, err := o.session.Client().Query().Market().Bid(
+		ctx,
+		&mvbeta.QueryBidRequest{
+			ID: mtypes.MakeBidID(o.orderID, o.session.Provider().Address()),
+		},
+	)
+	if err != nil {
+		// Use super-advanced technique for detecting if bid is not on blockchain
+		if matchBidNotFound.MatchString(err.Error()) {
+			return result, nil
+		}
+
+		return result, err
+	}
+
+	bid := bidResponse.GetBid()
+	result.bidFound = true
+	result.bid = bid
+
+	if bid.GetState() != mvbeta.BidOpen {
+		return result, nil
+	}
+
+	leaseResponse, err := o.session.Client().Query().Market().Lease(
+		ctx,
+		&mvbeta.QueryLeaseRequest{
+			ID: mtypes.MakeLeaseID(bid.ID),
+		},
+	)
+	if err != nil {
+		if matchLeaseNotFound.MatchString(err.Error()) {
+			return result, nil
+		}
+
+		o.session.Log().Error("could not get existing lease", "err", err, "errtype", fmt.Sprintf("%T", err))
+		return result, nil
+	}
+
+	if leaseResponse != nil {
+		lease := leaseResponse.GetLease()
+		if lease.GetState() == mtypes.LeaseActive {
+			result.leaseFound = true
+			result.lease = lease
+		}
+	}
+
+	return result, nil
 }
 
 func (o *order) run(checkForExistingBid bool) {
@@ -193,8 +254,10 @@ func (o *order) run(checkForExistingBid bool) {
 		// Channel that triggers when bid timeout is reached.
 		bidTimeout <-chan time.Time
 
-		group       *dtypes.Group
-		reservation ctypes.Reservation
+		group              *dtypes.Group
+		reservation        ctypes.Reservation
+		existingLease      mtypes.Lease
+		existingLeaseFound bool
 
 		won bool
 		msg *mvbeta.MsgCreateBid
@@ -209,12 +272,7 @@ func (o *order) run(checkForExistingBid bool) {
 	// Load existing bid if needed
 	if checkForExistingBid {
 		queryBidCh = runner.Do(func() runner.Result {
-			return runner.NewResult(o.session.Client().Query().Market().Bid(
-				ctx,
-				&mvbeta.QueryBidRequest{
-					ID: mtypes.MakeBidID(o.orderID, o.session.Provider().Address()),
-				},
-			))
+			return runner.NewResult(o.queryExistingBidAndLease(ctx))
 		})
 		// Hide the group details result for later
 		storedGroupCh = groupch
@@ -230,21 +288,15 @@ loop:
 
 		case queryBid := <-queryBidCh:
 			err := queryBid.Error()
-			bidFound := true
 			if err != nil {
-				// Use super-advanced technique for detecting if bid is not on blockchain
-				if matchBidNotFound.MatchString(err.Error()) {
-					bidFound = false
-				} else {
-					o.session.Log().Error("could not get existing bid", "err", err, "errtype", fmt.Sprintf("%T", err))
-					break loop
-				}
+				o.session.Log().Error("could not get existing bid", "err", err, "errtype", fmt.Sprintf("%T", err))
+				break loop
 			}
 
-			if bidFound {
+			existingBid := queryBid.Value().(existingBidQueryResult)
+			if existingBid.bidFound {
 				o.session.Log().Info("found existing bid")
-				bidResponse := queryBid.Value().(*mvbeta.QueryBidResponse)
-				bid := bidResponse.GetBid()
+				bid := existingBid.bid
 				bidState := bid.GetState()
 				if bidState != mvbeta.BidOpen {
 					o.session.Log().Error("bid in unexpected state", "bid-state", bidState)
@@ -252,12 +304,15 @@ loop:
 				}
 				bidPlaced = true
 
-				if o.isStaleBid(bid) {
+				if existingBid.leaseFound {
+					existingLease = existingBid.lease
+					existingLeaseFound = true
+				} else if o.isStaleBid(bid) {
 					o.session.Log().Info("found expired bid", "block-height", bid.GetCreatedAt())
 					break loop
+				} else {
+					bidTimeout = o.getBidTimeout()
 				}
-
-				bidTimeout = o.getBidTimeout()
 			}
 			groupch = storedGroupCh // Allow getting the group details result now
 			storedGroupCh = nil
@@ -265,6 +320,10 @@ loop:
 		case ev := <-o.sub.Events():
 			switch ev := ev.(type) {
 			case *mtypes.EventLeaseCreated:
+				if won {
+					break
+				}
+
 				// different group
 				if !o.orderID.GroupID().Equals(ev.ID.GroupID()) {
 					o.log.Debug("ignoring group", "group", ev.ID.GroupID())
@@ -340,6 +399,18 @@ loop:
 
 			res := result.Value().(dtypes.Group)
 			group = &res
+			if existingLeaseFound {
+				o.log.Info("lease won", "lease", existingLease.ID)
+				if err := o.bus.Publish(event.LeaseWon{
+					LeaseID:   existingLease.ID,
+					Group:     group,
+					Price:     existingLease.GetPrice(),
+					CreatedAt: existingLease.GetCreatedAt(),
+				}); err != nil {
+					o.log.Error("failed to publish to event queue", err)
+				}
+				won = true
+			}
 
 			shouldBidCh = runner.Do(func() runner.Result {
 				return runner.NewResult(o.shouldBid(group))

--- a/bidengine/order_test.go
+++ b/bidengine/order_test.go
@@ -32,6 +32,7 @@ import (
 	"pkg.akt.dev/go/testutil"
 	"pkg.akt.dev/go/util/pubsub"
 
+	"github.com/akash-network/provider/event"
 	cmocks "github.com/akash-network/provider/mocks/cluster"
 	clmocks "github.com/akash-network/provider/mocks/cluster/types"
 	"github.com/akash-network/provider/operator/waiter"
@@ -55,6 +56,7 @@ type orderTestScaffold struct {
 	cluster           *cmocks.Cluster
 	broadcasts        chan []sdk.Msg
 	reserveCallNotify chan int
+	eventSub          pubsub.Subscriber
 }
 
 type testBidPricingStrategy int64
@@ -171,6 +173,7 @@ func makeOrderForTest(
 	pricing BidPricingStrategy,
 	callerConfig *Config,
 	sessionHeight int64,
+	existingLeaseCreatedAt ...int64,
 ) (*order, orderTestScaffold, <-chan int) {
 	if pricing == nil {
 		pricing = testBidPricingStrategy(1)
@@ -196,6 +199,11 @@ func makeOrderForTest(
 	mySession := session.New(myLog, scaffold.client, myProvider, sessionHeight)
 
 	scaffold.testBus = pubsub.NewBus()
+	eventSub, err := scaffold.testBus.Subscribe()
+	require.NoError(t, err)
+	scaffold.eventSub = eventSub
+	t.Cleanup(scaffold.eventSub.Close)
+
 	var cfg Config
 	if callerConfig != nil {
 		cfg = *callerConfig // Copy values from caller
@@ -228,6 +236,25 @@ func makeOrderForTest(
 			},
 		}
 		scaffold.marketMocks.On("Bid", mock.Anything, queryBidRequest).Return(response, nil)
+
+		if bidState == mvbeta.BidOpen {
+			leaseID := mtypes.MakeLeaseID(bidID)
+			queryLeaseRequest := &mvbeta.QueryLeaseRequest{
+				ID: leaseID,
+			}
+			if len(existingLeaseCreatedAt) > 0 {
+				scaffold.marketMocks.On("Lease", mock.Anything, queryLeaseRequest).Return(&mvbeta.QueryLeaseResponse{
+					Lease: mtypes.Lease{
+						ID:        leaseID,
+						State:     mtypes.LeaseActive,
+						Price:     testutil.AkashDecCoin(t, 1),
+						CreatedAt: existingLeaseCreatedAt[0],
+					},
+				}, nil)
+			} else {
+				scaffold.marketMocks.On("Lease", mock.Anything, queryLeaseRequest).Return(nil, errors.New("lease not found"))
+			}
+		}
 	}
 
 	reservationFulfilledNotify := make(chan int, 1)
@@ -530,6 +557,32 @@ func Test_ShouldNotBidWhenAlreadySet(t *testing.T) {
 	require.Equal(t, closeBid.ID, *scaffold.bidID)
 }
 
+func Test_ShouldPublishRecoveredLeaseCreatedAtWhenBiddingIsSkipped(t *testing.T) {
+	const leaseCreatedAt int64 = 42
+
+	cfg := &Config{
+		BidTimeout: time.Second,
+	}
+	order, scaffold, reservationFulfilledNotify := makeOrderForTest(t, true, mvbeta.BidOpen, nil, cfg, testBidCreatedAt+1, leaseCreatedAt)
+
+	ev := testutil.ChannelWaitForValue(t, scaffold.eventSub.Events())
+	leaseWon, ok := ev.(event.LeaseWon)
+	require.True(t, ok)
+	require.Equal(t, mtypes.MakeLeaseID(*scaffold.bidID), leaseWon.LeaseID)
+	require.Equal(t, leaseCreatedAt, leaseWon.CreatedAt)
+
+	testutil.ChannelWaitForValue(t, reservationFulfilledNotify)
+	order.lc.Shutdown(nil)
+	testutil.ChannelWaitForClose(t, order.lc.Done())
+
+	scaffold.cluster.AssertNotCalled(t, "Unreserve", mock.Anything, mock.Anything)
+	scaffold.txClient.AssertNotCalled(t, "BroadcastMsgs", mock.Anything, []sdk.Msg{
+		&mvbeta.MsgCloseBid{
+			ID: mtypes.MakeBidID(order.orderID, scaffold.testAddr),
+		},
+	}, mock.Anything)
+}
+
 func Test_ShouldCloseBidWhenAlreadySetAndOld(t *testing.T) {
 	pricing, err := MakeRandomRangePricing()
 	require.NoError(t, err)
@@ -540,7 +593,7 @@ func Test_ShouldCloseBidWhenAlreadySetAndOld(t *testing.T) {
 		Attributes:      nil,
 	}
 
-	order, scaffold, _ := makeOrderForTest(t, true, mvbeta.BidOpen, nil, &cfg, 1)
+	order, scaffold, _ := makeOrderForTest(t, true, mvbeta.BidOpen, nil, &cfg, testBidCreatedAt+1)
 
 	testutil.ChannelWaitForClose(t, order.lc.Done())
 

--- a/cmd/provider-services/cmd/flags.go
+++ b/cmd/provider-services/cmd/flags.go
@@ -231,7 +231,7 @@ func addRunFlags(cmd *cobra.Command) error {
 		return err
 	}
 
-	cmd.Flags().Duration(FlagTxBroadcastTimeout, 12*time.Second, "tx broadcast timeout")
+	cmd.Flags().Duration(FlagTxBroadcastTimeout, cfg.BroadcastTimeout, "tx broadcast timeout")
 	if err := viper.BindPFlag(FlagTxBroadcastTimeout, cmd.Flags().Lookup(FlagTxBroadcastTimeout)); err != nil {
 		return err
 	}

--- a/cmd/provider-services/cmd/flags.go
+++ b/cmd/provider-services/cmd/flags.go
@@ -231,7 +231,7 @@ func addRunFlags(cmd *cobra.Command) error {
 		return err
 	}
 
-	cmd.Flags().Duration(FlagTxBroadcastTimeout, 30*time.Second, "tx broadcast timeout. defaults to 30s")
+	cmd.Flags().Duration(FlagTxBroadcastTimeout, 12*time.Second, "tx broadcast timeout")
 	if err := viper.BindPFlag(FlagTxBroadcastTimeout, cmd.Flags().Lookup(FlagTxBroadcastTimeout)); err != nil {
 		return err
 	}

--- a/cmd/provider-services/cmd/run.go
+++ b/cmd/provider-services/cmd/run.go
@@ -663,6 +663,10 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	config.DeploymentIngressDomain = deploymentIngressDomain
 	config.BidTimeout = bidTimeout
 	config.ManifestTimeout = manifestTimeout
+	if broadcastTimeout <= 0 {
+		logger.Warn("tx-broadcast-timeout must be positive, using default", "invalid", broadcastTimeout, "default", 12*time.Second)
+		broadcastTimeout = 12 * time.Second
+	}
 	config.BroadcastTimeout = broadcastTimeout
 
 	if reclamationWindow > 0 {

--- a/cmd/provider-services/cmd/run.go
+++ b/cmd/provider-services/cmd/run.go
@@ -664,10 +664,10 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	config.BidTimeout = bidTimeout
 	config.ManifestTimeout = manifestTimeout
 	if broadcastTimeout <= 0 {
-		logger.Warn("tx-broadcast-timeout must be positive, using default", "invalid", broadcastTimeout, "default", 12*time.Second)
-		broadcastTimeout = 12 * time.Second
+		logger.Warn("tx-broadcast-timeout must be positive, using default", "invalid", broadcastTimeout, "default", config.BroadcastTimeout)
+	} else {
+		config.BroadcastTimeout = broadcastTimeout
 	}
-	config.BroadcastTimeout = broadcastTimeout
 
 	if reclamationWindow > 0 {
 		config.ReclamationWindow = &reclamationWindow

--- a/cmd/provider-services/cmd/run.go
+++ b/cmd/provider-services/cmd/run.go
@@ -488,6 +488,7 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	bidTimeout := viper.GetDuration(FlagBidTimeout)
 	reclamationWindow := viper.GetDuration(FlagReclamationWindow)
 	manifestTimeout := viper.GetDuration(FlagManifestTimeout)
+	broadcastTimeout := viper.GetDuration(FlagTxBroadcastTimeout)
 	metricsListener := viper.GetString(FlagMetricsListener)
 	providerConfig := viper.GetString(FlagProviderConfig)
 	cachedResultMaxAge := viper.GetDuration(FlagCachedResultMaxAge)
@@ -662,6 +663,7 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	config.DeploymentIngressDomain = deploymentIngressDomain
 	config.BidTimeout = bidTimeout
 	config.ManifestTimeout = manifestTimeout
+	config.BroadcastTimeout = broadcastTimeout
 
 	if reclamationWindow > 0 {
 		config.ReclamationWindow = &reclamationWindow

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	BidDeposit                  sdk.Coin
 	BidTimeout                  time.Duration
 	ManifestTimeout             time.Duration
+	BroadcastTimeout            time.Duration
 	BalanceCheckerCfg           BalanceCheckerConfig
 	Attributes                  attrtypes.Attributes
 	MaxGroupVolumes             int

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/akash-network/provider/bidengine"
 	"github.com/akash-network/provider/cluster"
+	"github.com/akash-network/provider/manifest"
 )
 
 type Config struct {
@@ -35,7 +36,7 @@ func NewDefaultConfig() Config {
 	return Config{
 		ClusterWaitReadyDuration: time.Second * 10,
 		BidDeposit:               mtypes.DefaultBidMinDeposit,
-		BroadcastTimeout:         12 * time.Second,
+		BroadcastTimeout:         manifest.DefaultBroadcastTimeout,
 		BalanceCheckerCfg: BalanceCheckerConfig{
 			LeaseFundsCheckInterval: 1 * time.Minute,
 			WithdrawalPeriod:        24 * time.Hour,

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ func NewDefaultConfig() Config {
 	return Config{
 		ClusterWaitReadyDuration: time.Second * 10,
 		BidDeposit:               mtypes.DefaultBidMinDeposit,
-		BroadcastTimeout:         30 * time.Second,
+		BroadcastTimeout:         12 * time.Second,
 		BalanceCheckerCfg: BalanceCheckerConfig{
 			LeaseFundsCheckInterval: 1 * time.Minute,
 			WithdrawalPeriod:        24 * time.Hour,

--- a/config.go
+++ b/config.go
@@ -35,6 +35,7 @@ func NewDefaultConfig() Config {
 	return Config{
 		ClusterWaitReadyDuration: time.Second * 10,
 		BidDeposit:               mtypes.DefaultBidMinDeposit,
+		BroadcastTimeout:         30 * time.Second,
 		BalanceCheckerCfg: BalanceCheckerConfig{
 			LeaseFundsCheckInterval: 1 * time.Minute,
 			WithdrawalPeriod:        24 * time.Hour,

--- a/event/events.go
+++ b/event/events.go
@@ -8,11 +8,12 @@ import (
 	mtypes "pkg.akt.dev/go/node/market/v1"
 )
 
-// LeaseWon is the data structure that includes leaseID, group and price
+// LeaseWon is the data structure that includes leaseID, group, price and created height.
 type LeaseWon struct {
-	LeaseID mtypes.LeaseID
-	Group   *dtypes.Group
-	Price   sdk.DecCoin
+	LeaseID   mtypes.LeaseID
+	Group     *dtypes.Group
+	Price     sdk.DecCoin
+	CreatedAt int64
 }
 
 // ManifestReceived stores leaseID, manifest received, deployment and group details

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -5,6 +5,7 @@ import "time"
 type ServiceConfig struct {
 	HTTPServicesRequireAtLeastOneHost bool
 	ManifestTimeout                   time.Duration
+	BroadcastTimeout                  time.Duration
 	RPCQueryTimeout                   time.Duration
 	CachedResultMaxAge                time.Duration
 }

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -2,6 +2,8 @@ package manifest
 
 import "time"
 
+const DefaultBroadcastTimeout = 12 * time.Second
+
 type ServiceConfig struct {
 	HTTPServicesRequireAtLeastOneHost bool
 	ManifestTimeout                   time.Duration

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -291,9 +291,10 @@ func (m *manager) doFetchData(ctx context.Context) (manifestManagerFetchDataResu
 			return manifestManagerFetchDataResult{}, fmt.Errorf("%w: could not locate group %v ", errNoGroupForLease, leaseID)
 		}
 		ev := event.LeaseWon{
-			LeaseID: leaseID,
-			Group:   &groupForLease,
-			Price:   lease.GetPrice(),
+			LeaseID:   leaseID,
+			Group:     &groupForLease,
+			Price:     lease.GetPrice(),
+			CreatedAt: lease.GetCreatedAt(),
 		}
 
 		leases[i] = ev

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -263,7 +263,7 @@ loop:
 				if ev.LeaseID.GetProvider() != s.session.Provider().Address().String() {
 					continue
 				}
-				s.session.Log().Info("lease won", "lease", ev.LeaseID)
+				s.session.Log().Info("handling lease", "lease", ev.LeaseID)
 				s.handleLease(ev, true)
 			case *dtypes.EventDeploymentUpdated:
 				s.session.Log().Info("update received", "deployment", ev.ID, "version", ev.Hash)

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -263,7 +263,7 @@ loop:
 				if ev.LeaseID.GetProvider() != s.session.Provider().Address().String() {
 					continue
 				}
-				s.session.Log().Info("handling lease", "lease", ev.LeaseID)
+				s.session.Log().Info("lease won", "lease", ev.LeaseID)
 				s.handleLease(ev, true)
 			case *dtypes.EventDeploymentUpdated:
 				s.session.Log().Info("update received", "deployment", ev.ID, "version", ev.Hash)

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -351,7 +351,7 @@ func (s *service) handleLease(ev event.LeaseWon, isNew bool) {
 	if isNew && s.config.ManifestTimeout > time.Duration(0) {
 		// Create watchdog if it does not exist AND a manifest has not been received yet
 		if watchdog := s.watchdogs[ev.LeaseID.DeploymentID()]; watchdog == nil {
-			watchdog = newWatchdog(s.session, s.lc.ShuttingDown(), s.watchdogch, ev.LeaseID, s.config.ManifestTimeout)
+			watchdog = newWatchdog(s.session, s.lc.ShuttingDown(), s.watchdogch, ev.LeaseID, s.config.ManifestTimeout, s.config.BroadcastTimeout)
 			s.watchdogs[ev.LeaseID.DeploymentID()] = watchdog
 		}
 	}

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -351,7 +351,8 @@ func (s *service) handleLease(ev event.LeaseWon, isNew bool) {
 	if isNew && s.config.ManifestTimeout > time.Duration(0) {
 		// Create watchdog if it does not exist AND a manifest has not been received yet
 		if watchdog := s.watchdogs[ev.LeaseID.DeploymentID()]; watchdog == nil {
-			watchdog = newWatchdog(s.session, s.lc.ShuttingDown(), s.watchdogch, ev.LeaseID, s.config.ManifestTimeout, s.config.BroadcastTimeout)
+			timeout := manifestTimeoutForLease(s.config.ManifestTimeout, ev.CreatedAt, s.session.CreatedAtBlockHeight())
+			watchdog = newWatchdog(s.session, s.lc.ShuttingDown(), s.watchdogch, ev.LeaseID, timeout, s.config.BroadcastTimeout)
 			s.watchdogs[ev.LeaseID.DeploymentID()] = watchdog
 		}
 	}
@@ -359,6 +360,20 @@ func (s *service) handleLease(ev event.LeaseWon, isNew bool) {
 	manager := s.ensureManager(ev.LeaseID.DeploymentID())
 
 	manager.handleLease(ev)
+}
+
+func manifestTimeoutForLease(timeout time.Duration, leaseCreatedAt, currentBlockHeight int64) time.Duration {
+	if timeout <= 0 || leaseCreatedAt <= 0 || currentBlockHeight <= leaseCreatedAt {
+		return timeout
+	}
+
+	const minTimePerBlock = 5 * time.Second
+	elapsed := time.Duration(currentBlockHeight-leaseCreatedAt) * minTimePerBlock
+	if elapsed >= timeout {
+		return 0
+	}
+
+	return timeout - elapsed
 }
 
 func (s *service) ensureManager(did dtypes.DeploymentID) (manager *manager) {

--- a/manifest/watchdog.go
+++ b/manifest/watchdog.go
@@ -75,17 +75,20 @@ func (wd *watchdog) run() {
 				ID:     mtypes.MakeBidID(wd.leaseID.OrderID(), wd.sess.Provider().Address()),
 				Reason: mtypes.LeaseClosedReasonManifestTimeout,
 			}
-
 			return runner.NewResult(wd.sess.Client().Tx().BroadcastMsgs(wd.ctx, []sdk.Msg{msg}, aclient.WithResultCodeAsError()))
 		})
 	case err = <-wd.lc.ShutdownRequest():
 	}
 
-	wd.lc.ShutdownInitiated(err)
 	if runch != nil {
-		result := <-runch
-		if err := result.Error(); err != nil {
-			wd.log.Error("failed closing bid", "err", err)
+		select {
+		case result := <-runch:
+			if err := result.Error(); err != nil {
+				wd.log.Error("failed closing bid", "err", err)
+			}
+		case err = <-wd.lc.ShutdownRequest():
+			go func() { <-runch }()
 		}
 	}
+	wd.lc.ShutdownInitiated(err)
 }

--- a/manifest/watchdog.go
+++ b/manifest/watchdog.go
@@ -87,7 +87,7 @@ func (wd *watchdog) run() {
 				wd.log.Error("failed closing bid", "err", err)
 			}
 		case err = <-wd.lc.ShutdownRequest():
-			go func() { <-runch }()
+			// we need this case to skip waiting on runch when stop() is called
 		}
 	}
 	wd.lc.ShutdownInitiated(err)

--- a/manifest/watchdog.go
+++ b/manifest/watchdog.go
@@ -98,6 +98,7 @@ func (wd *watchdog) run() {
 			}
 			runch = nil
 		case err = <-wd.lc.ShutdownRequest():
+			wd.log.Info("watchdog shutdown requested, waiting for bid close tx to complete")
 		}
 	}
 	wd.lc.ShutdownInitiated(err)

--- a/manifest/watchdog.go
+++ b/manifest/watchdog.go
@@ -25,6 +25,7 @@ type watchdog struct {
 	lc      lifecycle.Lifecycle
 	sess    session.Session
 	ctx     context.Context
+	cancel  context.CancelFunc
 	log     log.Logger
 }
 
@@ -36,13 +37,11 @@ func newWatchdog(sess session.Session, parent <-chan struct{}, done chan<- dtype
 		lc:      lifecycle.New(),
 		sess:    sess,
 		ctx:     ctx,
+		cancel:  cancel,
 		log:     sess.Log().With("leaseID", leaseID),
 	}
 
-	go func() {
-		result.lc.WatchChannel(parent)
-		cancel()
-	}()
+	go result.lc.WatchChannel(parent)
 
 	go func() {
 		<-result.lc.Done()
@@ -54,12 +53,22 @@ func newWatchdog(sess session.Session, parent <-chan struct{}, done chan<- dtype
 	return result
 }
 
+// stop signals the watchdog to exit without closing the bid.
+// Called when: (1) manifest received within the timeout, (2) manifest manager is stopped.
 func (wd *watchdog) stop() {
 	wd.lc.ShutdownAsync(nil)
 }
 
+// run waits for the manifest timeout, then broadcasts MsgCloseBid.
+//
+// Rule: once the broadcast is started, we commit to it - it must complete regardless of
+// any concurrent stop() or parent shutdown. This prevents leaving an open bid on-chain.
+//
+// wd.ctx is derived from context.Background() and is only canceled via defer wd.cancel()
+// at the end of run(), so the broadcast context is always alive while run() executes.
 func (wd *watchdog) run() {
 	defer wd.lc.ShutdownCompleted()
+	defer wd.cancel()
 
 	var runch <-chan runner.Result
 	var err error
@@ -78,16 +87,20 @@ func (wd *watchdog) run() {
 			return runner.NewResult(wd.sess.Client().Tx().BroadcastMsgs(wd.ctx, []sdk.Msg{msg}, aclient.WithResultCodeAsError()))
 		})
 	case err = <-wd.lc.ShutdownRequest():
+		// Manifest received or parent shutdown before timeout - exit without closing the bid.
 	}
 
-	if runch != nil {
+	// ShutdownRequest may arrive while we wait for the broadcast result
+	// consume it to unblock the sender, but keep looping until runch delivers.
+	// wd.ctx is not canceled until run() returns, so none of these signals can interrupt the in-flight broadcast.
+	for runch != nil {
 		select {
 		case result := <-runch:
 			if err := result.Error(); err != nil {
 				wd.log.Error("failed closing bid", "err", err)
 			}
+			runch = nil
 		case err = <-wd.lc.ShutdownRequest():
-			// we need this case to skip waiting on runch when stop() is called
 		}
 	}
 	wd.lc.ShutdownInitiated(err)

--- a/manifest/watchdog.go
+++ b/manifest/watchdog.go
@@ -20,25 +20,22 @@ import (
 )
 
 type watchdog struct {
-	leaseID mtypes.LeaseID
-	timeout time.Duration
-	lc      lifecycle.Lifecycle
-	sess    session.Session
-	ctx     context.Context
-	cancel  context.CancelFunc
-	log     log.Logger
+	leaseID          mtypes.LeaseID
+	timeout          time.Duration
+	broadcastTimeout time.Duration
+	lc               lifecycle.Lifecycle
+	sess             session.Session
+	log              log.Logger
 }
 
-func newWatchdog(sess session.Session, parent <-chan struct{}, done chan<- dtypes.DeploymentID, leaseID mtypes.LeaseID, timeout time.Duration) *watchdog {
-	ctx, cancel := context.WithCancel(context.Background())
+func newWatchdog(sess session.Session, parent <-chan struct{}, done chan<- dtypes.DeploymentID, leaseID mtypes.LeaseID, timeout, broadcastTimeout time.Duration) *watchdog {
 	result := &watchdog{
-		leaseID: leaseID,
-		timeout: timeout,
-		lc:      lifecycle.New(),
-		sess:    sess,
-		ctx:     ctx,
-		cancel:  cancel,
-		log:     sess.Log().With("leaseID", leaseID),
+		leaseID:          leaseID,
+		timeout:          timeout,
+		broadcastTimeout: broadcastTimeout,
+		lc:               lifecycle.New(),
+		sess:             sess,
+		log:              sess.Log().With("leaseID", leaseID),
 	}
 
 	go result.lc.WatchChannel(parent)
@@ -63,12 +60,9 @@ func (wd *watchdog) stop() {
 //
 // Rule: once the broadcast is started, we commit to it - it must complete regardless of
 // any concurrent stop() or parent shutdown. This prevents leaving an open bid on-chain.
-//
-// wd.ctx is derived from context.Background() and is only canceled via defer wd.cancel()
-// at the end of run(), so the broadcast context is always alive while run() executes.
+// broadcastTimeout bounds how long we wait for the RPC response to prevent a permanent hang.
 func (wd *watchdog) run() {
 	defer wd.lc.ShutdownCompleted()
-	defer wd.cancel()
 
 	var runch <-chan runner.Result
 	var err error
@@ -80,19 +74,22 @@ func (wd *watchdog) run() {
 		wd.log.Info("watchdog closing bid")
 
 		runch = runner.Do(func() runner.Result {
+			ctx, cancel := context.WithTimeout(context.Background(), wd.broadcastTimeout)
+			defer cancel()
+
 			msg := &mvbeta.MsgCloseBid{
 				ID:     mtypes.MakeBidID(wd.leaseID.OrderID(), wd.sess.Provider().Address()),
 				Reason: mtypes.LeaseClosedReasonManifestTimeout,
 			}
-			return runner.NewResult(wd.sess.Client().Tx().BroadcastMsgs(wd.ctx, []sdk.Msg{msg}, aclient.WithResultCodeAsError()))
+			return runner.NewResult(wd.sess.Client().Tx().BroadcastMsgs(ctx, []sdk.Msg{msg}, aclient.WithResultCodeAsError()))
 		})
 	case err = <-wd.lc.ShutdownRequest():
 		// Manifest received or parent shutdown before timeout - exit without closing the bid.
 	}
 
-	// ShutdownRequest may arrive while we wait for the broadcast result
-	// consume it to unblock the sender, but keep looping until runch delivers.
-	// wd.ctx is not canceled until run() returns, so none of these signals can interrupt the in-flight broadcast.
+	// ShutdownRequest may arrive while we wait for the broadcast result.
+	// Consume it to unblock the sender, but keep looping until runch delivers.
+	// The broadcast context is independent and bounded by broadcastTimeout.
 	for runch != nil {
 		select {
 		case result := <-runch:

--- a/manifest/watchdog.go
+++ b/manifest/watchdog.go
@@ -29,6 +29,10 @@ type watchdog struct {
 }
 
 func newWatchdog(sess session.Session, parent <-chan struct{}, done chan<- dtypes.DeploymentID, leaseID mtypes.LeaseID, timeout, broadcastTimeout time.Duration) *watchdog {
+	if broadcastTimeout <= 0 {
+		broadcastTimeout = DefaultBroadcastTimeout
+	}
+
 	result := &watchdog{
 		leaseID:          leaseID,
 		timeout:          timeout,

--- a/manifest/watchdog_test.go
+++ b/manifest/watchdog_test.go
@@ -29,6 +29,10 @@ type watchdogTestScaffold struct {
 }
 
 func makeWatchdogTestScaffold(t *testing.T, timeout time.Duration) (*watchdog, *watchdogTestScaffold) {
+	return makeWatchdogTestScaffoldWithBlocking(t, timeout, nil)
+}
+
+func makeWatchdogTestScaffoldWithBlocking(t *testing.T, timeout time.Duration, blockUntilRelease <-chan struct{}) (*watchdog, *watchdogTestScaffold) {
 	scaffold := &watchdogTestScaffold{}
 	scaffold.parentCh = make(chan struct{})
 	scaffold.doneCh = make(chan dtypes.DeploymentID, 1)
@@ -39,6 +43,9 @@ func makeWatchdogTestScaffold(t *testing.T, timeout time.Duration) (*watchdog, *
 
 	txClientMock := &clientmocks.TxClient{}
 	txClientMock.On("BroadcastMsgs", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		if blockUntilRelease != nil {
+			<-blockUntilRelease
+		}
 		scaffold.broadcasts <- args.Get(1).([]sdk.Msg)
 	}).Return(&sdk.Result{}, nil)
 
@@ -72,6 +79,7 @@ func TestWatchdogTimeout(t *testing.T) {
 
 	msg := msgs[0].(*mvbeta.MsgCloseBid)
 	require.Equal(t, scaffold.leaseID, msg.ID.LeaseID())
+	require.Equal(t, mtypes.LeaseClosedReasonManifestTimeout, msg.Reason)
 
 	deploymentID := testutil.ChannelWaitForValue(t, scaffold.doneCh)
 	require.Equal(t, deploymentID, scaffold.leaseID.DeploymentID())
@@ -117,6 +125,25 @@ func TestWatchdogStopsOnParent(t *testing.T) {
 		t.Fatal("should no have broadcast any message")
 	default:
 	}
+
+	deploymentID := testutil.ChannelWaitForValue(t, scaffold.doneCh)
+	require.Equal(t, deploymentID, scaffold.leaseID.DeploymentID())
+}
+
+func TestWatchdogStopWhileWaitingForBroadcast(t *testing.T) {
+	releaseCh := make(chan struct{})
+	wd, scaffold := makeWatchdogTestScaffoldWithBlocking(t, 100*time.Millisecond, releaseCh)
+
+	<-time.After(200 * time.Millisecond)
+	wd.stop()
+
+	select {
+	case <-wd.lc.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock: stop() blocked while watchdog was waiting on broadcast")
+	}
+
+	close(releaseCh)
 
 	deploymentID := testutil.ChannelWaitForValue(t, scaffold.doneCh)
 	require.Equal(t, deploymentID, scaffold.leaseID.DeploymentID())

--- a/manifest/watchdog_test.go
+++ b/manifest/watchdog_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	clientmocks "pkg.akt.dev/go/mocks/node/client"
+	aclient "pkg.akt.dev/go/node/client/v1beta3"
 	dtypes "pkg.akt.dev/go/node/deployment/v1"
 	mtypes "pkg.akt.dev/go/node/market/v1"
 	mvbeta "pkg.akt.dev/go/node/market/v1beta5"
@@ -29,10 +31,14 @@ type watchdogTestScaffold struct {
 }
 
 func makeWatchdogTestScaffold(t *testing.T, timeout time.Duration) (*watchdog, *watchdogTestScaffold) {
-	return makeWatchdogTestScaffoldWithBlocking(t, timeout, nil)
+	return makeWatchdogTestScaffoldFull(t, timeout, 30*time.Second, nil)
 }
 
 func makeWatchdogTestScaffoldWithBlocking(t *testing.T, timeout time.Duration, blockUntilRelease <-chan struct{}) (*watchdog, *watchdogTestScaffold) {
+	return makeWatchdogTestScaffoldFull(t, timeout, 30*time.Second, blockUntilRelease)
+}
+
+func makeWatchdogTestScaffoldFull(t *testing.T, timeout, broadcastTimeout time.Duration, blockUntilRelease <-chan struct{}) (*watchdog, *watchdogTestScaffold) {
 	scaffold := &watchdogTestScaffold{}
 	scaffold.parentCh = make(chan struct{})
 	scaffold.doneCh = make(chan dtypes.DeploymentID, 1)
@@ -42,12 +48,19 @@ func makeWatchdogTestScaffoldWithBlocking(t *testing.T, timeout time.Duration, b
 	scaffold.broadcasts = make(chan []sdk.Msg, 1)
 
 	txClientMock := &clientmocks.TxClient{}
-	txClientMock.On("BroadcastMsgs", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		if blockUntilRelease != nil {
-			<-blockUntilRelease
-		}
-		scaffold.broadcasts <- args.Get(1).([]sdk.Msg)
-	}).Return(&sdk.Result{}, nil)
+	txClientMock.EXPECT().
+		BroadcastMsgs(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, msgs []sdk.Msg, _ ...aclient.BroadcastOption) (any, error) {
+			if blockUntilRelease != nil {
+				select {
+				case <-blockUntilRelease:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
+			scaffold.broadcasts <- msgs
+			return &sdk.Result{}, nil
+		})
 
 	scaffold.client = &clientmocks.Client{}
 	scaffold.client.On("Tx").Return(txClientMock)
@@ -55,7 +68,7 @@ func makeWatchdogTestScaffoldWithBlocking(t *testing.T, timeout time.Duration, b
 
 	require.NotNil(t, sess.Client())
 
-	wd := newWatchdog(sess, scaffold.parentCh, scaffold.doneCh, scaffold.leaseID, timeout)
+	wd := newWatchdog(sess, scaffold.parentCh, scaffold.doneCh, scaffold.leaseID, timeout, broadcastTimeout)
 
 	return wd, scaffold
 }
@@ -123,6 +136,27 @@ func TestWatchdogStopsOnParent(t *testing.T) {
 	select {
 	case <-scaffold.broadcasts:
 		t.Fatal("should no have broadcast any message")
+	default:
+	}
+
+	deploymentID := testutil.ChannelWaitForValue(t, scaffold.doneCh)
+	require.Equal(t, deploymentID, scaffold.leaseID.DeploymentID())
+}
+
+func TestWatchdogBroadcastTimeout(t *testing.T) {
+	// Mock blocks forever; broadcast context expires after 10ms → watchdog exits cleanly.
+	neverRelease := make(chan struct{})
+	wd, scaffold := makeWatchdogTestScaffoldFull(t, 100*time.Millisecond, 10*time.Millisecond, neverRelease)
+
+	select {
+	case <-wd.lc.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("watchdog hung after broadcast timeout")
+	}
+
+	select {
+	case <-scaffold.broadcasts:
+		t.Fatal("broadcast should not have completed")
 	default:
 	}
 

--- a/manifest/watchdog_test.go
+++ b/manifest/watchdog_test.go
@@ -137,14 +137,19 @@ func TestWatchdogStopWhileWaitingForBroadcast(t *testing.T) {
 	<-time.After(200 * time.Millisecond)
 	wd.stop()
 
+	close(releaseCh)
+
 	select {
 	case <-wd.lc.Done():
 	case <-time.After(5 * time.Second):
-		t.Fatal("deadlock: stop() blocked while watchdog was waiting on broadcast")
+		t.Fatal("deadlock: watchdog did not complete after broadcast")
 	}
-
-	close(releaseCh)
 
 	deploymentID := testutil.ChannelWaitForValue(t, scaffold.doneCh)
 	require.Equal(t, deploymentID, scaffold.leaseID.DeploymentID())
+
+	broadcasts := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
+	msgs := broadcasts.([]sdk.Msg)
+	require.Len(t, msgs, 1)
+	require.Equal(t, mtypes.LeaseClosedReasonManifestTimeout, msgs[0].(*mvbeta.MsgCloseBid).Reason)
 }

--- a/manifest/watchdog_test.go
+++ b/manifest/watchdog_test.go
@@ -79,6 +79,16 @@ func makeWatchdogTestScaffoldFull(t *testing.T, timeout, broadcastTimeout time.D
 	return wd, scaffold
 }
 
+func TestManifestTimeoutForLease(t *testing.T) {
+	const leaseCreatedAt int64 = 100
+	timeout := time.Minute
+
+	require.Equal(t, timeout, manifestTimeoutForLease(timeout, 0, 200))
+	require.Equal(t, timeout, manifestTimeoutForLease(timeout, leaseCreatedAt, leaseCreatedAt))
+	require.Equal(t, 30*time.Second, manifestTimeoutForLease(timeout, leaseCreatedAt, 106))
+	require.Equal(t, time.Duration(0), manifestTimeoutForLease(timeout, leaseCreatedAt, 112))
+}
+
 func TestWatchdogTimeout(t *testing.T) {
 	wd, scaffold := makeWatchdogTestScaffold(t, 3*time.Second)
 

--- a/manifest/watchdog_test.go
+++ b/manifest/watchdog_test.go
@@ -22,20 +22,21 @@ import (
 )
 
 type watchdogTestScaffold struct {
-	client     *clientmocks.Client
-	parentCh   chan struct{}
-	doneCh     chan dtypes.DeploymentID
-	broadcasts chan []sdk.Msg
-	leaseID    mtypes.LeaseID
-	provider   ptypes.Provider
+	client           *clientmocks.Client
+	parentCh         chan struct{}
+	doneCh           chan dtypes.DeploymentID
+	broadcasts       chan []sdk.Msg
+	broadcastStarted chan struct{}
+	leaseID          mtypes.LeaseID
+	provider         ptypes.Provider
 }
 
 func makeWatchdogTestScaffold(t *testing.T, timeout time.Duration) (*watchdog, *watchdogTestScaffold) {
-	return makeWatchdogTestScaffoldFull(t, timeout, 30*time.Second, nil)
+	return makeWatchdogTestScaffoldFull(t, timeout, DefaultBroadcastTimeout, nil)
 }
 
 func makeWatchdogTestScaffoldWithBlocking(t *testing.T, timeout time.Duration, blockUntilRelease <-chan struct{}) (*watchdog, *watchdogTestScaffold) {
-	return makeWatchdogTestScaffoldFull(t, timeout, 30*time.Second, blockUntilRelease)
+	return makeWatchdogTestScaffoldFull(t, timeout, DefaultBroadcastTimeout, blockUntilRelease)
 }
 
 func makeWatchdogTestScaffoldFull(t *testing.T, timeout, broadcastTimeout time.Duration, blockUntilRelease <-chan struct{}) (*watchdog, *watchdogTestScaffold) {
@@ -46,11 +47,16 @@ func makeWatchdogTestScaffoldFull(t *testing.T, timeout, broadcastTimeout time.D
 	scaffold.leaseID = testutil.LeaseID(t)
 	scaffold.leaseID.Provider = scaffold.provider.Owner
 	scaffold.broadcasts = make(chan []sdk.Msg, 1)
+	scaffold.broadcastStarted = make(chan struct{}, 1)
 
 	txClientMock := &clientmocks.TxClient{}
 	txClientMock.EXPECT().
 		BroadcastMsgs(mock.Anything, mock.Anything, mock.Anything).
 		RunAndReturn(func(ctx context.Context, msgs []sdk.Msg, _ ...aclient.BroadcastOption) (any, error) {
+			select {
+			case scaffold.broadcastStarted <- struct{}{}:
+			default:
+			}
 			if blockUntilRelease != nil {
 				select {
 				case <-blockUntilRelease:
@@ -144,7 +150,7 @@ func TestWatchdogStopsOnParent(t *testing.T) {
 }
 
 func TestWatchdogBroadcastTimeout(t *testing.T) {
-	// Mock blocks forever; broadcast context expires after 10ms → watchdog exits cleanly.
+	// Mock blocks forever; broadcast context expires after 10ms and watchdog exits cleanly.
 	neverRelease := make(chan struct{})
 	wd, scaffold := makeWatchdogTestScaffoldFull(t, 100*time.Millisecond, 10*time.Millisecond, neverRelease)
 
@@ -164,11 +170,38 @@ func TestWatchdogBroadcastTimeout(t *testing.T) {
 	require.Equal(t, deploymentID, scaffold.leaseID.DeploymentID())
 }
 
+func TestWatchdogUsesDefaultBroadcastTimeout(t *testing.T) {
+	releaseCh := make(chan struct{})
+	wd, scaffold := makeWatchdogTestScaffoldFull(t, 100*time.Millisecond, 0, releaseCh)
+
+	select {
+	case <-scaffold.broadcastStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for broadcast to start")
+	}
+
+	close(releaseCh)
+
+	select {
+	case <-wd.lc.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("watchdog hung after broadcast completed")
+	}
+
+	broadcasts := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
+	msgs := broadcasts.([]sdk.Msg)
+	require.Len(t, msgs, 1)
+}
+
 func TestWatchdogStopWhileWaitingForBroadcast(t *testing.T) {
 	releaseCh := make(chan struct{})
 	wd, scaffold := makeWatchdogTestScaffoldWithBlocking(t, 100*time.Millisecond, releaseCh)
 
-	<-time.After(200 * time.Millisecond)
+	select {
+	case <-scaffold.broadcastStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for broadcast to start")
+	}
 	wd.stop()
 
 	close(releaseCh)

--- a/service.go
+++ b/service.go
@@ -106,6 +106,7 @@ func NewService(ctx context.Context,
 	manifestConfig := manifest.ServiceConfig{
 		HTTPServicesRequireAtLeastOneHost: !cfg.DeploymentIngressStaticHosts,
 		ManifestTimeout:                   cfg.ManifestTimeout,
+		BroadcastTimeout:                  cfg.BroadcastTimeout,
 		RPCQueryTimeout:                   cfg.RPCQueryTimeout,
 		CachedResultMaxAge:                cfg.CachedResultMaxAge,
 	}


### PR DESCRIPTION
# Resolves:
https://github.com/akash-network/support/issues/435

# Root of the issue:
1. The broadcast of bid close runs with wd.ctx, but we call ShutdownInitiated before it finishes. 
2. That closes stoppingch, so WatchChannel returns and cancels wd.ctx while the broadcast is still in progress. 
3. The broadcast then fails with "context canceled" and the bid is not closed on-chain.

# Changes

1. Commit to the broadcast once started. Even if stop() signal received during the wait of the broadcast result - we don't cancel the broadcast.

I moved wd.lc.ShutdownInitiated(err) after `case result := <-runch:`, so it will be called right after runner will finish its job.

2. Added broadcast timeout, that will cancel the execution in FlagTxBroadcastTimeout and return.

3. I added a select case for the `case err = <-wd.lc.ShutdownRequest():` in case shutdown will be initiated outside to prevent deadlock if stop() is called during the broadcast.

# Is that a regression that we got recently?

The bug is long-standing. The v1 upgrade likely made it more visible by changing client behavior and timing, not by introducing new logic. So may this issue may appeared after pkg.akt.dev client changes. 

# Testing
Created a lease and waited 5min.
Provider logs:
```
5:32PM INF watchdog closing bid leaseID=akash1nfyvsjhl7wcyduq7hkx87jja7mu5qyfmcrf0sv/7/1/1/akash1ff4s67p9xjykezkn7gnmdzpz8vdw3kn0ewx7ss module=provider-manifest
5:32PM INF watchdog done lease=akash1nfyvsjhl7wcyduq7hkx87jja7mu5qyfmcrf0sv/7 module=provider-manifest
5:32PM INF lease closed lease=akash1nfyvsjhl7wcyduq7hkx87jja7mu5qyfmcrf0sv/7/1/1/akash1ff4s67p9xjykezkn7gnmdzpz8vdw3kn0ewx7ss module=provider-manifest
5:32PM INF unreserving unmanaged order cmp=service lease=akash1nfyvsjhl7wcyduq7hkx87jja7mu5qyfmcrf0sv/7/1/1/akash1ff4s67p9xjykezkn7gnmdzpz8vdw3kn0ewx7ss module=provider-cluster
5:32PM INF lease removed deployment=akash1nfyvsjhl7wcyduq7hkx87jja7mu5qyfmcrf0sv/7 lease=akash1nfyvsjhl7wcyduq7hkx87jja7mu5qyfmcrf0sv/7/1/1/akash1ff4s67p9xjykezkn7gnmdzpz8vdw3kn0ewx7ss module=manifest-manager
5:32PM DBG unreserving capacity cmp=inventory-service module=provider-cluster order=akash1nfyvsjhl7wcyduq7hkx87jja7mu5qyfmcrf0sv/7/1/1
5:32PM INF attempting to removing reservation cmp=inventory-service module=provider-cluster order=akash1nfyvsjhl7wcyduq7hkx87jja7mu5qyfmcrf0sv/7/1/1
5:32PM INF removing reservation cmp=inventory-service module=provider-cluster order=akash1nfyvsjhl7wcyduq7hkx87jja7mu5qyfmcrf0sv/7/1/1
5:32PM INF unreserve capacity complete cmp=inventory-service module=provider-cluster order=akash1nfyvsjhl7wcyduq7hkx87jja7mu5qyfmcrf0sv/7/1/1
```

Also tested a cancelation timeout of 10ms:
```
5:24PM ERR failed closing bid err="context deadline exceeded" leaseID=akash1nfyvsjhl7wcyduq7hkx87jja7mu5qyfmcrf0sv/6/1/1/akash1ff4s67p9xjykezkn7gnmdzpz8vdw3kn0ewx7ss module=provider-manifest
```
Which is expected.

