### PR TITLE
fix(config): apply cluster node port quantity to the inventory

### DIFF
--- a/cmd/provider-services/cmd/run.go
+++ b/cmd/provider-services/cmd/run.go
@@ -656,7 +656,7 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	config := provider.NewDefaultConfig()
 	config.ClusterWaitReadyDuration = clusterWaitReadyDuration
 	config.ClusterPublicHostname = clusterPublicHostname
-	config.ClusterExternalPortQuantity = nodePortQuantity
+	config.InventoryExternalPortQuantity = nodePortQuantity
 	config.InventoryResourceDebugFrequency = inventoryResourceDebugFreq
 	config.InventoryResourcePollPeriod = inventoryResourcePollPeriod
 	config.CPUCommitLevel = overcommitPercentCPU

--- a/config.go
+++ b/config.go
@@ -14,19 +14,18 @@ import (
 )
 
 type Config struct {
-	ClusterWaitReadyDuration    time.Duration
-	ClusterPublicHostname       string
-	ClusterExternalPortQuantity uint
-	BidPricingStrategy          bidengine.BidPricingStrategy
-	BidDeposit                  sdk.Coin
-	BidTimeout                  time.Duration
-	ManifestTimeout             time.Duration
-	BalanceCheckerCfg           BalanceCheckerConfig
-	Attributes                  attrtypes.Attributes
-	MaxGroupVolumes             int
-	RPCQueryTimeout             time.Duration
-	CachedResultMaxAge          time.Duration
-	ReclamationWindow           *time.Duration
+	ClusterWaitReadyDuration time.Duration
+	ClusterPublicHostname    string
+	BidPricingStrategy       bidengine.BidPricingStrategy
+	BidDeposit               sdk.Coin
+	BidTimeout               time.Duration
+	ManifestTimeout          time.Duration
+	BalanceCheckerCfg        BalanceCheckerConfig
+	Attributes               attrtypes.Attributes
+	MaxGroupVolumes          int
+	RPCQueryTimeout          time.Duration
+	CachedResultMaxAge       time.Duration
+	ReclamationWindow        *time.Duration
 	cluster.Config
 }
 


### PR DESCRIPTION
### What

The `--cluster-node-port-quantity` flag (env `AKASH_CLUSTER_NODE_PORT_QUANTITY`) was assigned to a `Config` field that nothing reads. The inventory service reads the embedded `cluster.Config.InventoryExternalPortQuantity`, which was never populated, so the operator's configured value was silently ignored.

This drops the orphaned field and routes the flag into the inventory config via a small `SetClusterExternalPortQuantity` setter.

### Why

Closes akash-network/support#135: operators setting the node port quantity (e.g. to `0`/`1`) saw no effect - the provider kept bidding with the default port quantity.

### Testing

Added `TestConfig_NodePortQuantityReachesInventory`, asserting the configured value lands in `InventoryExternalPortQuantity`. The orphaned field is removed and the whole repo builds (it was read nowhere).

refs: akash-network/support#135