### PR TITLE
fix(cluster): report leased ip inventory status

### DIFF
--- a/cluster/inventory.go
+++ b/cluster/inventory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	tpubsub "github.com/troian/pubsub"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"cosmossdk.io/log"
 
@@ -407,15 +408,39 @@ type inventoryServiceState struct {
 	reservations []*reservation
 }
 
-func countPendingIPs(state *inventoryServiceState) uint {
-	pending := uint(0)
+func countReservedIPs(state *inventoryServiceState) uint {
+	reserved := uint(0)
 	for _, entry := range state.reservations {
 		if !entry.ipsConfirmed {
-			pending += entry.endpointQuantity
+			reserved += entry.endpointQuantity
 		}
 	}
 
-	return pending
+	return reserved
+}
+
+func availableLeasedIPs(total, inUse, reserved uint) uint {
+	if inUse >= total {
+		return 0
+	}
+
+	available := total - inUse
+	if reserved >= available {
+		return 0
+	}
+
+	return available - reserved
+}
+
+func leasedIPStatus(state *inventoryServiceState) inventoryV1.ResourcePair {
+	reserved := countReservedIPs(state)
+	allocated := state.ipAddrUsage.InUse + reserved
+
+	return inventoryV1.NewResourcePair(
+		int64(state.ipAddrUsage.Available), // nolint: gosec
+		int64(state.ipAddrUsage.Available), // nolint: gosec
+		int64(allocated),                   // nolint: gosec
+		resource.DecimalSI)
 }
 
 func (is *inventoryService) handleRequest(req inventoryRequest, state *inventoryServiceState) {
@@ -434,15 +459,15 @@ func (is *inventoryService) handleRequest(req inventoryRequest, state *inventory
 			req.ch <- inventoryResponse{err: errNoLeasedIPsAvailable}
 			return
 		}
-		numIPUnused := state.ipAddrUsage.Available - state.ipAddrUsage.InUse
-		pending := countPendingIPs(state)
-		if reservation.endpointQuantity > (numIPUnused - pending) {
+		reserved := countReservedIPs(state)
+		available := availableLeasedIPs(state.ipAddrUsage.Available, state.ipAddrUsage.InUse, reserved)
+		if reservation.endpointQuantity > available {
 			is.log.Info("insufficient number of IP addresses available", "order", req.order)
 			req.ch <- inventoryResponse{err: fmt.Errorf("%w: unable to reserve %d", errInsufficientIPs, reservation.endpointQuantity)}
 			return
 		}
 
-		is.log.Info("reservation used leased IPs", "used", reservation.endpointQuantity, "available", state.ipAddrUsage.Available, "in-use", state.ipAddrUsage.InUse, "pending", pending)
+		is.log.Info("reservation used leased IPs", "used", reservation.endpointQuantity, "available", state.ipAddrUsage.Available, "in-use", state.ipAddrUsage.InUse, "reserved", reserved, "remaining", available)
 	} else {
 		reservation.ipsConfirmed = true // No IPs, just mark it as confirmed implicitly
 	}
@@ -816,7 +841,8 @@ func (is *inventoryService) getStatusV1(state *inventoryServiceState) (*provider
 	}
 
 	status := &provider.Inventory{
-		Cluster: state.inventory.Snapshot(),
+		Cluster:  state.inventory.Snapshot(),
+		LeasedIP: leasedIPStatus(state),
 		Reservations: provider.Reservations{
 			Pending: provider.ReservationsMetric{
 				Count:     0,

--- a/cluster/inventory_test.go
+++ b/cluster/inventory_test.go
@@ -400,6 +400,67 @@ func makeGroupForInventoryTest(sharedHTTP, nodePort, leasedIP bool) manifest.Gro
 	return group
 }
 
+func TestInventory_StatusV1ReportsLeasedIPResourcePair(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	inv := <-cinventory.NewNull(ctx, "nodeA").ResultChan()
+	reservationWithIPs := func(quantity uint, confirmed bool) *reservation {
+		return &reservation{
+			resources:        &dvbeta.GroupSpec{},
+			endpointQuantity: quantity,
+			ipsConfirmed:     confirmed,
+		}
+	}
+
+	status, err := (&inventoryService{}).getStatusV1(&inventoryServiceState{
+		inventory: inv,
+		ipAddrUsage: cip.AddressUsage{
+			Available: 10,
+			InUse:     4,
+		},
+		reservations: []*reservation{
+			reservationWithIPs(2, false),
+			reservationWithIPs(3, true),
+			reservationWithIPs(1, false),
+		},
+	})
+	require.NoError(t, err)
+
+	leasedIP := status.GetLeasedIP()
+	require.Equal(t, int64(10), leasedIP.GetCapacity().Value())
+	require.Equal(t, int64(10), leasedIP.GetAllocatable().Value())
+	require.Equal(t, int64(7), leasedIP.GetAllocated().Value())
+	require.Equal(t, int64(3), leasedIP.Available().Value())
+}
+
+func TestInventory_StatusV1SaturatesLeasedIPResourcePairAvailable(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	inv := <-cinventory.NewNull(ctx, "nodeA").ResultChan()
+	status, err := (&inventoryService{}).getStatusV1(&inventoryServiceState{
+		inventory: inv,
+		ipAddrUsage: cip.AddressUsage{
+			Available: 3,
+			InUse:     2,
+		},
+		reservations: []*reservation{
+			{
+				resources:        &dvbeta.GroupSpec{},
+				endpointQuantity: 4,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	leasedIP := status.GetLeasedIP()
+	require.Equal(t, int64(3), leasedIP.GetCapacity().Value())
+	require.Equal(t, int64(3), leasedIP.GetAllocatable().Value())
+	require.Equal(t, int64(6), leasedIP.GetAllocated().Value())
+	require.Equal(t, int64(0), leasedIP.Available().Value())
+}
+
 func TestInventory_ReserveIPNoIPOperator(t *testing.T) {
 	config := Config{
 		InventoryResourcePollPeriod:     5 * time.Second,


### PR DESCRIPTION
## Description
Reports leased IP capacity in provider gRPC status through `cluster.inventory.leased_ip`, using the chain-sdk `akash.inventory.v1.ResourcePair` added in akash-network/chain-sdk#313.

The provider maps the IP operator total pool to `capacity` and `allocatable`, and maps confirmed in-use IPs plus unconfirmed reserved IPs to `allocated`. Consumers can use `allocatable - allocated` as the remaining leased IP capacity for bid screening.

## Purpose of the Change
- [x] New feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [x] Dependency upgrade

## Related Issues
- [AKT-366](https://linear.app/akash-network/issue/AKT-366)
- SDK support: https://github.com/akash-network/chain-sdk/pull/313

## Notes for Reviewers
- `pkg.akt.dev/go` is bumped to `v0.2.12`.
- Leased IP requests are matched by counting unique `LEASED_IP` endpoint sequence numbers in the group spec via `GetEndpointQuantityOfResourceGroup`.
- Remaining leased IP capacity is represented by `leased_ip.allocatable - leased_ip.allocated`.