### PR TITLE
fix(bidengine): increment reservation counter metrics

### DIFF
--- a/bidengine/order.go
+++ b/bidengine/order.go
@@ -372,12 +372,12 @@ loop:
 			clusterch = nil
 
 			if result.Error() != nil {
-				reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.FailLabel)
+				reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.FailLabel).Inc()
 				o.log.Error("reserving resources", "err", result.Error())
 				break loop
 			}
 
-			reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.SuccessLabel)
+			reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.SuccessLabel).Inc()
 
 			o.log.Info("Reservation fulfilled")
 
@@ -480,9 +480,9 @@ loop:
 			o.log.Debug("unreserving reservation")
 			if err := o.cluster.Unreserve(reservation.OrderID()); err != nil {
 				o.log.Error("error unreserving reservation", "err", err)
-				reservationCounter.WithLabelValues("close", metricsutils.FailLabel)
+				reservationCounter.WithLabelValues("close", metricsutils.FailLabel).Inc()
 			} else {
-				reservationCounter.WithLabelValues("close", metricsutils.SuccessLabel)
+				reservationCounter.WithLabelValues("close", metricsutils.SuccessLabel).Inc()
 			}
 		}
 

--- a/bidengine/order_metrics_test.go
+++ b/bidengine/order_metrics_test.go
@@ -1,0 +1,43 @@
+package bidengine
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	mvbeta "pkg.akt.dev/go/node/market/v1beta5"
+	metricsutils "pkg.akt.dev/go/util/metrics"
+
+	atestutil "pkg.akt.dev/go/testutil"
+)
+
+// Test_ReservationCounterIncrements guards that the reservation metrics are
+// actually recorded. The success/fail counters were calling WithLabelValues
+// without a terminal .Inc(), making them silent no-ops, so a full reserve +
+// unreserve cycle never moved them.
+func Test_ReservationCounterIncrements(t *testing.T) {
+	openSuccess := testutil.ToFloat64(
+		reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.SuccessLabel))
+	closeSuccess := testutil.ToFloat64(
+		reservationCounter.WithLabelValues("close", metricsutils.SuccessLabel))
+
+	order, scaffold, _ := makeOrderForTest(t, false, mvbeta.BidStateInvalid, nil, nil, testBidCreatedAt)
+
+	// Wait for the bid to be broadcast — by then the reservation has succeeded.
+	_ = atestutil.ChannelWaitForValue(t, scaffold.broadcasts)
+	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+
+	// Shutting down triggers the unreserve path.
+	order.lc.Shutdown(nil)
+	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+
+	gotOpen := testutil.ToFloat64(
+		reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.SuccessLabel))
+	gotClose := testutil.ToFloat64(
+		reservationCounter.WithLabelValues("close", metricsutils.SuccessLabel))
+
+	require.Equal(t, openSuccess+1, gotOpen, "reservation open-success counter must increment")
+	require.Equal(t, closeSuccess+1, gotClose, "reservation close-success counter must increment")
+}

--- a/go.mod
+++ b/go.mod
@@ -280,6 +280,7 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20221122204822-d1a8c34382f1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/libopenstorage/secrets v0.0.0-20240416031220-a17cf7f72c6c // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect


### PR DESCRIPTION
### What

Four `reservationCounter.WithLabelValues(...)` calls in `bidengine/order.go` were missing a terminal `.Inc()`, so the returned counter was discarded and the metric was never recorded.

### Why

Every other counter in this file (`orderCompleteCounter`, `shouldBidCounter`, `bidCounter`) calls `.Inc()`; these four (reservation open/close × success/fail) were the exception. As a result the reservation metrics stayed flat at zero, so operators had no visibility into reservation success/failure rates.

### Testing

Added `Test_ReservationCounterIncrements`: runs a full reserve + unreserve cycle and asserts the open-success and close-success counters each advance by one. Fails without the `.Inc()` calls. (`go mod tidy` registered `prometheus/.../testutil`'s indirect dep `kylelemons/godebug`; go.sum unchanged.)