### PR TITLE
fix(inventory): exclude tainted nodes from the inventory

### DIFF
--- a/operator/inventory/node-discovery.go
+++ b/operator/inventory/node-discovery.go
@@ -1049,24 +1049,21 @@ func removeManagedLabels(in map[string]string) map[string]string {
 	return out
 }
 
-// nodeHasBlockingTaint reports whether any taint would prevent Akash workloads
-// from being scheduled onto the node. Akash pods carry no custom tolerations,
-// so a NoSchedule or NoExecute taint means the node cannot accept workloads and
-// its capacity must be kept out of the inventory; otherwise the provider bids
-// on capacity it can never use and the deployment fails to schedule.
+// isNodeReady reports whether the node can actually accept Akash workloads. It
+// must be both in the Ready condition and free of any scheduling-blocking
+// taint: Akash pods carry no custom tolerations, so a NoSchedule/NoExecute
+// taint (e.g. control-plane, CriticalAddonsOnly) means the node can never host
+// a workload and its capacity must stay out of the inventory; otherwise the
+// provider bids on capacity it cannot use and the deployment fails to schedule.
 // PreferNoSchedule is a soft preference and does not block scheduling.
-func nodeHasBlockingTaint(taints []corev1.Taint) bool {
-	for _, taint := range taints {
+func isNodeReady(node *corev1.Node) bool {
+	for _, taint := range node.Spec.Taints {
 		if taint.Effect == corev1.TaintEffectNoSchedule || taint.Effect == corev1.TaintEffectNoExecute {
-			return true
+			return false
 		}
 	}
 
-	return false
-}
-
-func isNodeReady(conditions []corev1.NodeCondition) bool {
-	for _, c := range conditions {
+	for _, c := range node.Status.Conditions {
 		if c.Type == corev1.NodeReady {
 			return c.Status == "True"
 		}
@@ -1088,7 +1085,7 @@ func generateLabels(cfg Config, knode *corev1.Node, node v1.Node, sc storageClas
 	sort.Strings(presentSc)
 	adjConfig.FilterOutStorageClasses(presentSc)
 
-	isExcluded := !isNodeReady(knode.Status.Conditions) || knode.Spec.Unschedulable || nodeHasBlockingTaint(knode.Spec.Taints) || adjConfig.Exclude.IsNodeExcluded(knode.Name)
+	isExcluded := !isNodeReady(knode) || knode.Spec.Unschedulable || adjConfig.Exclude.IsNodeExcluded(knode.Name)
 
 	if isExcluded {
 		node.Capabilities.StorageClasses = []string{}

--- a/operator/inventory/node-discovery.go
+++ b/operator/inventory/node-discovery.go
@@ -1049,6 +1049,22 @@ func removeManagedLabels(in map[string]string) map[string]string {
 	return out
 }
 
+// nodeHasBlockingTaint reports whether any taint would prevent Akash workloads
+// from being scheduled onto the node. Akash pods carry no custom tolerations,
+// so a NoSchedule or NoExecute taint means the node cannot accept workloads and
+// its capacity must be kept out of the inventory; otherwise the provider bids
+// on capacity it can never use and the deployment fails to schedule.
+// PreferNoSchedule is a soft preference and does not block scheduling.
+func nodeHasBlockingTaint(taints []corev1.Taint) bool {
+	for _, taint := range taints {
+		if taint.Effect == corev1.TaintEffectNoSchedule || taint.Effect == corev1.TaintEffectNoExecute {
+			return true
+		}
+	}
+
+	return false
+}
+
 func isNodeReady(conditions []corev1.NodeCondition) bool {
 	for _, c := range conditions {
 		if c.Type == corev1.NodeReady {
@@ -1072,7 +1088,7 @@ func generateLabels(cfg Config, knode *corev1.Node, node v1.Node, sc storageClas
 	sort.Strings(presentSc)
 	adjConfig.FilterOutStorageClasses(presentSc)
 
-	isExcluded := !isNodeReady(knode.Status.Conditions) || knode.Spec.Unschedulable || adjConfig.Exclude.IsNodeExcluded(knode.Name)
+	isExcluded := !isNodeReady(knode.Status.Conditions) || knode.Spec.Unschedulable || nodeHasBlockingTaint(knode.Spec.Taints) || adjConfig.Exclude.IsNodeExcluded(knode.Name)
 
 	if isExcluded {
 		node.Capabilities.StorageClasses = []string{}

--- a/operator/inventory/node-discovery_test.go
+++ b/operator/inventory/node-discovery_test.go
@@ -202,3 +202,56 @@ func TestSubPodAllocatedResourcesLogsAndKeepsNegative(t *testing.T) {
 		})
 	}
 }
+
+func readyNode(taints ...corev1.Taint) *corev1.Node {
+	return &corev1.Node{
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+		},
+		Spec: corev1.NodeSpec{Taints: taints},
+	}
+}
+
+func TestGenerateLabels_Taints(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *corev1.Node
+		excluded bool
+	}{
+		{
+			name:     "ready, untainted node is included",
+			node:     readyNode(),
+			excluded: false,
+		},
+		{
+			name:     "NoSchedule taint excludes the node",
+			node:     readyNode(corev1.Taint{Key: "node-role.kubernetes.io/control-plane", Effect: corev1.TaintEffectNoSchedule}),
+			excluded: true,
+		},
+		{
+			name:     "NoExecute taint excludes the node",
+			node:     readyNode(corev1.Taint{Key: "CriticalAddonsOnly", Effect: corev1.TaintEffectNoExecute}),
+			excluded: true,
+		},
+		{
+			name:     "PreferNoSchedule taint does not exclude the node",
+			node:     readyNode(corev1.Taint{Key: "soft", Effect: corev1.TaintEffectPreferNoSchedule}),
+			excluded: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels, _ := generateLabels(Config{}, tt.node, v1.Node{}, storageClasses{})
+
+			_, managed := labels[builder.AkashManagedLabelName]
+			if tt.excluded {
+				require.False(t, managed, "tainted node must not be marked akash-managed")
+			} else {
+				require.True(t, managed, "schedulable node must be marked akash-managed")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

Node discovery (`operator/inventory/node-discovery.go`) only excluded nodes that were not-ready, cordoned (`Unschedulable`), or in the operator exclude list. Nodes carrying a `NoSchedule`/`NoExecute` taint were still reported as available capacity.

This adds `nodeHasBlockingTaint` and treats any `NoSchedule`/`NoExecute` taint as a reason to keep the node out of the inventory. `PreferNoSchedule` is a soft preference and is left alone.

### Why

Closes the behaviour reported in akash-network/support#253: providers with tainted nodes (e.g. `node-role.kubernetes.io/control-plane`, `CriticalAddonsOnly`) kept bidding using that capacity once the rest of the cluster was full. Akash pods carry no custom tolerations, so the pod can never schedule onto a tainted node - the deployment fails `FailedScheduling` and the provider closes it minutes later. Reported in the wild on multiple providers and on a support call.

### Testing

Added `TestGenerateLabels_Taints`: a ready, untainted node is marked akash-managed; `NoSchedule` and `NoExecute` tainted nodes are excluded; `PreferNoSchedule` is not. Fails without the fix.

refs: akash-network/support#253