### PR TITLE
chore: replaced error key with err in logs

### DIFF
--- a/balance_checker.go
+++ b/balance_checker.go
@@ -311,7 +311,7 @@ loop:
 				scheduledWithdraw := false
 
 				if res.err != nil {
-					bc.log.Info("couldn't check lease balance. retrying in 1m", "leaseId", res.lid, "err", res.err.Error())
+					bc.log.Info("couldn't check lease balance. retrying in 1m", "leaseId", res.lid, "err", res.err)
 					timerPeriod = time.Minute
 				} else if !withdraw && !lState.scheduledWithdrawAt.IsZero() {
 					withdrawIn := time.Until(lState.scheduledWithdrawAt)

--- a/balance_checker.go
+++ b/balance_checker.go
@@ -311,7 +311,7 @@ loop:
 				scheduledWithdraw := false
 
 				if res.err != nil {
-					bc.log.Info("couldn't check lease balance. retrying in 1m", "leaseId", res.lid, "error", res.err.Error())
+					bc.log.Info("couldn't check lease balance. retrying in 1m", "leaseId", res.lid, "err", res.err.Error())
 					timerPeriod = time.Minute
 				} else if !withdraw && !lState.scheduledWithdrawAt.IsZero() {
 					withdrawIn := time.Until(lState.scheduledWithdrawAt)

--- a/bidengine/order.go
+++ b/bidengine/order.go
@@ -236,7 +236,7 @@ loop:
 				if matchBidNotFound.MatchString(err.Error()) {
 					bidFound = false
 				} else {
-					o.session.Log().Error("could not get existing bid", "error", err, "errtype", fmt.Sprintf("%T", err))
+					o.session.Log().Error("could not get existing bid", "err", err, "errtype", fmt.Sprintf("%T", err))
 					break loop
 				}
 			}
@@ -334,7 +334,7 @@ loop:
 			o.log.Info("group fetched")
 
 			if result.Error() != nil {
-				o.log.Error("fetching group", "error", result.Error())
+				o.log.Error("fetching group", "err", result.Error())
 				break loop
 			}
 
@@ -350,7 +350,7 @@ loop:
 
 			if result.Error() != nil {
 				shouldBidCounter.WithLabelValues(metricsutils.FailLabel).Inc()
-				o.log.Error("failure during checking should bid", "error", result.Error())
+				o.log.Error("failure during checking should bid", "err", result.Error())
 				break loop
 			}
 
@@ -373,7 +373,7 @@ loop:
 
 			if result.Error() != nil {
 				reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.FailLabel)
-				o.log.Error("reserving resources", "error", result.Error())
+				o.log.Error("reserving resources", "err", result.Error())
 				break loop
 			}
 
@@ -409,7 +409,7 @@ loop:
 		case result := <-pricech:
 			pricech = nil
 			if result.Error() != nil {
-				o.log.Error("error calculating price", "error", result.Error())
+				o.log.Error("error calculating price", "err", result.Error())
 				break loop
 			}
 
@@ -443,7 +443,7 @@ loop:
 			bidch = nil
 			if result.Error() != nil {
 				bidCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.FailLabel).Inc()
-				o.log.Error("bid failed", "error", result.Error())
+				o.log.Error("bid failed", "err", result.Error())
 				break loop
 			}
 
@@ -478,7 +478,7 @@ loop:
 		if reservation != nil {
 			o.log.Debug("unreserving reservation")
 			if err := o.cluster.Unreserve(reservation.OrderID()); err != nil {
-				o.log.Error("error unreserving reservation", "error", err)
+				o.log.Error("error unreserving reservation", "err", err)
 				reservationCounter.WithLabelValues("close", metricsutils.FailLabel)
 			} else {
 				reservationCounter.WithLabelValues("close", metricsutils.SuccessLabel)
@@ -495,7 +495,7 @@ loop:
 
 			_, err := o.session.Client().Tx().BroadcastMsgs(ctx, []sdk.Msg{msg}, aclient.WithResultCodeAsError())
 			if err != nil {
-				o.log.Error("closing bid", "error", err)
+				o.log.Error("closing bid", "err", err)
 				bidCounter.WithLabelValues("close", metricsutils.FailLabel).Inc()
 			} else {
 				o.log.Info("bid closed", "order-id", o.orderID)
@@ -587,7 +587,7 @@ func (o *order) shouldBid(group *dtypes.Group) (bool, error) {
 
 	if err := group.GroupSpec.ValidateBasic(); err != nil {
 		o.log.Error("unable to fulfill: group validation error",
-			"error", err)
+			"err", err)
 		return false, nil
 	}
 	return true, nil

--- a/bidengine/service.go
+++ b/bidengine/service.go
@@ -275,7 +275,7 @@ loop:
 	for {
 		select {
 		case shutdownErr := <-s.lc.ShutdownRequest():
-			s.session.Log().Debug("received shutdown request", "error", shutdownErr)
+			s.session.Log().Debug("received shutdown request", "err", shutdownErr)
 			s.lc.ShutdownInitiated(shutdownErr)
 			break loop
 		case orders := <-s.ordersch:
@@ -284,7 +284,7 @@ loop:
 				s.session.Log().Debug("creating catchup order", "order", key)
 				order, err := newOrder(s, orderID, s.cfg, s.pass, true)
 				if err != nil {
-					s.session.Log().Error("creating catchup order", "order", key, "error", err)
+					s.session.Log().Error("creating catchup order", "order", key, "err", err)
 					continue
 				}
 				s.orders[key] = order
@@ -306,7 +306,7 @@ loop:
 				// create an order object for managing the bid process and order lifecycle
 				order, err := newOrder(s, ev.ID, s.cfg, s.pass, false)
 				if err != nil {
-					s.session.Log().Error("handling order", "order", key, "error", err)
+					s.session.Log().Error("handling order", "order", key, "err", err)
 					break
 				}
 

--- a/cluster/kube/client.go
+++ b/cluster/kube/client.go
@@ -815,7 +815,7 @@ func (c *client) TeardownLease(ctx context.Context, lid mtypes.LeaseID) error {
 	})
 
 	if result != nil {
-		c.log.Error("teardown lease: unable to delete namespace", "ns", builder.LidNS(lid), "error", result)
+		c.log.Error("teardown lease: unable to delete namespace", "ns", builder.LidNS(lid), "err", result)
 		if kerrors.IsNotFound(result) {
 			result = nil
 		}
@@ -825,7 +825,7 @@ func (c *client) TeardownLease(ctx context.Context, lid mtypes.LeaseID) error {
 	})
 
 	if err != nil {
-		c.log.Error("teardown lease: unable to delete manifest", "ns", builder.LidNS(lid), "error", err)
+		c.log.Error("teardown lease: unable to delete manifest", "ns", builder.LidNS(lid), "err", err)
 	}
 
 	return result

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -107,7 +107,7 @@ func newDeploymentManager(s *service, deployment ctypes.IDeployment, isNewLease 
 
 	err := s.bus.Publish(event.LeaseAddFundsMonitor{LeaseID: lid, IsNewLease: isNewLease})
 	if err != nil {
-		s.log.Error("unable to publish LeaseAddFundsMonitor event", "error", err, "lease", lid)
+		s.log.Error("unable to publish LeaseAddFundsMonitor event", "err", err, "lease", lid)
 	}
 
 	return dm

--- a/cluster/manager_cleanup.go
+++ b/cluster/manager_cleanup.go
@@ -51,7 +51,7 @@ func (dch *deployCleanupHelper) purgeAll(ctx context.Context) {
 		err := dch.client.PurgeDeclaredHostname(ctx, dch.lease, hostname)
 		if err != nil {
 			dch.log.Error("could not purge hostname",
-				"lease", dch.lease, "hsotname", hostname, "err", err)
+				"lease", dch.lease, "hostname", hostname, "err", err)
 		}
 	}
 

--- a/cluster/manager_cleanup.go
+++ b/cluster/manager_cleanup.go
@@ -51,7 +51,7 @@ func (dch *deployCleanupHelper) purgeAll(ctx context.Context) {
 		err := dch.client.PurgeDeclaredHostname(ctx, dch.lease, hostname)
 		if err != nil {
 			dch.log.Error("could not purge hostname",
-				"lease", dch.lease, "hsotname", hostname, "error", err)
+				"lease", dch.lease, "hsotname", hostname, "err", err)
 		}
 	}
 
@@ -63,7 +63,7 @@ func (dch *deployCleanupHelper) purgeAll(ctx context.Context) {
 				"serviceName", ipEntry.serviceName,
 				"port", ipEntry.port,
 				"proto", ipEntry.proto,
-				"error", err)
+				"err", err)
 		}
 	}
 }

--- a/cluster/util/service_discovery_agent.go
+++ b/cluster/util/service_discovery_agent.go
@@ -228,7 +228,7 @@ func (sda *serviceDiscoveryAgent) discoverDNS() (clientFactory, error) {
 	// FUTURE - try and find a 3rd party API that allows timeouts to be put on this request
 	_, addrs, err := net.LookupSRV(sda.portName, "TCP", fmt.Sprintf("%s.%s.svc.cluster.local", sda.serviceName, sda.namespace))
 	if err != nil {
-		sda.log.Error("dns discovery failed", "error", err, "portName", sda.portName, "service-name", sda.serviceName, "namespace", sda.namespace)
+		sda.log.Error("dns discovery failed", "err", err, "portName", sda.portName, "service-name", sda.serviceName, "namespace", sda.namespace)
 		return nil, err
 	}
 

--- a/gateway/rest/router.go
+++ b/gateway/rest/router.go
@@ -692,10 +692,10 @@ func wsLogWriter(ctx context.Context, ws *websocket.Conn, cfg wsStreamConfig) {
 
 	logs, err := cfg.client.LeaseLogs(cctx, cfg.lid, cfg.services, cfg.follow, cfg.tailLines)
 	if err != nil {
-		cfg.log.Error("couldn't fetch logs", "error", err.Error())
+		cfg.log.Error("couldn't fetch logs", "err", err.Error())
 		err = ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocketCloseCodeFrom(err), ""))
 		if err != nil {
-			cfg.log.Error("couldn't push control message through websocket", "error", err.Error())
+			cfg.log.Error("couldn't push control message through websocket", "err", err.Error())
 		}
 		return
 	}
@@ -786,10 +786,10 @@ func wsEventWriter(ctx context.Context, ws *websocket.Conn, cfg wsStreamConfig) 
 
 	evts, err := cfg.client.LeaseEvents(cctx, cfg.lid, cfg.services, cfg.follow)
 	if err != nil {
-		cfg.log.Error("couldn't fetch events", "error", err.Error())
+		cfg.log.Error("couldn't fetch events", "err", err.Error())
 		err = ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocketCloseCodeFrom(err), ""))
 		if err != nil {
-			cfg.log.Error("couldn't push control message through websocket", "error", err.Error())
+			cfg.log.Error("couldn't push control message through websocket", "err", err.Error())
 		}
 		return
 	}
@@ -799,7 +799,7 @@ func wsEventWriter(ctx context.Context, ws *websocket.Conn, cfg wsStreamConfig) 
 			websocket.CloseMessage,
 			websocket.FormatCloseMessage(websocketLeaseNotFound, ""))
 		if err != nil {
-			cfg.log.Error("couldn't push control message through websocket", "error", err.Error())
+			cfg.log.Error("couldn't push control message through websocket", "err", err.Error())
 		}
 		return
 	}

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -384,7 +384,7 @@ func (m *manager) validateRequests() {
 		default:
 		}
 		if err := m.validateRequest(req); err != nil {
-			m.log.Error("invalid manifest", "err", err.Error())
+			m.log.Error("invalid manifest", "err", err)
 			req.ch <- err
 			continue
 		}
@@ -474,7 +474,7 @@ func (m *manager) checkHostnamesForManifest(requestManifest maniv2beta2.Manifest
 			if !m.config.HTTPServicesRequireAtLeastOneHost {
 				continue
 			}
-			// For each service that exposes via an Ingress, then require a hsotname
+			// For each service that exposes via an Ingress, then require a hostname
 			for _, service := range mgroup.Services {
 				for _, expose := range service.Expose {
 					if expose.IsIngress() && len(expose.Hosts) == 0 {

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -384,7 +384,7 @@ func (m *manager) validateRequests() {
 		default:
 		}
 		if err := m.validateRequest(req); err != nil {
-			m.log.Error("invalid manifest", "error", err.Error())
+			m.log.Error("invalid manifest", "err", err.Error())
 			req.ch <- err
 			continue
 		}

--- a/operator/hostname/operator_test.go
+++ b/operator/hostname/operator_test.go
@@ -78,7 +78,7 @@ package hostname
 // 	require.Equal(t, directive.NextTimeout, uint32(60000))
 // 	require.Equal(t, directive.MaxBodySize, uint32(1048576))
 // 	require.Equal(t, directive.NextTries, uint32(3))
-// 	require.Equal(t, directive.NextCases, []string{"error", "timeout"})
+// 	require.Equal(t, directive.NextCases, []string{"error",  "timeout"})
 // }
 //
 // func TestBuildDirectiveWithValues(t *testing.T) {

--- a/operator/hostname/operator_test.go
+++ b/operator/hostname/operator_test.go
@@ -78,7 +78,7 @@ package hostname
 // 	require.Equal(t, directive.NextTimeout, uint32(60000))
 // 	require.Equal(t, directive.MaxBodySize, uint32(1048576))
 // 	require.Equal(t, directive.NextTries, uint32(3))
-// 	require.Equal(t, directive.NextCases, []string{"error",  "timeout"})
+// 	require.Equal(t, directive.NextCases, []string{"error", "timeout"})
 // }
 //
 // func TestBuildDirectiveWithValues(t *testing.T) {

--- a/operator/ip/operator.go
+++ b/operator/ip/operator.go
@@ -541,7 +541,7 @@ func handleIPLeaseStatusGet(op *ipOperator, rw http.ResponseWriter, req *http.Re
 	owner := vars["owner"]
 	_, err = sdktypes.AccAddressFromBech32(owner) // Validate this is a bech32 address
 	if err != nil {
-		op.log.Error("could not parse owner address as bech32", "onwer", owner, "err", err)
+		op.log.Error("could not parse owner address as bech32", "owner", owner, "err", err)
 		rw.WriteHeader(http.StatusNotFound)
 		return
 	}

--- a/operator/ip/operator.go
+++ b/operator/ip/operator.go
@@ -517,7 +517,7 @@ func handleIPLeaseStatusGet(op *ipOperator, rw http.ResponseWriter, req *http.Re
 	dseqStr := vars["dseq"]
 	dseq, err := strconv.ParseUint(dseqStr, 10, 64)
 	if err != nil {
-		op.log.Error("could not parse path component as uint64", "dseq", dseqStr, "error", err)
+		op.log.Error("could not parse path component as uint64", "dseq", dseqStr, "err", err)
 		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
@@ -525,7 +525,7 @@ func handleIPLeaseStatusGet(op *ipOperator, rw http.ResponseWriter, req *http.Re
 	gseqStr := vars["gseq"]
 	gseq, err := strconv.ParseUint(gseqStr, 10, 32)
 	if err != nil {
-		op.log.Error("could not parse path component as uint32", "gseq", gseqStr, "error", err)
+		op.log.Error("could not parse path component as uint32", "gseq", gseqStr, "err", err)
 		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
@@ -533,7 +533,7 @@ func handleIPLeaseStatusGet(op *ipOperator, rw http.ResponseWriter, req *http.Re
 	oseqStr := vars["oseq"]
 	oseq, err := strconv.ParseUint(oseqStr, 10, 32)
 	if err != nil {
-		op.log.Error("could not parse path component as uint32", "oseq", oseqStr, "error", err)
+		op.log.Error("could not parse path component as uint32", "oseq", oseqStr, "err", err)
 		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
@@ -541,7 +541,7 @@ func handleIPLeaseStatusGet(op *ipOperator, rw http.ResponseWriter, req *http.Re
 	owner := vars["owner"]
 	_, err = sdktypes.AccAddressFromBech32(owner) // Validate this is a bech32 address
 	if err != nil {
-		op.log.Error("could not parse owner address as bech32", "onwer", owner, "error", err)
+		op.log.Error("could not parse owner address as bech32", "onwer", owner, "err", err)
 		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
@@ -556,7 +556,7 @@ func handleIPLeaseStatusGet(op *ipOperator, rw http.ResponseWriter, req *http.Re
 
 	ipStatus, err := op.mllbc.GetIPAddressStatusForLease(req.Context(), leaseID)
 	if err != nil {
-		op.log.Error("Could not get IP address status", "lease-id", leaseID, "error", err)
+		op.log.Error("Could not get IP address status", "lease-id", leaseID, "err", err)
 		handleHTTPError(op, rw, req, err, http.StatusInternalServerError)
 		return
 	}
@@ -584,7 +584,7 @@ func handleIPLeaseStatusGet(op *ipOperator, rw http.ResponseWriter, req *http.Re
 	}
 	err = encoder.Encode(responseData)
 	if err != nil {
-		op.log.Error("failed writing JSON of ip status response", "error", err)
+		op.log.Error("failed writing JSON of ip status response", "err", err)
 	}
 }
 

--- a/operator/waiter/waiter.go
+++ b/operator/waiter/waiter.go
@@ -60,7 +60,7 @@ func (w *operatorWaiter) run(ctx context.Context) {
 		for {
 			err := waitable.Check(ctx)
 			if err != nil {
-				w.log.Error("not yet ready", "waitable", waitable, "error", err)
+				w.log.Error("not yet ready", "waitable", waitable, "err", err)
 
 				select {
 				case <-ctx.Done():


### PR DESCRIPTION
There is an inconsistency in provider logs - where we use err and error as a key randomly.
As we agreed on err, I created a PR that replaces error key with err