### PR TITLE
fix(manifest): keep bid close independent of shutdown

### DIFF
--- a/cmd/provider-services/cmd/flags.go
+++ b/cmd/provider-services/cmd/flags.go
@@ -231,7 +231,7 @@ func addRunFlags(cmd *cobra.Command) error {
 		return err
 	}
 
-	cmd.Flags().Duration(FlagTxBroadcastTimeout, 30*time.Second, "tx broadcast timeout. defaults to 30s")
+	cmd.Flags().Duration(FlagTxBroadcastTimeout, cfg.BroadcastTimeout, "tx broadcast timeout. defaults to 30s")
 	if err := viper.BindPFlag(FlagTxBroadcastTimeout, cmd.Flags().Lookup(FlagTxBroadcastTimeout)); err != nil {
 		return err
 	}

--- a/cmd/provider-services/cmd/run.go
+++ b/cmd/provider-services/cmd/run.go
@@ -495,6 +495,7 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	bidTimeout := viper.GetDuration(FlagBidTimeout)
 	reclamationWindow := viper.GetDuration(FlagReclamationWindow)
 	manifestTimeout := viper.GetDuration(FlagManifestTimeout)
+	broadcastTimeout := viper.GetDuration(FlagTxBroadcastTimeout)
 	metricsListener := viper.GetString(FlagMetricsListener)
 	providerConfig := viper.GetString(FlagProviderConfig)
 	cachedResultMaxAge := viper.GetDuration(FlagCachedResultMaxAge)
@@ -667,6 +668,11 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	config.DeploymentIngressDomain = deploymentIngressDomain
 	config.BidTimeout = bidTimeout
 	config.ManifestTimeout = manifestTimeout
+	if broadcastTimeout <= 0 {
+		logger.Warn("tx-broadcast-timeout must be positive, using default", "invalid", broadcastTimeout, "default", config.BroadcastTimeout)
+	} else {
+		config.BroadcastTimeout = broadcastTimeout
+	}
 
 	if reclamationWindow > 0 {
 		config.ReclamationWindow = &reclamationWindow

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/akash-network/provider/bidengine"
 	"github.com/akash-network/provider/cluster"
+	"github.com/akash-network/provider/manifest"
 )
 
 type Config struct {
@@ -20,6 +21,7 @@ type Config struct {
 	BidDeposit               sdk.Coin
 	BidTimeout               time.Duration
 	ManifestTimeout          time.Duration
+	BroadcastTimeout         time.Duration
 	BalanceCheckerCfg        BalanceCheckerConfig
 	Attributes               attrtypes.Attributes
 	MaxGroupVolumes          int
@@ -33,6 +35,7 @@ func NewDefaultConfig() Config {
 	return Config{
 		ClusterWaitReadyDuration: time.Second * 10,
 		BidDeposit:               mtypes.DefaultBidMinDeposit,
+		BroadcastTimeout:         manifest.DefaultBroadcastTimeout,
 		BalanceCheckerCfg: BalanceCheckerConfig{
 			LeaseFundsCheckInterval: 1 * time.Minute,
 			WithdrawalPeriod:        24 * time.Hour,

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -2,9 +2,12 @@ package manifest
 
 import "time"
 
+const DefaultBroadcastTimeout = 30 * time.Second
+
 type ServiceConfig struct {
 	HTTPServicesRequireAtLeastOneHost bool
 	ManifestTimeout                   time.Duration
+	BroadcastTimeout                  time.Duration
 	RPCQueryTimeout                   time.Duration
 	CachedResultMaxAge                time.Duration
 }

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -351,7 +351,7 @@ func (s *service) handleLease(ev event.LeaseWon, isNew bool) {
 	if isNew && s.config.ManifestTimeout > time.Duration(0) {
 		// Create watchdog if it does not exist AND a manifest has not been received yet
 		if watchdog := s.watchdogs[ev.LeaseID.DeploymentID()]; watchdog == nil {
-			watchdog = newWatchdog(s.session, s.lc.ShuttingDown(), s.watchdogch, ev.LeaseID, s.config.ManifestTimeout)
+			watchdog = newWatchdog(s.session, s.lc.ShuttingDown(), s.watchdogch, ev.LeaseID, s.config.ManifestTimeout, s.config.BroadcastTimeout)
 			s.watchdogs[ev.LeaseID.DeploymentID()] = watchdog
 		}
 	}

--- a/manifest/watchdog.go
+++ b/manifest/watchdog.go
@@ -20,29 +20,29 @@ import (
 )
 
 type watchdog struct {
-	leaseID mtypes.LeaseID
-	timeout time.Duration
-	lc      lifecycle.Lifecycle
-	sess    session.Session
-	ctx     context.Context
-	log     log.Logger
+	leaseID          mtypes.LeaseID
+	timeout          time.Duration
+	broadcastTimeout time.Duration
+	lc               lifecycle.Lifecycle
+	sess             session.Session
+	log              log.Logger
 }
 
-func newWatchdog(sess session.Session, parent <-chan struct{}, done chan<- dtypes.DeploymentID, leaseID mtypes.LeaseID, timeout time.Duration) *watchdog {
-	ctx, cancel := context.WithCancel(context.Background())
-	result := &watchdog{
-		leaseID: leaseID,
-		timeout: timeout,
-		lc:      lifecycle.New(),
-		sess:    sess,
-		ctx:     ctx,
-		log:     sess.Log().With("leaseID", leaseID),
+func newWatchdog(sess session.Session, parent <-chan struct{}, done chan<- dtypes.DeploymentID, leaseID mtypes.LeaseID, timeout, broadcastTimeout time.Duration) *watchdog {
+	if broadcastTimeout <= 0 {
+		broadcastTimeout = DefaultBroadcastTimeout
 	}
 
-	go func() {
-		result.lc.WatchChannel(parent)
-		cancel()
-	}()
+	result := &watchdog{
+		leaseID:          leaseID,
+		timeout:          timeout,
+		broadcastTimeout: broadcastTimeout,
+		lc:               lifecycle.New(),
+		sess:             sess,
+		log:              sess.Log().With("leaseID", leaseID),
+	}
+
+	go result.lc.WatchChannel(parent)
 
 	go func() {
 		<-result.lc.Done()
@@ -58,6 +58,10 @@ func (wd *watchdog) stop() {
 	wd.lc.ShutdownAsync(nil)
 }
 
+// run waits for the manifest timeout, then broadcasts MsgCloseBid.
+//
+// Once the close-bid broadcast starts, it must not inherit watchdog shutdown
+// cancellation. Otherwise a provider shutdown can leave the expired bid open.
 func (wd *watchdog) run() {
 	defer wd.lc.ShutdownCompleted()
 
@@ -71,21 +75,32 @@ func (wd *watchdog) run() {
 		wd.log.Info("watchdog closing bid")
 
 		runch = runner.Do(func() runner.Result {
+			ctx, cancel := context.WithTimeout(context.Background(), wd.broadcastTimeout)
+			defer cancel()
+
 			msg := &mvbeta.MsgCloseBid{
 				ID:     mtypes.MakeBidID(wd.leaseID.OrderID(), wd.sess.Provider().Address()),
 				Reason: mtypes.LeaseClosedReasonManifestTimeout,
 			}
 
-			return runner.NewResult(wd.sess.Client().Tx().BroadcastMsgs(wd.ctx, []sdk.Msg{msg}, aclient.WithResultCodeAsError()))
+			return runner.NewResult(wd.sess.Client().Tx().BroadcastMsgs(ctx, []sdk.Msg{msg}, aclient.WithResultCodeAsError()))
 		})
 	case err = <-wd.lc.ShutdownRequest():
 	}
 
-	wd.lc.ShutdownInitiated(err)
-	if runch != nil {
-		result := <-runch
-		if err := result.Error(); err != nil {
-			wd.log.Error("failed closing bid", "err", err)
+	shutdownRequest := wd.lc.ShutdownRequest()
+	for runch != nil {
+		select {
+		case result := <-runch:
+			if err := result.Error(); err != nil {
+				wd.log.Error("failed closing bid", "err", err)
+			}
+			runch = nil
+		case err = <-shutdownRequest:
+			wd.log.Info("watchdog shutdown requested, waiting for bid close tx to complete")
+			shutdownRequest = nil
 		}
 	}
+
+	wd.lc.ShutdownInitiated(err)
 }

--- a/manifest/watchdog_test.go
+++ b/manifest/watchdog_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	clientmocks "pkg.akt.dev/go/mocks/node/client"
+	aclient "pkg.akt.dev/go/node/client/v1beta3"
 	dtypes "pkg.akt.dev/go/node/deployment/v1"
 	mtypes "pkg.akt.dev/go/node/market/v1"
 	mvbeta "pkg.akt.dev/go/node/market/v1beta5"
@@ -20,15 +22,25 @@ import (
 )
 
 type watchdogTestScaffold struct {
-	client     *clientmocks.Client
-	parentCh   chan struct{}
-	doneCh     chan dtypes.DeploymentID
-	broadcasts chan []sdk.Msg
-	leaseID    mtypes.LeaseID
-	provider   ptypes.Provider
+	client           *clientmocks.Client
+	parentCh         chan struct{}
+	doneCh           chan dtypes.DeploymentID
+	broadcasts       chan []sdk.Msg
+	broadcastStarted chan struct{}
+	broadcastErr     chan error
+	leaseID          mtypes.LeaseID
+	provider         ptypes.Provider
 }
 
 func makeWatchdogTestScaffold(t *testing.T, timeout time.Duration) (*watchdog, *watchdogTestScaffold) {
+	return makeWatchdogTestScaffoldFull(t, timeout, DefaultBroadcastTimeout, nil)
+}
+
+func makeWatchdogTestScaffoldWithBlocking(t *testing.T, timeout time.Duration, blockUntilRelease <-chan struct{}) (*watchdog, *watchdogTestScaffold) {
+	return makeWatchdogTestScaffoldFull(t, timeout, DefaultBroadcastTimeout, blockUntilRelease)
+}
+
+func makeWatchdogTestScaffoldFull(t *testing.T, timeout, broadcastTimeout time.Duration, blockUntilRelease <-chan struct{}) (*watchdog, *watchdogTestScaffold) {
 	scaffold := &watchdogTestScaffold{}
 	scaffold.parentCh = make(chan struct{})
 	scaffold.doneCh = make(chan dtypes.DeploymentID, 1)
@@ -36,11 +48,36 @@ func makeWatchdogTestScaffold(t *testing.T, timeout time.Duration) (*watchdog, *
 	scaffold.leaseID = testutil.LeaseID(t)
 	scaffold.leaseID.Provider = scaffold.provider.Owner
 	scaffold.broadcasts = make(chan []sdk.Msg, 1)
+	scaffold.broadcastStarted = make(chan struct{}, 1)
+	scaffold.broadcastErr = make(chan error, 1)
 
 	txClientMock := &clientmocks.TxClient{}
-	txClientMock.On("BroadcastMsgs", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		scaffold.broadcasts <- args.Get(1).([]sdk.Msg)
-	}).Return(&sdk.Result{}, nil)
+	txClientMock.EXPECT().
+		BroadcastMsgs(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, msgs []sdk.Msg, _ ...aclient.BroadcastOption) (any, error) {
+			select {
+			case scaffold.broadcastStarted <- struct{}{}:
+			default:
+			}
+
+			if blockUntilRelease != nil {
+				select {
+				case <-blockUntilRelease:
+				case <-ctx.Done():
+					scaffold.broadcastErr <- ctx.Err()
+					return nil, ctx.Err()
+				}
+			}
+
+			if err := ctx.Err(); err != nil {
+				scaffold.broadcastErr <- err
+				return nil, err
+			}
+
+			scaffold.broadcasts <- msgs
+			scaffold.broadcastErr <- nil
+			return &sdk.Result{}, nil
+		})
 
 	scaffold.client = &clientmocks.Client{}
 	scaffold.client.On("Tx").Return(txClientMock)
@@ -48,7 +85,7 @@ func makeWatchdogTestScaffold(t *testing.T, timeout time.Duration) (*watchdog, *
 
 	require.NotNil(t, sess.Client())
 
-	wd := newWatchdog(sess, scaffold.parentCh, scaffold.doneCh, scaffold.leaseID, timeout)
+	wd := newWatchdog(sess, scaffold.parentCh, scaffold.doneCh, scaffold.leaseID, timeout, broadcastTimeout)
 
 	return wd, scaffold
 }
@@ -120,4 +157,60 @@ func TestWatchdogStopsOnParent(t *testing.T) {
 
 	deploymentID := testutil.ChannelWaitForValue(t, scaffold.doneCh)
 	require.Equal(t, deploymentID, scaffold.leaseID.DeploymentID())
+}
+
+func TestWatchdogCloseBidIgnoresParentCancelOnceStarted(t *testing.T) {
+	releaseCh := make(chan struct{})
+	wd, scaffold := makeWatchdogTestScaffoldWithBlocking(t, 100*time.Millisecond, releaseCh)
+
+	select {
+	case <-scaffold.broadcastStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for broadcast to start")
+	}
+
+	close(scaffold.parentCh)
+	close(releaseCh)
+
+	select {
+	case err := <-scaffold.broadcastErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for broadcast result")
+	}
+
+	select {
+	case <-wd.lc.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting on watchdog to stop")
+	}
+
+	broadcasts := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
+	msgs := broadcasts.([]sdk.Msg)
+	require.Len(t, msgs, 1)
+	require.Equal(t, mtypes.LeaseClosedReasonManifestTimeout, msgs[0].(*mvbeta.MsgCloseBid).Reason)
+}
+
+func TestWatchdogBroadcastTimeout(t *testing.T) {
+	neverRelease := make(chan struct{})
+	wd, scaffold := makeWatchdogTestScaffoldFull(t, 100*time.Millisecond, 10*time.Millisecond, neverRelease)
+
+	select {
+	case err := <-scaffold.broadcastErr:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for broadcast timeout")
+	}
+
+	select {
+	case <-wd.lc.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("watchdog hung after broadcast timeout")
+	}
+
+	select {
+	case <-scaffold.broadcasts:
+		t.Fatal("broadcast should not have completed")
+	default:
+	}
 }

--- a/service.go
+++ b/service.go
@@ -106,6 +106,7 @@ func NewService(ctx context.Context,
 	manifestConfig := manifest.ServiceConfig{
 		HTTPServicesRequireAtLeastOneHost: !cfg.DeploymentIngressStaticHosts,
 		ManifestTimeout:                   cfg.ManifestTimeout,
+		BroadcastTimeout:                  cfg.BroadcastTimeout,
 		RPCQueryTimeout:                   cfg.RPCQueryTimeout,
 		CachedResultMaxAge:                cfg.CachedResultMaxAge,
 	}


### PR DESCRIPTION
## Summary
- Fixes akash-network/support#435 by keeping manifest timeout bid close independent from watchdog shutdown.
- Wires the existing tx broadcast timeout into the manifest watchdog.
- Replaces PR #371

## Testing
- GOWORK=off go test ./manifest -count=1
- GOWORK=off go test ./...