### PR TITLE
ci: run integration tests in 2 batches

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -4,6 +4,12 @@ name: Integration tests
 # yamllint disable-line rule:truthy
 on:
   workflow_call:
+    inputs:
+      e2e_target:
+        description: 'Make target for E2E tests'
+        required: false
+        default: 'test-e2e-integration'
+        type: string
 
 env:
   KUBE_SSH_NODES: kind
@@ -144,7 +150,7 @@ jobs:
       - name: Run E2E Tests
         working-directory: ${{ env.GOPATH }}/src/github.com/akash-network/provider
         run: |
-          make test-e2e-integration
+          make ${{ inputs.e2e_target }}
       - name: Print operator inventory logs
         if: always()
         working-directory: ${{ env.GOPATH }}/src/github.com/akash-network/provider/_run/kube

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -104,8 +104,15 @@ jobs:
         uses: ./.github/actions/setup-ubuntu
       - run: make shellcheck
 
-  integration-tests:
+  integration-tests-batch1:
     uses: ./.github/workflows/integration-tests.yaml
+    with:
+      e2e_target: test-e2e-integration-batch1
+
+  integration-tests-batch2:
+    uses: ./.github/workflows/integration-tests.yaml
+    with:
+      e2e_target: test-e2e-integration-batch2
 
   dispatch-release:
     runs-on: ubuntu-latest
@@ -118,7 +125,8 @@ jobs:
       - coverage
       - yamlcheck
       - shellcheck
-      - integration-tests
+      - integration-tests-batch1
+      - integration-tests-batch2
     steps:
       - uses: actions/checkout@v4
         with:

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -761,6 +761,27 @@ func TestIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, &E2EIPAddress{IntegrationTestSuite{ipMarketplace: true}})
 }
 
+func TestIntegrationBatch1(t *testing.T) {
+	integrationTestOnly(t)
+
+	suite.Run(t, new(E2EContainerToContainer))
+	suite.Run(t, new(E2EAppNodePort))
+	suite.Run(t, new(E2EDeploymentUpdate))
+	suite.Run(t, new(E2EApp))
+	suite.Run(t, new(E2EMigrateHostname))
+}
+
+func TestIntegrationBatch2(t *testing.T) {
+	integrationTestOnly(t)
+
+	suite.Run(t, new(E2EPersistentStorageDefault))
+	suite.Run(t, new(E2EPersistentStorageBeta2))
+	suite.Run(t, new(E2EPersistentStorageDeploymentUpdate))
+	suite.Run(t, new(E2EStorageClassRam))
+	suite.Run(t, new(E2ECustomCurrency))
+	suite.Run(t, &E2EIPAddress{IntegrationTestSuite{ipMarketplace: true}})
+}
+
 // TestQueryApp enables rapid testing of the querying functionality locally
 // Not for CI tests.
 func TestQueryApp(t *testing.T) {

--- a/make/test-integration.mk
+++ b/make/test-integration.mk
@@ -27,6 +27,14 @@ test-e2e-integration:
 	# ```
 	$(KIND_VARS) $(INTEGRATION_VARS) $(GO_TEST) -count=1 -p 4 -tags "e2e" -v ./integration/... -run TestIntegrationTestSuite -timeout 3000s
 
+.PHONY: test-e2e-integration-batch1
+test-e2e-integration-batch1:
+	$(KIND_VARS) $(INTEGRATION_VARS) $(GO_TEST) -count=1 -tags "e2e" -v ./integration/... -run TestIntegrationBatch1 -timeout 1500s
+
+.PHONY: test-e2e-integration-batch2
+test-e2e-integration-batch2:
+	$(KIND_VARS) $(INTEGRATION_VARS) $(GO_TEST) -count=1 -tags "e2e" -v ./integration/... -run TestIntegrationBatch2 -timeout 1500s
+
 .PHONY: test-e2e-integration-k8s
 test-e2e-integration-k8s:
 	$(INTEGRATION_VARS) \


### PR DESCRIPTION
## Summary

Split E2E integration tests into two parallel batches to reduce overall CI wall time.

Previously, all 12 test suites ran sequentially in a single `TestIntegrationTestSuite` function. Each suite performs a full stack setup (in-process testnet, provider, operators) and teardown independently, with no ordering dependencies between suites — making them safe to split.

### Changes

- **`integration/e2e_test.go`** — added `TestIntegrationBatch1` and `TestIntegrationBatch2` alongside the existing `TestIntegrationTestSuite`; removed duplicate `E2EPersistentStorageDefault` entry that was previously run twice
  - Batch 1:
    - `E2EContainerToContainer`
    - `E2EAppNodePort`
    - `E2EDeploymentUpdate`
    - `E2EApp`
    - `E2EMigrateHostname`
  - Batch 2:
    - `E2EPersistentStorageDefault`
    - `E2EPersistentStorageBeta2`
    - `E2EPersistentStorageDeploymentUpdate`
    - `E2EStorageClassRam`
    - `E2ECustomCurrency`
    - `E2EIPAddress`

- **`make/test-integration.mk`** — added `test-e2e-integration-batch1` and `test-e2e-integration-batch2` targets

- **`.github/workflows/integration-tests.yaml`** — added `e2e_target` input (default: `test-e2e-integration`) to make the reusable workflow target-parametric

- **`.github/workflows/tests.yaml`** — replaced single `integration-tests` job with two parallel jobs (`integration-tests-batch1`, `integration-tests-batch2`), each passing the respective make target; both are required for `dispatch-release`

### Expected impact

Each parallel job runs its own Kind cluster (full isolation, no shared k8s state). Aims to reduce overall integration tests CI time.
