### PR TITLE
chore(docker): include grpcurl in provider image

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,12 @@ KINDEST_VERSION=v1.32.0
 GO111MODULE=on
 CGO_ENABLED=1
 REDIS_VERSION=7
+# grpcurl release bundled into the provider image (see Dockerfile). To bump,
+# update the version and both checksums here; the Dockerfile is not touched.
+# Checksums are from grpcurl_<version>_checksums.txt on the GitHub release.
+GRPCURL_VERSION=1.9.3
+GRPCURL_SHA256_AMD64=a926b62a85787ccf73ef8736b3ae554f1242e39d92bb8767a79d6dd23b11d1d5
+GRPCURL_SHA256_ARM64=b20a00c1cb82ab81ec32696766d4076e99b4cb5ca0823a71767ba64dbea0f263
 ROOT_DIR=${AP_ROOT}
 AP_DEVCACHE_BASE=${AP_ROOT}/.cache
 AP_DEVCACHE=${AP_DEVCACHE_BASE}

--- a/.goreleaser-docker.yaml
+++ b/.goreleaser-docker.yaml
@@ -114,6 +114,9 @@ dockers:
     goarch: amd64
     build_flag_templates:
       - --platform=linux/amd64
+      - --build-arg=GRPCURL_VERSION={{ .Env.GRPCURL_VERSION }}
+      - --build-arg=GRPCURL_SHA256_AMD64={{ .Env.GRPCURL_SHA256_AMD64 }}
+      - --build-arg=GRPCURL_SHA256_ARM64={{ .Env.GRPCURL_SHA256_ARM64 }}
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.url={{.GitURL}}
@@ -131,6 +134,9 @@ dockers:
     goarch: arm64
     build_flag_templates:
       - --platform=linux/arm64
+      - --build-arg=GRPCURL_VERSION={{ .Env.GRPCURL_VERSION }}
+      - --build-arg=GRPCURL_SHA256_AMD64={{ .Env.GRPCURL_SHA256_AMD64 }}
+      - --build-arg=GRPCURL_SHA256_ARM64={{ .Env.GRPCURL_SHA256_ARM64 }}
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.url={{.GitURL}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -261,6 +261,9 @@ dockers:
     build_flag_templates:
       - --pull
       - --platform=linux/amd64
+      - --build-arg=GRPCURL_VERSION={{ .Env.GRPCURL_VERSION }}
+      - --build-arg=GRPCURL_SHA256_AMD64={{ .Env.GRPCURL_SHA256_AMD64 }}
+      - --build-arg=GRPCURL_SHA256_ARM64={{ .Env.GRPCURL_SHA256_ARM64 }}
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.url=https://github.com/akash-network/provider
@@ -281,6 +284,9 @@ dockers:
     build_flag_templates:
       - --pull
       - --platform=linux/arm64
+      - --build-arg=GRPCURL_VERSION={{ .Env.GRPCURL_VERSION }}
+      - --build-arg=GRPCURL_SHA256_AMD64={{ .Env.GRPCURL_SHA256_AMD64 }}
+      - --build-arg=GRPCURL_SHA256_ARM64={{ .Env.GRPCURL_SHA256_ARM64 }}
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.url=https://github.com/akash-network/provider

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,28 @@ RUN \
 
 ENV DEBIAN_FRONTEND=""
 
+# grpcurl is used to probe the inventory operator's gRPC API (e.g. from a
+# liveness probe). It is not packaged in apt, so install a pinned release.
+# The version and per-arch checksums are supplied as build args (sourced from
+# .env via the goreleaser build), so bumping the release does not require
+# editing this Dockerfile.
+ARG GRPCURL_VERSION
+ARG GRPCURL_SHA256_AMD64
+ARG GRPCURL_SHA256_ARM64
+RUN set -eux; \
+    case "$(dpkg --print-architecture)" in \
+      amd64) arch=x86_64; sha="${GRPCURL_SHA256_AMD64}" ;; \
+      arm64) arch=arm64;  sha="${GRPCURL_SHA256_ARM64}" ;; \
+      *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac; \
+    curl -fL --retry 5 --retry-delay 2 --retry-connrefused --connect-timeout 10 --max-time 120 \
+      -o /tmp/grpcurl.tar.gz \
+      "https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION}_linux_${arch}.tar.gz"; \
+    echo "${sha}  /tmp/grpcurl.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/grpcurl.tar.gz -C /usr/bin grpcurl; \
+    rm /tmp/grpcurl.tar.gz; \
+    grpcurl -version
+
 # default port for provider API
 EXPOSE 8443
 

--- a/make/releasing.mk
+++ b/make/releasing.mk
@@ -4,6 +4,12 @@ GORELEASER_IMAGE         := ghcr.io/goreleaser/goreleaser-cross:$(GOTOOLCHAIN_SE
 GORELEASER_MOUNT_CONFIG  ?= false
 GORELEASER_MOD_MOUNT     ?= $(shell cat $(ROOT_DIR)/.github/repo | tr -d '\n')
 
+# grpcurl version and per-arch checksums bundled into the provider image. Read
+# from .env so bumping the release only touches that file, not the Dockerfile.
+GRPCURL_VERSION          ?= $(shell sed -n 's/^GRPCURL_VERSION=//p' $(ROOT_DIR)/.env)
+GRPCURL_SHA256_AMD64     ?= $(shell sed -n 's/^GRPCURL_SHA256_AMD64=//p' $(ROOT_DIR)/.env)
+GRPCURL_SHA256_ARM64     ?= $(shell sed -n 's/^GRPCURL_SHA256_ARM64=//p' $(ROOT_DIR)/.env)
+
 GORELEASER_SKIP_FLAGS    := $(GORELEASER_SKIP)
 GORELEASER_SKIP          :=
 
@@ -77,6 +83,9 @@ docker-image: wasmvm-libs
 		-e GOPATH=/go \
 		-e GOTOOLCHAIN="$(GOTOOLCHAIN)" \
 		-e GOWORK="$(GORELEASER_GOWORK)" \
+		-e GRPCURL_VERSION="$(GRPCURL_VERSION)" \
+		-e GRPCURL_SHA256_AMD64="$(GRPCURL_SHA256_AMD64)" \
+		-e GRPCURL_SHA256_ARM64="$(GRPCURL_SHA256_ARM64)" \
 		-v $(GOPATH):/go \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(shell pwd):/go/src/$(GO_MOD_NAME) \
@@ -106,6 +115,9 @@ release: wasmvm-libs gen-changelog
 		-e GOTOOLCHAIN="$(GOTOOLCHAIN)" \
 		-e GOPATH=/go \
 		-e GOWORK="$(GORELEASER_GOWORK)" \
+		-e GRPCURL_VERSION="$(GRPCURL_VERSION)" \
+		-e GRPCURL_SHA256_AMD64="$(GRPCURL_SHA256_AMD64)" \
+		-e GRPCURL_SHA256_ARM64="$(GRPCURL_SHA256_ARM64)" \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(GOPATH):/go \
 		-v $(shell pwd):/go/src/$(GO_MOD_NAME) \


### PR DESCRIPTION
## Summary

Resolves akash-network/support#317.

The inventory operator exposes a gRPC API (`akash.inventory.v1.ClusterRPC`). Bundling `grpcurl` in the provider image makes it possible to probe that API from inside the container - for example, a liveness probe that restarts the pod when allocated resources exceed allocatable.

## Change

`grpcurl` is not available via apt, so the Dockerfile installs a pinned release:

- Pinned to `v1.9.3`.
- Works for both **amd64** and **arm64** (the image is built for both), selecting the right asset via `dpkg --print-architecture`.
- The downloaded tarball is **sha256-verified** against the published checksum before extraction.
- Only the `grpcurl` binary is installed; the tarball is removed afterwards.
- `grpcurl -version` runs at the end so the build fails fast if anything is wrong.

## Testing

Built the image locally (amd64) and confirmed the install step downloads, passes the checksum check, extracts the binary, and `grpcurl -version` reports `v1.9.3`. The arm64 asset uses the official published checksum.

refs: akash-network/support#317