### PR TITLE
fix: copy GPU attributes when converting resources

### DIFF
--- a/pkg/apis/akash.network/v2beta2/types.go
+++ b/pkg/apis/akash.network/v2beta2/types.go
@@ -200,7 +200,7 @@ func resourcesFromAkash(aru rtypes.Resources) (Resources, error) {
 			return Resources{}, errors.New("k8s api: gpu units value overflows uint32")
 		}
 		res.GPU.Units = uint32(aru.GPU.Units.Value()) // nolint: gosec
-		res.GPU.Attributes = aru.GPU.Attributes
+		res.GPU.Attributes = aru.GPU.Attributes.Dup()
 	}
 
 	res.Storage = make(ResourceStorage, 0, len(aru.Storage))

--- a/pkg/apis/akash.network/v2beta2/types_test.go
+++ b/pkg/apis/akash.network/v2beta2/types_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	attrtypes "pkg.akt.dev/go/node/types/attributes/v1"
+	rtypes "pkg.akt.dev/go/node/types/resources/v1beta4"
 	atestutil "pkg.akt.dev/go/testutil"
 
 	mtestutil "github.com/akash-network/provider/testutil/manifest/v2beta2"
@@ -28,4 +30,25 @@ func Test_Manifest_encoding(t *testing.T) {
 		assert.Equal(t, lid, deployment.LeaseID(), spec.Name)
 		assert.Equal(t, &mgroup, deployment.ManifestGroup(), spec.Name)
 	}
+}
+
+func TestResourcesFromAkashCopiesGPUAttributes(t *testing.T) {
+	attrs := attrtypes.Attributes{
+		attrtypes.NewStringAttribute("vendor/nvidia/model/a100", "true"),
+	}
+
+	resources := rtypes.Resources{
+		GPU: &rtypes.GPU{
+			Units:      rtypes.NewResourceValue(1),
+			Attributes: attrs,
+		},
+	}
+
+	converted, err := resourcesFromAkash(resources)
+	require.NoError(t, err)
+	require.Len(t, converted.GPU.Attributes, 1)
+
+	converted.GPU.Attributes[0].Value = "false"
+
+	assert.Equal(t, "true", resources.GPU.Attributes[0].Value)
 }


### PR DESCRIPTION
## Summary
- Copy GPU attributes with `Dup()` in `resourcesFromAkash`, matching CPU, memory, and storage handling.
- Add a regression test that mutates converted GPU attributes and verifies the source Akash resource is unchanged.

## Testing
- `GOTOOLCHAIN=auto go test ./pkg/apis/akash.network/v2beta2`
