### PR TITLE
fix(builder): key GPU interface node selector by interface, not memory size

### DIFF
--- a/cluster/kube/builder/workload.go
+++ b/cluster/kube/builder/workload.go
@@ -537,7 +537,7 @@ func nodeSelectorsFromResources(res *crd.SchedulerResources) []corev1.NodeSelect
 
 		if gpu.Interface != "" {
 			selectors = append(selectors, corev1.NodeSelectorRequirement{
-				Key:      fmt.Sprintf("%s.interface.%s", key, gpu.MemorySize),
+				Key:      fmt.Sprintf("%s.interface.%s", key, gpu.Interface),
 				Operator: corev1.NodeSelectorOpGt,
 				Values: []string{
 					"0",

--- a/cluster/kube/builder/workload_gpu_selector_test.go
+++ b/cluster/kube/builder/workload_gpu_selector_test.go
@@ -1,0 +1,40 @@
+package builder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	crd "github.com/akash-network/provider/pkg/apis/akash.network/v2beta2"
+)
+
+// Test_nodeSelectorsFromResources_GPUInterface guards against the interface
+// selector being keyed off the GPU memory size instead of the interface. The
+// inventory operator publishes the node label as
+// "<gpu-key>.interface.<interface>", so the selector must match that, otherwise
+// a workload requesting a specific GPU interface can never be scheduled.
+func Test_nodeSelectorsFromResources_GPUInterface(t *testing.T) {
+	res := &crd.SchedulerResources{
+		GPU: &crd.SchedulerResourceGPU{
+			Vendor:     "nvidia",
+			Model:      "a100",
+			MemorySize: "80Gi",
+			Interface:  "pcie",
+		},
+	}
+
+	selectors := nodeSelectorsFromResources(res)
+
+	key := fmt.Sprintf("%s.vendor.%s.model.%s", AkashServiceCapabilityGPU, "nvidia", "a100")
+	wantInterfaceKey := fmt.Sprintf("%s.interface.%s", key, "pcie")
+	badInterfaceKey := fmt.Sprintf("%s.interface.%s", key, "80Gi")
+
+	keys := make(map[string]struct{}, len(selectors))
+	for _, s := range selectors {
+		keys[s.Key] = struct{}{}
+	}
+
+	require.Contains(t, keys, wantInterfaceKey, "interface selector must be keyed by the GPU interface")
+	require.NotContains(t, keys, badInterfaceKey, "interface selector must not be keyed by the memory size")
+}


### PR DESCRIPTION
### What

The GPU `interface` node-selector requirement in `cluster/kube/builder/workload.go` was built with `gpu.MemorySize` in the label key instead of `gpu.Interface`:

```go
if gpu.Interface != "" {
    Key: fmt.Sprintf("%s.interface.%s", key, gpu.MemorySize) // -> gpu.Interface
}
```

### Why

The inventory operator publishes the node label as `<gpu>.interface.<interface>` (`operator/inventory/node-discovery.go`, via `info.Interface`). Because the builder keyed the selector off the memory size instead, a workload requesting a specific GPU interface (e.g. `pcie`) produced a node-affinity requirement that can never match a real node label — so the pod fails to schedule.

### Testing

Added `Test_nodeSelectorsFromResources_GPUInterface`: a GPU with `memory_size=80Gi`, `interface=pcie` must yield a selector keyed `...interface.pcie`, and must NOT yield `...interface.80Gi`. Fails before the fix