### PR TITLE
fix(cluster): continue IP confirmation after a per-item error

### DIFF
--- a/cluster/inventory.go
+++ b/cluster/inventory.go
@@ -885,7 +885,7 @@ func (is *inventoryService) runCheck(ctx context.Context, state *inventoryServic
 				// This error is not really fatal, so don't bail on this entirely. The other results
 				// retrieved in this code are still valid
 				is.log.Error("failed checking IP address usage", "orderID", confirmItem.orderID, "error", err)
-				break
+				continue
 			}
 
 			numConfirmed := uint(len(status))

--- a/cluster/inventory_runcheck_test.go
+++ b/cluster/inventory_runcheck_test.go
@@ -1,0 +1,66 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"pkg.akt.dev/go/testutil"
+
+	cip "github.com/akash-network/provider/cluster/types/v1beta3/clients/ip"
+	cipmocks "github.com/akash-network/provider/mocks/cluster/types/clients/ip"
+)
+
+// Test_runCheck_IPConfirmContinuesAfterError guards against a per-item IP status
+// error aborting the whole confirmation pass. The error is explicitly non-fatal
+// ("The other results retrieved in this code are still valid"), so a failure on
+// one reservation must not stop the remaining ones from being confirmed —
+// otherwise their IPs stay pending forever and the IP quota leaks.
+func Test_runCheck_IPConfirmContinuesAfterError(t *testing.T) {
+	mkReservation := func(t *testing.T) *reservation {
+		return &reservation{
+			order:            testutil.OrderID(t),
+			allocated:        true,
+			ipsConfirmed:     false,
+			endpointQuantity: 1,
+		}
+	}
+
+	failing := mkReservation(t)
+	ok1 := mkReservation(t)
+	ok2 := mkReservation(t)
+
+	ipClient := &cipmocks.Client{}
+	ipClient.On("GetIPAddressUsage", mock.Anything).Return(cip.AddressUsage{}, nil)
+
+	// The first reservation errors; the others return exactly the expected count.
+	ipClient.On("GetIPAddressStatus", mock.Anything, failing.OrderID()).
+		Return([]cip.LeaseIPStatus(nil), errors.New("transient ip operator error"))
+	for _, r := range []*reservation{ok1, ok2} {
+		ipClient.On("GetIPAddressStatus", mock.Anything, r.OrderID()).
+			Return([]cip.LeaseIPStatus{{}}, nil)
+	}
+
+	is := &inventoryService{log: testutil.Logger(t)}
+	is.clients.ip = ipClient
+
+	state := &inventoryServiceState{
+		reservations: []*reservation{failing, ok1, ok2},
+	}
+
+	res := <-is.runCheck(context.Background(), state)
+	require.NoError(t, res.Error())
+
+	out := res.Value().(runCheckResult)
+
+	confirmed := map[string]bool{}
+	for _, oid := range out.confirmedResult {
+		confirmed[oid.String()] = true
+	}
+
+	require.True(t, confirmed[ok1.OrderID().String()], "reservation after the failing one must still be confirmed")
+	require.True(t, confirmed[ok2.OrderID().String()], "all reservations after the failing one must still be confirmed")
+}


### PR DESCRIPTION
### What

The IP confirmation loop in `inventoryService.runCheck` (`cluster/inventory.go`) called `break` on the first failed `GetIPAddressStatus`, aborting the whole pass - even though the comment right above it states the error is non-fatal and "The other results retrieved in this code are still valid". This changes it to `continue` so only the failed item is skipped.

### Why

A single transient IP-operator error left every reservation *after* the failing one unconfirmed. Their endpoints stay counted as pending indefinitely, so the provider's IP quota leaks and is never reclaimed for those leases — the code did the opposite of what its own comment intends.

### Testing

Added `Test_runCheck_IPConfirmContinuesAfterError`: three allocated, unconfirmed reservations where the first `GetIPAddressStatus` errors and the other two succeed; it asserts both later reservations are still confirmed. Fails on `break`, passes on `continue`