### PR TITLE
fix(manifest): classify manifest validation failures as client errors

### DIFF
--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -411,8 +411,13 @@ func (m *manager) validateRequest(req manifestRequest) error {
 	default:
 	}
 
-	err := req.value.Manifest.Validate()
-	if err != nil {
+	// Any failure from Manifest.Validate is a client-side validation error.
+	// Ensure it is classified as such even if the upstream error is not already
+	// tagged with ErrInvalidManifest, so the gateway returns 4xx rather than 500.
+	if err := req.value.Manifest.Validate(); err != nil {
+		if !errors.Is(err, maniv2beta2.ErrInvalidManifest) {
+			err = fmt.Errorf("%w: %w", maniv2beta2.ErrInvalidManifest, err)
+		}
 		return err
 	}
 

--- a/manifest/manager_test.go
+++ b/manifest/manager_test.go
@@ -1,5 +1,17 @@
 package manifest
 
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	maniv2beta2 "pkg.akt.dev/go/manifest/v2beta3"
+
+	"github.com/akash-network/provider/utils/httperror"
+)
+
 // import (
 // 	"context"
 // 	"testing"
@@ -421,3 +433,39 @@ package manifest
 // 		t.Fatal("timed out waiting for service shutdown")
 // 	}
 // }
+
+// TestValidateRequestWrapsManifestError ensures that a manifest validation
+// failure is tagged with ErrInvalidManifest, even when the underlying error
+// from Manifest.Validate is not already tagged. This keeps the gateway from
+// returning a 500 for what is a client-side error (see akash-network/support#421).
+func TestValidateRequestWrapsManifestError(t *testing.T) {
+	// A service with zero-value (nil) resources fails resource validation with a
+	// raw error that upstream does not tag with ErrInvalidManifest.
+	mani := maniv2beta2.Manifest{
+		{
+			Name: "group1",
+			Services: []maniv2beta2.Service{
+				{
+					Name:  "svc1",
+					Image: "test-image",
+					Count: 1,
+				},
+			},
+		},
+	}
+
+	rawErr := mani.Validate()
+	require.Error(t, rawErr)
+	require.NotErrorIs(t, rawErr, maniv2beta2.ErrInvalidManifest,
+		"precondition: upstream error is expected to be untagged")
+
+	m := &manager{}
+	err := m.validateRequest(manifestRequest{
+		ctx:   context.Background(),
+		value: &submitRequest{Manifest: mani},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, maniv2beta2.ErrInvalidManifest)
+	require.Equal(t, http.StatusUnprocessableEntity,
+		httperror.StatusCodeFrom(ManifestSubmitErrorToHTTP(err)))
+}


### PR DESCRIPTION
## Summary

`validateRequest` returned the raw `Manifest.Validate()` error. When that error was not tagged with `ErrInvalidManifest` (e.g. resource validation such as `"GPU must not be nil"`), the gateway mapped it to **HTTP 500** instead of **422**, causing the console proxy to report a misleading **503** to users who simply sent an invalid manifest.

## Change

Treat any `Manifest.Validate()` failure as a client-side error by ensuring it is tagged with `ErrInvalidManifest`, so the gateway returns 4xx. This is correct by definition (a failed manifest validation is a bad request) and is also defensive: it returns the right status even if the upstream `pkg.akt.dev/go` dependency has not yet been bumped.

```go
if err := req.value.Manifest.Validate(); err != nil {
    if !errors.Is(err, maniv2beta2.ErrInvalidManifest) {
        err = fmt.Errorf("%w: %w", maniv2beta2.ErrInvalidManifest, err)
    }
    return err
}
```

## Tests

Added `TestValidateRequestWrapsManifestError`, asserting an untagged validation error is wrapped and maps to HTTP 422. Verified it fails without the fix and passes with it. `go test`, `gofmt`, `go vet` and `golangci-lint` (repo config) are clean.

## Related

Root cause is also addressed upstream in chain-sdk (resource validation errors there were unwrapped). This change resolves the issue immediately on the provider side and guards against future untagged validation errors.

refs: akash-network/support#421