### PR TITLE
fix(inventory): preserve raw negative state

### DIFF
--- a/cluster/inventory.go
+++ b/cluster/inventory.go
@@ -47,6 +47,7 @@ var (
 	errInventoryReservation     = errors.New("inventory error")
 	errNoLeasedIPsAvailable     = fmt.Errorf("%w: no leased IPs available", errInventoryReservation)
 	errInsufficientIPs          = fmt.Errorf("%w: insufficient number of IPs", errInventoryReservation)
+	inventoryStatusQuantityZero = resource.NewQuantity(0, resource.DecimalSI)
 )
 
 var (
@@ -840,8 +841,12 @@ func (is *inventoryService) getStatusV1(state *inventoryServiceState) (*provider
 		return nil, errInventoryNotAvailableYet
 	}
 
+	cluster := state.inventory.Snapshot()
+	cluster = *cluster.Dup()
+	sanitizeStatusCluster(&cluster)
+
 	status := &provider.Inventory{
-		Cluster:  state.inventory.Snapshot(),
+		Cluster:  cluster,
 		LeasedIP: leasedIPStatus(state),
 		Reservations: provider.Reservations{
 			Pending: provider.ReservationsMetric{
@@ -867,6 +872,37 @@ func (is *inventoryService) getStatusV1(state *inventoryServiceState) (*provider
 	}
 
 	return status, nil
+}
+
+func sanitizeStatusCluster(cluster *inventoryV1.Cluster) {
+	for idx := range cluster.Nodes {
+		sanitizeStatusNodeResources(&cluster.Nodes[idx].Resources)
+	}
+
+	for idx := range cluster.Storage {
+		sanitizeStatusResourcePair(&cluster.Storage[idx].Quantity)
+	}
+}
+
+func sanitizeStatusNodeResources(resources *inventoryV1.NodeResources) {
+	sanitizeStatusResourcePair(&resources.CPU.Quantity)
+	sanitizeStatusResourcePair(&resources.Memory.Quantity)
+	sanitizeStatusResourcePair(&resources.GPU.Quantity)
+	sanitizeStatusResourcePair(&resources.EphemeralStorage)
+	sanitizeStatusResourcePair(&resources.VolumesAttached)
+	sanitizeStatusResourcePair(&resources.VolumesMounted)
+}
+
+func sanitizeStatusResourcePair(pair *inventoryV1.ResourcePair) {
+	sanitizeStatusQuantity(pair.Capacity)
+	sanitizeStatusQuantity(pair.Allocatable)
+	sanitizeStatusQuantity(pair.Allocated)
+}
+
+func sanitizeStatusQuantity(quantity *resource.Quantity) {
+	if quantity.Cmp(*inventoryStatusQuantityZero) < 0 {
+		quantity.Set(0)
+	}
 }
 
 func reservationCountEndpoints(reservation *reservation) uint {

--- a/cluster/inventory_test.go
+++ b/cluster/inventory_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	tpubsub "github.com/troian/pubsub"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes"
 	kfake "k8s.io/client-go/kubernetes/fake"
 
+	inventoryV1 "pkg.akt.dev/go/inventory/v1"
 	manifest "pkg.akt.dev/go/manifest/v2beta3"
 	dvbeta "pkg.akt.dev/go/node/deployment/v1beta4"
 	mtypes "pkg.akt.dev/go/node/market/v1"
@@ -33,6 +35,26 @@ import (
 	afake "github.com/akash-network/provider/pkg/client/clientset/versioned/fake"
 	"github.com/akash-network/provider/tools/fromctx"
 )
+
+type statusTestInventory struct {
+	snapshot inventoryV1.Cluster
+}
+
+func (inv statusTestInventory) Adjust(ctypes.ReservationGroup, ...ctypes.InventoryOption) error {
+	return nil
+}
+
+func (inv statusTestInventory) Metrics() inventoryV1.Metrics {
+	return inventoryV1.Metrics{}
+}
+
+func (inv statusTestInventory) Snapshot() inventoryV1.Cluster {
+	return *inv.snapshot.Dup()
+}
+
+func (inv statusTestInventory) Dup() ctypes.Inventory {
+	return statusTestInventory{snapshot: *inv.snapshot.Dup()}
+}
 
 func TestInventory_reservationAllocatable(t *testing.T) {
 	mkrg := func(cpu uint64, gpu uint64, memory uint64, storage uint64, endpointsCount uint, count uint32) dvbeta.ResourceUnit {
@@ -459,6 +481,53 @@ func TestInventory_StatusV1SaturatesLeasedIPResourcePairAvailable(t *testing.T) 
 	require.Equal(t, int64(3), leasedIP.GetAllocatable().Value())
 	require.Equal(t, int64(6), leasedIP.GetAllocated().Value())
 	require.Equal(t, int64(0), leasedIP.Available().Value())
+}
+
+func TestInventory_StatusV1SanitizesNegativeClusterSnapshot(t *testing.T) {
+	snapshot := inventoryV1.Cluster{
+		Nodes: inventoryV1.Nodes{
+			{
+				Name: "node",
+				Resources: inventoryV1.NodeResources{
+					CPU: inventoryV1.CPU{
+						Quantity: inventoryV1.NewResourcePairMilli(1000, -500, -250, resource.DecimalSI),
+					},
+					Memory: inventoryV1.Memory{
+						Quantity: inventoryV1.NewResourcePair(-1, 1024, -1, resource.DecimalSI),
+					},
+					GPU: inventoryV1.GPU{
+						Quantity: inventoryV1.NewResourcePair(4, -1, -1, resource.DecimalSI),
+					},
+					EphemeralStorage: inventoryV1.NewResourcePair(100, -1, -1, resource.DecimalSI),
+					VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+					VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+				},
+			},
+		},
+		Storage: inventoryV1.ClusterStorage{
+			{
+				Quantity: inventoryV1.NewResourcePair(50, -1, -1, resource.DecimalSI),
+				Info:     inventoryV1.StorageInfo{Class: "default"},
+			},
+		},
+	}
+
+	status, err := (&inventoryService{}).getStatusV1(&inventoryServiceState{
+		inventory: statusTestInventory{snapshot: snapshot},
+	})
+	require.NoError(t, err)
+
+	node := status.Cluster.Nodes[0]
+	require.Equal(t, int64(0), node.Resources.CPU.Quantity.Allocatable.MilliValue())
+	require.Equal(t, int64(0), node.Resources.CPU.Quantity.Allocated.MilliValue())
+	require.Equal(t, int64(0), node.Resources.Memory.Quantity.Capacity.Value())
+	require.Equal(t, int64(0), node.Resources.Memory.Quantity.Allocated.Value())
+	require.Equal(t, int64(0), node.Resources.GPU.Quantity.Allocatable.Value())
+	require.Equal(t, int64(0), node.Resources.GPU.Quantity.Allocated.Value())
+	require.Equal(t, int64(0), node.Resources.EphemeralStorage.Allocatable.Value())
+	require.Equal(t, int64(0), node.Resources.EphemeralStorage.Allocated.Value())
+	require.Equal(t, int64(0), status.Cluster.Storage[0].Quantity.Allocatable.Value())
+	require.Equal(t, int64(0), status.Cluster.Storage[0].Quantity.Allocated.Value())
 }
 
 func TestInventory_ReserveIPNoIPOperator(t *testing.T) {

--- a/cluster/kube/operators/clients/inventory/client.go
+++ b/cluster/kube/operators/clients/inventory/client.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	"github.com/go-logr/logr"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 	"pkg.akt.dev/go/util/ctxlog"
@@ -46,6 +47,7 @@ type client struct {
 
 type inventory struct {
 	inventoryV1.Cluster
+	log logr.Logger
 }
 
 type inventoryState struct {
@@ -219,13 +221,13 @@ func (cl *client) subscriber(in <-chan inventoryV1.Cluster, out chan<- ctypes.In
 		case inv := <-in:
 			pending = append(pending, inv)
 			if och == nil {
-				msg = newInventory(pending[0])
+				msg = newInventory(cl.ctx, pending[0])
 				och = out
 			}
 		case och <- msg:
 			pending = pending[1:]
 			if len(pending) > 0 {
-				msg = newInventory(pending[0])
+				msg = newInventory(cl.ctx, pending[0])
 			} else {
 				och = nil
 				msg = nil

--- a/cluster/kube/operators/clients/inventory/client.go
+++ b/cluster/kube/operators/clients/inventory/client.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-	"github.com/go-logr/logr"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 	"pkg.akt.dev/go/util/ctxlog"
@@ -47,7 +46,7 @@ type client struct {
 
 type inventory struct {
 	inventoryV1.Cluster
-	log logr.Logger
+	ctx context.Context
 }
 
 type inventoryState struct {

--- a/cluster/kube/operators/clients/inventory/client.go
+++ b/cluster/kube/operators/clients/inventory/client.go
@@ -46,7 +46,7 @@ type client struct {
 
 type inventory struct {
 	inventoryV1.Cluster
-	ctx context.Context
+	safe inventoryV1.Cluster
 }
 
 type inventoryState struct {
@@ -220,13 +220,13 @@ func (cl *client) subscriber(in <-chan inventoryV1.Cluster, out chan<- ctypes.In
 		case inv := <-in:
 			pending = append(pending, inv)
 			if och == nil {
-				msg = newInventory(cl.ctx, pending[0])
+				msg = newInventory(pending[0])
 				och = out
 			}
 		case och <- msg:
 			pending = pending[1:]
 			if len(pending) > 0 {
-				msg = newInventory(cl.ctx, pending[0])
+				msg = newInventory(pending[0])
 			} else {
 				och = nil
 				msg = nil

--- a/cluster/kube/operators/clients/inventory/client_test.go
+++ b/cluster/kube/operators/clients/inventory/client_test.go
@@ -317,16 +317,11 @@ func TestInventoryZero(t *testing.T) {
 	require.Len(t, inv.Metrics().Nodes, 0)
 }
 
-func TestInventoryMetrics_bad_gpu_values_no_overflow(t *testing.T) {
-	scaffold := makeInventoryScaffold(t)
-	cl, err := NewClient(scaffold.ctx)
-	require.NoError(t, err)
-	require.NotNil(t, cl)
-
-	scaffold.gInv.invch <- inventoryV1.Cluster{
+func makeBaseCluster() inventoryV1.Cluster {
+	return inventoryV1.Cluster{
 		Nodes: inventoryV1.Nodes{
 			inventoryV1.Node{
-				Name: "bad-gpu-node",
+				Name: "node",
 				Resources: inventoryV1.NodeResources{
 					CPU: inventoryV1.CPU{
 						Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
@@ -335,7 +330,7 @@ func TestInventoryMetrics_bad_gpu_values_no_overflow(t *testing.T) {
 						Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
 					},
 					GPU: inventoryV1.GPU{
-						Quantity: inventoryV1.NewResourcePair(0, -1, 0, resource.DecimalSI),
+						Quantity: inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
 					},
 					EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
 					VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
@@ -345,45 +340,29 @@ func TestInventoryMetrics_bad_gpu_values_no_overflow(t *testing.T) {
 			},
 		},
 	}
-
-	inv := waitForInventory(t, cl.ResultChan())
-	require.NotNil(t, inv)
-
-	metrics := inv.Metrics()
-	require.Len(t, metrics.Nodes, 1)
-	assert.Equal(t, uint64(0), metrics.Nodes[0].Available.GPU, "negative allocatable must yield 0, not uint64 overflow")
-	assert.Equal(t, uint64(0), metrics.TotalAvailable.GPU)
 }
 
-func TestInventoryMetrics_negative_quantities_clamped_no_overflow(t *testing.T) {
+func TestInventoryMetrics_negative_quantities_clamped(t *testing.T) {
 	tests := []struct {
-		name     string
-		cluster  inventoryV1.Cluster
-		check    func(t *testing.T, m inventoryV1.Metrics)
+		name   string
+		mutate func(c *inventoryV1.Cluster)
+		check  func(t *testing.T, m inventoryV1.Metrics)
 	}{
 		{
+			name: "negative_allocatable_gpu",
+			mutate: func(c *inventoryV1.Cluster) {
+				c.Nodes[0].Resources.GPU.Quantity.Allocatable.Set(-1)
+			},
+			check: func(t *testing.T, m inventoryV1.Metrics) {
+				require.Len(t, m.Nodes, 1)
+				assert.Equal(t, uint64(0), m.Nodes[0].Available.GPU, "negative allocatable must yield 0")
+				assert.Equal(t, uint64(0), m.TotalAvailable.GPU)
+			},
+		},
+		{
 			name: "negative_allocatable_cpu",
-			cluster: inventoryV1.Cluster{
-				Nodes: inventoryV1.Nodes{
-					inventoryV1.Node{
-						Name: "bad-cpu-node",
-						Resources: inventoryV1.NodeResources{
-							CPU: inventoryV1.CPU{
-								Quantity: inventoryV1.NewResourcePairMilli(1000, -1, 0, resource.DecimalSI),
-							},
-							Memory: inventoryV1.Memory{
-								Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
-							},
-							GPU: inventoryV1.GPU{
-								Quantity: inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-							},
-							EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
-							VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-							VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-						},
-						Capabilities: inventoryV1.NodeCapabilities{},
-					},
-				},
+			mutate: func(c *inventoryV1.Cluster) {
+				c.Nodes[0].Resources.CPU.Quantity.Allocatable.SetMilli(-1)
 			},
 			check: func(t *testing.T, m inventoryV1.Metrics) {
 				require.Len(t, m.Nodes, 1)
@@ -393,27 +372,8 @@ func TestInventoryMetrics_negative_quantities_clamped_no_overflow(t *testing.T) 
 		},
 		{
 			name: "negative_allocatable_memory",
-			cluster: inventoryV1.Cluster{
-				Nodes: inventoryV1.Nodes{
-					inventoryV1.Node{
-						Name: "bad-memory-node",
-						Resources: inventoryV1.NodeResources{
-							CPU: inventoryV1.CPU{
-								Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
-							},
-							Memory: inventoryV1.Memory{
-								Quantity: inventoryV1.NewResourcePair(1024, -1, 0, resource.DecimalSI),
-							},
-							GPU: inventoryV1.GPU{
-								Quantity: inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-							},
-							EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
-							VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-							VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-						},
-						Capabilities: inventoryV1.NodeCapabilities{},
-					},
-				},
+			mutate: func(c *inventoryV1.Cluster) {
+				c.Nodes[0].Resources.Memory.Quantity.Allocatable.Set(-1)
 			},
 			check: func(t *testing.T, m inventoryV1.Metrics) {
 				require.Len(t, m.Nodes, 1)
@@ -423,27 +383,8 @@ func TestInventoryMetrics_negative_quantities_clamped_no_overflow(t *testing.T) 
 		},
 		{
 			name: "negative_allocatable_storage_ephemeral",
-			cluster: inventoryV1.Cluster{
-				Nodes: inventoryV1.Nodes{
-					inventoryV1.Node{
-						Name: "bad-storage-node",
-						Resources: inventoryV1.NodeResources{
-							CPU: inventoryV1.CPU{
-								Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
-							},
-							Memory: inventoryV1.Memory{
-								Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
-							},
-							GPU: inventoryV1.GPU{
-								Quantity: inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-							},
-							EphemeralStorage: inventoryV1.NewResourcePair(100, -1, 0, resource.DecimalSI),
-							VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-							VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-						},
-						Capabilities: inventoryV1.NodeCapabilities{},
-					},
-				},
+			mutate: func(c *inventoryV1.Cluster) {
+				c.Nodes[0].Resources.EphemeralStorage.Allocatable.Set(-1)
 			},
 			check: func(t *testing.T, m inventoryV1.Metrics) {
 				require.Len(t, m.Nodes, 1)
@@ -453,35 +394,14 @@ func TestInventoryMetrics_negative_quantities_clamped_no_overflow(t *testing.T) 
 		},
 		{
 			name: "negative_allocatable_storage_class",
-			cluster: inventoryV1.Cluster{
-				Nodes: inventoryV1.Nodes{
-					inventoryV1.Node{
-						Name: "node",
-						Resources: inventoryV1.NodeResources{
-							CPU: inventoryV1.CPU{
-								Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
-							},
-							Memory: inventoryV1.Memory{
-								Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
-							},
-							GPU: inventoryV1.GPU{
-								Quantity: inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-							},
-							EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
-							VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-							VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-						},
-						Capabilities: inventoryV1.NodeCapabilities{
-							StorageClasses: []string{"default"},
-						},
-					},
-				},
-				Storage: inventoryV1.ClusterStorage{
+			mutate: func(c *inventoryV1.Cluster) {
+				c.Nodes[0].Capabilities.StorageClasses = []string{"default"}
+				c.Storage = inventoryV1.ClusterStorage{
 					{
 						Quantity: inventoryV1.NewResourcePair(0, -1, 0, resource.DecimalSI),
 						Info:     inventoryV1.StorageInfo{Class: "default"},
 					},
-				},
+				}
 			},
 			check: func(t *testing.T, m inventoryV1.Metrics) {
 				assert.Equal(t, uint64(0), m.TotalAllocatable.Storage["default"])
@@ -489,27 +409,8 @@ func TestInventoryMetrics_negative_quantities_clamped_no_overflow(t *testing.T) 
 		},
 		{
 			name: "allocated_exceeds_allocatable_gpu",
-			cluster: inventoryV1.Cluster{
-				Nodes: inventoryV1.Nodes{
-					inventoryV1.Node{
-						Name: "overalloc-node",
-						Resources: inventoryV1.NodeResources{
-							CPU: inventoryV1.CPU{
-								Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
-							},
-							Memory: inventoryV1.Memory{
-								Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
-							},
-							GPU: inventoryV1.GPU{
-								Quantity: inventoryV1.NewResourcePair(4, 4, 10, resource.DecimalSI),
-							},
-							EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
-							VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-							VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
-						},
-						Capabilities: inventoryV1.NodeCapabilities{},
-					},
-				},
+			mutate: func(c *inventoryV1.Cluster) {
+				c.Nodes[0].Resources.GPU.Quantity = inventoryV1.NewResourcePair(4, 4, 10, resource.DecimalSI)
 			},
 			check: func(t *testing.T, m inventoryV1.Metrics) {
 				require.Len(t, m.Nodes, 1)
@@ -526,7 +427,9 @@ func TestInventoryMetrics_negative_quantities_clamped_no_overflow(t *testing.T) 
 			require.NoError(t, err)
 			require.NotNil(t, cl)
 
-			scaffold.gInv.invch <- tt.cluster
+			cluster := makeBaseCluster()
+			tt.mutate(&cluster)
+			scaffold.gInv.invch <- cluster
 
 			inv := waitForInventory(t, cl.ResultChan())
 			require.NotNil(t, inv)

--- a/cluster/kube/operators/clients/inventory/client_test.go
+++ b/cluster/kube/operators/clients/inventory/client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -211,6 +212,7 @@ func makeInventoryScaffold(t *testing.T) *inventoryScaffold {
 	kc := kfake.NewClientset()
 	ctx = context.WithValue(ctx, fromctx.CtxKeyKubeClientSet, kubernetes.Interface(kc))
 	ctx = context.WithValue(ctx, fromctx.CtxKeyInventoryUnderTest, true)
+	ctx = logr.NewContext(ctx, logr.Discard())
 
 	gSrv := setupInventoryGRPC(ctx, group, ports[0])
 
@@ -313,6 +315,225 @@ func TestInventoryZero(t *testing.T) {
 	// The inventory was called and the kubernetes client says there are no nodes & no pods. Inventory
 	// should be zero
 	require.Len(t, inv.Metrics().Nodes, 0)
+}
+
+func TestInventoryMetrics_bad_gpu_values_no_overflow(t *testing.T) {
+	scaffold := makeInventoryScaffold(t)
+	cl, err := NewClient(scaffold.ctx)
+	require.NoError(t, err)
+	require.NotNil(t, cl)
+
+	scaffold.gInv.invch <- inventoryV1.Cluster{
+		Nodes: inventoryV1.Nodes{
+			inventoryV1.Node{
+				Name: "bad-gpu-node",
+				Resources: inventoryV1.NodeResources{
+					CPU: inventoryV1.CPU{
+						Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
+					},
+					Memory: inventoryV1.Memory{
+						Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
+					},
+					GPU: inventoryV1.GPU{
+						Quantity: inventoryV1.NewResourcePair(0, -1, 0, resource.DecimalSI),
+					},
+					EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
+					VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+					VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+				},
+				Capabilities: inventoryV1.NodeCapabilities{},
+			},
+		},
+	}
+
+	inv := waitForInventory(t, cl.ResultChan())
+	require.NotNil(t, inv)
+
+	metrics := inv.Metrics()
+	require.Len(t, metrics.Nodes, 1)
+	assert.Equal(t, uint64(0), metrics.Nodes[0].Available.GPU, "negative allocatable must yield 0, not uint64 overflow")
+	assert.Equal(t, uint64(0), metrics.TotalAvailable.GPU)
+}
+
+func TestInventoryMetrics_negative_quantities_clamped_no_overflow(t *testing.T) {
+	tests := []struct {
+		name     string
+		cluster  inventoryV1.Cluster
+		check    func(t *testing.T, m inventoryV1.Metrics)
+	}{
+		{
+			name: "negative_allocatable_cpu",
+			cluster: inventoryV1.Cluster{
+				Nodes: inventoryV1.Nodes{
+					inventoryV1.Node{
+						Name: "bad-cpu-node",
+						Resources: inventoryV1.NodeResources{
+							CPU: inventoryV1.CPU{
+								Quantity: inventoryV1.NewResourcePairMilli(1000, -1, 0, resource.DecimalSI),
+							},
+							Memory: inventoryV1.Memory{
+								Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
+							},
+							GPU: inventoryV1.GPU{
+								Quantity: inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+							},
+							EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
+							VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+							VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+						},
+						Capabilities: inventoryV1.NodeCapabilities{},
+					},
+				},
+			},
+			check: func(t *testing.T, m inventoryV1.Metrics) {
+				require.Len(t, m.Nodes, 1)
+				assert.Equal(t, uint64(0), m.Nodes[0].Allocatable.CPU)
+				assert.Equal(t, uint64(0), m.TotalAllocatable.CPU)
+			},
+		},
+		{
+			name: "negative_allocatable_memory",
+			cluster: inventoryV1.Cluster{
+				Nodes: inventoryV1.Nodes{
+					inventoryV1.Node{
+						Name: "bad-memory-node",
+						Resources: inventoryV1.NodeResources{
+							CPU: inventoryV1.CPU{
+								Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
+							},
+							Memory: inventoryV1.Memory{
+								Quantity: inventoryV1.NewResourcePair(1024, -1, 0, resource.DecimalSI),
+							},
+							GPU: inventoryV1.GPU{
+								Quantity: inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+							},
+							EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
+							VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+							VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+						},
+						Capabilities: inventoryV1.NodeCapabilities{},
+					},
+				},
+			},
+			check: func(t *testing.T, m inventoryV1.Metrics) {
+				require.Len(t, m.Nodes, 1)
+				assert.Equal(t, uint64(0), m.Nodes[0].Allocatable.Memory)
+				assert.Equal(t, uint64(0), m.TotalAllocatable.Memory)
+			},
+		},
+		{
+			name: "negative_allocatable_storage_ephemeral",
+			cluster: inventoryV1.Cluster{
+				Nodes: inventoryV1.Nodes{
+					inventoryV1.Node{
+						Name: "bad-storage-node",
+						Resources: inventoryV1.NodeResources{
+							CPU: inventoryV1.CPU{
+								Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
+							},
+							Memory: inventoryV1.Memory{
+								Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
+							},
+							GPU: inventoryV1.GPU{
+								Quantity: inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+							},
+							EphemeralStorage: inventoryV1.NewResourcePair(100, -1, 0, resource.DecimalSI),
+							VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+							VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+						},
+						Capabilities: inventoryV1.NodeCapabilities{},
+					},
+				},
+			},
+			check: func(t *testing.T, m inventoryV1.Metrics) {
+				require.Len(t, m.Nodes, 1)
+				assert.Equal(t, uint64(0), m.Nodes[0].Allocatable.StorageEphemeral)
+				assert.Equal(t, uint64(0), m.TotalAllocatable.StorageEphemeral)
+			},
+		},
+		{
+			name: "negative_allocatable_storage_class",
+			cluster: inventoryV1.Cluster{
+				Nodes: inventoryV1.Nodes{
+					inventoryV1.Node{
+						Name: "node",
+						Resources: inventoryV1.NodeResources{
+							CPU: inventoryV1.CPU{
+								Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
+							},
+							Memory: inventoryV1.Memory{
+								Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
+							},
+							GPU: inventoryV1.GPU{
+								Quantity: inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+							},
+							EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
+							VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+							VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+						},
+						Capabilities: inventoryV1.NodeCapabilities{
+							StorageClasses: []string{"default"},
+						},
+					},
+				},
+				Storage: inventoryV1.ClusterStorage{
+					{
+						Quantity: inventoryV1.NewResourcePair(0, -1, 0, resource.DecimalSI),
+						Info:     inventoryV1.StorageInfo{Class: "default"},
+					},
+				},
+			},
+			check: func(t *testing.T, m inventoryV1.Metrics) {
+				assert.Equal(t, uint64(0), m.TotalAllocatable.Storage["default"])
+			},
+		},
+		{
+			name: "allocated_exceeds_allocatable_gpu",
+			cluster: inventoryV1.Cluster{
+				Nodes: inventoryV1.Nodes{
+					inventoryV1.Node{
+						Name: "overalloc-node",
+						Resources: inventoryV1.NodeResources{
+							CPU: inventoryV1.CPU{
+								Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
+							},
+							Memory: inventoryV1.Memory{
+								Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
+							},
+							GPU: inventoryV1.GPU{
+								Quantity: inventoryV1.NewResourcePair(4, 4, 10, resource.DecimalSI),
+							},
+							EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
+							VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+							VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+						},
+						Capabilities: inventoryV1.NodeCapabilities{},
+					},
+				},
+			},
+			check: func(t *testing.T, m inventoryV1.Metrics) {
+				require.Len(t, m.Nodes, 1)
+				assert.Equal(t, uint64(0), m.Nodes[0].Available.GPU, "allocated>allocatable must yield 0 available")
+				assert.Equal(t, uint64(4), m.Nodes[0].Allocatable.GPU)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scaffold := makeInventoryScaffold(t)
+			cl, err := NewClient(scaffold.ctx)
+			require.NoError(t, err)
+			require.NotNil(t, cl)
+
+			scaffold.gInv.invch <- tt.cluster
+
+			inv := waitForInventory(t, cl.ResultChan())
+			require.NotNil(t, inv)
+
+			tt.check(t, inv.Metrics())
+		})
+	}
 }
 
 func TestInventorySingleNodeNoPods(t *testing.T) {

--- a/cluster/kube/operators/clients/inventory/client_test.go
+++ b/cluster/kube/operators/clients/inventory/client_test.go
@@ -404,7 +404,9 @@ func TestInventoryMetrics_negative_quantities_clamped(t *testing.T) {
 				}
 			},
 			check: func(t *testing.T, m inventoryV1.Metrics) {
-				assert.Equal(t, uint64(0), m.TotalAllocatable.Storage["default"])
+				v, exists := m.TotalAllocatable.Storage["default"]
+				require.True(t, exists, "storage class key must be present")
+				assert.Equal(t, uint64(0), v)
 			},
 		},
 		{

--- a/cluster/kube/operators/clients/inventory/client_test.go
+++ b/cluster/kube/operators/clients/inventory/client_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -212,7 +211,6 @@ func makeInventoryScaffold(t *testing.T) *inventoryScaffold {
 	kc := kfake.NewClientset()
 	ctx = context.WithValue(ctx, fromctx.CtxKeyKubeClientSet, kubernetes.Interface(kc))
 	ctx = context.WithValue(ctx, fromctx.CtxKeyInventoryUnderTest, true)
-	ctx = logr.NewContext(ctx, logr.Discard())
 
 	gSrv := setupInventoryGRPC(ctx, group, ports[0])
 
@@ -320,7 +318,7 @@ func TestInventoryZero(t *testing.T) {
 func makeBaseCluster() inventoryV1.Cluster {
 	return inventoryV1.Cluster{
 		Nodes: inventoryV1.Nodes{
-			inventoryV1.Node{
+			{
 				Name: "node",
 				Resources: inventoryV1.NodeResources{
 					CPU: inventoryV1.CPU{
@@ -330,115 +328,116 @@ func makeBaseCluster() inventoryV1.Cluster {
 						Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
 					},
 					GPU: inventoryV1.GPU{
-						Quantity: inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+						Quantity: inventoryV1.NewResourcePair(4, 4, 0, resource.DecimalSI),
 					},
 					EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
 					VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
 					VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
 				},
-				Capabilities: inventoryV1.NodeCapabilities{},
+			},
+		},
+		Storage: inventoryV1.ClusterStorage{
+			{
+				Quantity: inventoryV1.NewResourcePair(50, 50, 0, resource.DecimalSI),
+				Info:     inventoryV1.StorageInfo{Class: "default"},
 			},
 		},
 	}
 }
 
-func TestInventoryMetrics_negative_quantities_clamped(t *testing.T) {
-	tests := []struct {
-		name   string
-		mutate func(c *inventoryV1.Cluster)
-		check  func(t *testing.T, m inventoryV1.Metrics)
-	}{
-		{
-			name: "negative_allocatable_gpu",
-			mutate: func(c *inventoryV1.Cluster) {
-				c.Nodes[0].Resources.GPU.Quantity.Allocatable.Set(-1)
-			},
-			check: func(t *testing.T, m inventoryV1.Metrics) {
-				require.Len(t, m.Nodes, 1)
-				assert.Equal(t, uint64(0), m.Nodes[0].Available.GPU, "negative allocatable must yield 0")
-				assert.Equal(t, uint64(0), m.TotalAvailable.GPU)
-			},
-		},
-		{
-			name: "negative_allocatable_cpu",
-			mutate: func(c *inventoryV1.Cluster) {
-				c.Nodes[0].Resources.CPU.Quantity.Allocatable.SetMilli(-1)
-			},
-			check: func(t *testing.T, m inventoryV1.Metrics) {
-				require.Len(t, m.Nodes, 1)
-				assert.Equal(t, uint64(0), m.Nodes[0].Allocatable.CPU)
-				assert.Equal(t, uint64(0), m.TotalAllocatable.CPU)
-			},
-		},
-		{
-			name: "negative_allocatable_memory",
-			mutate: func(c *inventoryV1.Cluster) {
-				c.Nodes[0].Resources.Memory.Quantity.Allocatable.Set(-1)
-			},
-			check: func(t *testing.T, m inventoryV1.Metrics) {
-				require.Len(t, m.Nodes, 1)
-				assert.Equal(t, uint64(0), m.Nodes[0].Allocatable.Memory)
-				assert.Equal(t, uint64(0), m.TotalAllocatable.Memory)
-			},
-		},
-		{
-			name: "negative_allocatable_storage_ephemeral",
-			mutate: func(c *inventoryV1.Cluster) {
-				c.Nodes[0].Resources.EphemeralStorage.Allocatable.Set(-1)
-			},
-			check: func(t *testing.T, m inventoryV1.Metrics) {
-				require.Len(t, m.Nodes, 1)
-				assert.Equal(t, uint64(0), m.Nodes[0].Allocatable.StorageEphemeral)
-				assert.Equal(t, uint64(0), m.TotalAllocatable.StorageEphemeral)
-			},
-		},
-		{
-			name: "negative_allocatable_storage_class",
-			mutate: func(c *inventoryV1.Cluster) {
-				c.Nodes[0].Capabilities.StorageClasses = []string{"default"}
-				c.Storage = inventoryV1.ClusterStorage{
-					{
-						Quantity: inventoryV1.NewResourcePair(0, -1, 0, resource.DecimalSI),
-						Info:     inventoryV1.StorageInfo{Class: "default"},
+func TestInventorySnapshotSanitizesNegativeQuantities(t *testing.T) {
+	cluster := makeBaseCluster()
+	cluster.Nodes[0].Resources.CPU.Quantity.Allocatable.SetMilli(-500)
+	cluster.Nodes[0].Resources.CPU.Quantity.Allocated.SetMilli(-250)
+	cluster.Nodes[0].Resources.Memory.Quantity.Capacity.Set(-1)
+	cluster.Nodes[0].Resources.GPU.Quantity.Allocatable.Set(-1)
+	cluster.Nodes[0].Resources.EphemeralStorage.Allocated.Set(-1)
+	cluster.Storage[0].Quantity.Allocatable.Set(-1)
+
+	inv := newInventory(cluster)
+	snapshot := inv.Snapshot()
+
+	require.Equal(t, int64(0), snapshot.Nodes[0].Resources.CPU.Quantity.Allocatable.MilliValue())
+	require.Equal(t, int64(0), snapshot.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
+	require.Equal(t, int64(0), snapshot.Nodes[0].Resources.Memory.Quantity.Capacity.Value())
+	require.Equal(t, int64(0), snapshot.Nodes[0].Resources.GPU.Quantity.Allocatable.Value())
+	require.Equal(t, int64(0), snapshot.Nodes[0].Resources.EphemeralStorage.Allocated.Value())
+	require.Equal(t, int64(0), snapshot.Storage[0].Quantity.Allocatable.Value())
+
+	require.Equal(t, int64(-500), inv.Cluster.Nodes[0].Resources.CPU.Quantity.Allocatable.MilliValue())
+	require.Equal(t, int64(-250), inv.Cluster.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
+}
+
+func TestInventoryMetricsSanitizesNegativeQuantities(t *testing.T) {
+	cluster := makeBaseCluster()
+	cluster.Nodes[0].Resources.CPU.Quantity.Allocatable.SetMilli(-500)
+	cluster.Nodes[0].Resources.GPU.Quantity.Allocatable.Set(-1)
+	cluster.Storage[0].Quantity.Allocatable.Set(-1)
+
+	metrics := newInventory(cluster).Metrics()
+
+	require.Len(t, metrics.Nodes, 1)
+	require.Equal(t, uint64(0), metrics.Nodes[0].Allocatable.CPU)
+	require.Equal(t, uint64(0), metrics.Nodes[0].Allocatable.GPU)
+	require.Equal(t, uint64(0), metrics.TotalAllocatable.CPU)
+	require.Equal(t, uint64(0), metrics.TotalAllocatable.GPU)
+	require.Equal(t, uint64(0), metrics.TotalAllocatable.Storage["default"])
+}
+
+func TestInventoryAdjustSanitizesNegativeAllocatedBeforeBidding(t *testing.T) {
+	cluster := makeBaseCluster()
+	cluster.Nodes[0].Resources.CPU.Quantity.Allocated.SetMilli(-1000)
+
+	inv := newInventory(cluster)
+	reservation := &testReservation{
+		resources: dvbeta.GroupSpec{
+			Name: "group",
+			Resources: dvbeta.ResourceUnits{
+				{
+					Resources: rtypes.Resources{
+						ID:     1,
+						CPU:    &rtypes.CPU{Units: rtypes.NewResourceValue(1500)},
+						GPU:    &rtypes.GPU{Units: rtypes.NewResourceValue(0)},
+						Memory: &rtypes.Memory{Quantity: rtypes.NewResourceValue(1)},
 					},
-				}
-			},
-			check: func(t *testing.T, m inventoryV1.Metrics) {
-				v, exists := m.TotalAllocatable.Storage["default"]
-				require.True(t, exists, "storage class key must be present")
-				assert.Equal(t, uint64(0), v)
-			},
-		},
-		{
-			name: "allocated_exceeds_allocatable_gpu",
-			mutate: func(c *inventoryV1.Cluster) {
-				c.Nodes[0].Resources.GPU.Quantity = inventoryV1.NewResourcePair(4, 4, 10, resource.DecimalSI)
-			},
-			check: func(t *testing.T, m inventoryV1.Metrics) {
-				require.Len(t, m.Nodes, 1)
-				assert.Equal(t, uint64(0), m.Nodes[0].Available.GPU, "allocated>allocatable must yield 0 available")
-				assert.Equal(t, uint64(4), m.Nodes[0].Allocatable.GPU)
+					Count: 1,
+				},
 			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			scaffold := makeInventoryScaffold(t)
-			cl, err := NewClient(scaffold.ctx)
-			require.NoError(t, err)
-			require.NotNil(t, cl)
+	err := inv.Adjust(reservation)
 
-			cluster := makeBaseCluster()
-			tt.mutate(&cluster)
-			scaffold.gInv.invch <- cluster
+	require.ErrorIs(t, err, ctypes.ErrInsufficientCapacity)
+}
 
-			inv := waitForInventory(t, cl.ResultChan())
-			require.NotNil(t, inv)
+func TestInventoryAdjustKeepsRawStateAndUpdatesSafeState(t *testing.T) {
+	cluster := makeBaseCluster()
+	cluster.Nodes[0].Resources.CPU.Quantity.Allocated.SetMilli(-1000)
 
-			tt.check(t, inv.Metrics())
-		})
+	inv := newInventory(cluster)
+	reservation := &testReservation{
+		resources: dvbeta.GroupSpec{
+			Name: "group",
+			Resources: dvbeta.ResourceUnits{
+				{
+					Resources: rtypes.Resources{
+						ID:     1,
+						CPU:    &rtypes.CPU{Units: rtypes.NewResourceValue(500)},
+						GPU:    &rtypes.GPU{Units: rtypes.NewResourceValue(0)},
+						Memory: &rtypes.Memory{Quantity: rtypes.NewResourceValue(1)},
+					},
+					Count: 1,
+				},
+			},
+		},
 	}
+
+	err := inv.Adjust(reservation)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(-1000), inv.Cluster.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
+	require.Equal(t, int64(500), inv.Snapshot().Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
 }
 
 func TestInventorySingleNodeNoPods(t *testing.T) {

--- a/cluster/kube/operators/clients/inventory/inventory.go
+++ b/cluster/kube/operators/clients/inventory/inventory.go
@@ -1,9 +1,14 @@
 package inventory
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	inventoryV1 "pkg.akt.dev/go/inventory/v1"
 	dvbeta "pkg.akt.dev/go/node/deployment/v1beta4"
@@ -14,24 +19,67 @@ import (
 	ctypes "github.com/akash-network/provider/cluster/types/v1beta3"
 	cinventory "github.com/akash-network/provider/cluster/types/v1beta3/clients/inventory"
 	crd "github.com/akash-network/provider/pkg/apis/akash.network/v2beta2"
+	"github.com/akash-network/provider/tools/fromctx"
+)
+
+var (
+	errNegativeQuantityClamped = errors.New("inventory resource quantity was negative (device plugin or allocation bug), clamped to 0 to prevent uint64 overflow")
+)
+
+const (
+	stageAllocatableCPU              = "allocatable_cpu"
+	stageAllocatableGPU              = "allocatable_gpu"
+	stageAllocatableMemory           = "allocatable_memory"
+	stageAllocatableStorage          = "allocatable_storage"
+	stageAllocatableStorageEphemeral = "allocatable_storage_ephemeral"
+	stageAvailableCPU                = "available_cpu"
+	stageAvailableGPU                = "available_gpu"
+	stageAvailableMemory             = "available_memory"
+	stageAvailableStorage            = "available_storage"
+	stageAvailableStorageEphemeral   = "available_storage_ephemeral"
 )
 
 var _ ctypes.Inventory = (*inventory)(nil)
 
-func newInventory(clState inventoryV1.Cluster) *inventory {
-	inv := &inventory{
-		Cluster: clState,
+func safeQuantityToUint64(log logr.Logger, q *resource.Quantity, stage string, keysAndValues ...interface{}) uint64 {
+	if q == nil {
+		return 0
 	}
+	v := q.Value()
+	if v < 0 {
+		kvs := append([]interface{}{"stage", stage, "value", v}, keysAndValues...)
+		log.Error(errNegativeQuantityClamped, "negative quantity clamped", kvs...)
+		return 0
+	}
+	return uint64(v)
+}
 
-	return inv
+func safeMilliQuantityToUint64(log logr.Logger, q *resource.Quantity, stage string, keysAndValues ...interface{}) uint64 {
+	if q == nil {
+		return 0
+	}
+	v := q.MilliValue()
+	if v < 0 {
+		kvs := append([]interface{}{"stage", stage, "milliValue", v}, keysAndValues...)
+		log.Error(errNegativeQuantityClamped, "negative quantity clamped", kvs...)
+		return 0
+	}
+	return uint64(v)
+}
+
+func newInventory(ctx context.Context, clState inventoryV1.Cluster) *inventory {
+	log := fromctx.LogrFromCtx(ctx).WithName("inventory")
+	return &inventory{
+		Cluster: clState,
+		log:     log,
+	}
 }
 
 func (inv *inventory) dup() inventory {
-	dup := inventory{
+	return inventory{
 		Cluster: *inv.Cluster.Dup(),
+		log:     inv.log,
 	}
-
-	return dup
 }
 
 func (inv *inventory) Dup() ctypes.Inventory {
@@ -332,47 +380,63 @@ func (inv *inventory) Metrics() inventoryV1.Metrics {
 		Nodes: make([]inventoryV1.NodeMetrics, 0, len(inv.Nodes)),
 	}
 
+	log := inv.log
 	for _, nd := range inv.Nodes {
+		ndLog := log.WithValues("node", nd.Name)
+		gpuAllocatable := safeQuantityToUint64(ndLog, nd.Resources.GPU.Quantity.Allocatable, stageAllocatableGPU)
 		invNode := inventoryV1.NodeMetrics{
 			Name: nd.Name,
 			Allocatable: inventoryV1.ResourcesMetric{
-				CPU:              uint64(nd.Resources.CPU.Quantity.Allocatable.MilliValue()), // nolint: gosec
-				GPU:              uint64(nd.Resources.GPU.Quantity.Allocatable.Value()),      // nolint: gosec
-				Memory:           uint64(nd.Resources.Memory.Quantity.Allocatable.Value()),   // nolint: gosec
-				StorageEphemeral: uint64(nd.Resources.EphemeralStorage.Allocatable.Value()),  // nolint: gosec
+				CPU:              safeMilliQuantityToUint64(ndLog, nd.Resources.CPU.Quantity.Allocatable, stageAllocatableCPU),
+				GPU:              gpuAllocatable,
+				Memory:           safeQuantityToUint64(ndLog, nd.Resources.Memory.Quantity.Allocatable, stageAllocatableMemory),
+				StorageEphemeral: safeQuantityToUint64(ndLog, nd.Resources.EphemeralStorage.Allocatable, stageAllocatableStorageEphemeral),
 			},
 		}
 
-		cpuTotal += uint64(nd.Resources.CPU.Quantity.Allocatable.MilliValue())             // nolint: gosec
-		gpuTotal += uint64(nd.Resources.GPU.Quantity.Allocatable.Value())                  // nolint: gosec
-		memoryTotal += uint64(nd.Resources.Memory.Quantity.Allocatable.Value())            // nolint: gosec
-		storageEphemeralTotal += uint64(nd.Resources.EphemeralStorage.Allocatable.Value()) // nolint: gosec
+		cpuTotal += safeMilliQuantityToUint64(ndLog, nd.Resources.CPU.Quantity.Allocatable, stageAllocatableCPU)
+		gpuTotal += gpuAllocatable
+		memoryTotal += safeQuantityToUint64(ndLog, nd.Resources.Memory.Quantity.Allocatable, stageAllocatableMemory)
+		storageEphemeralTotal += safeQuantityToUint64(ndLog, nd.Resources.EphemeralStorage.Allocatable, stageAllocatableStorageEphemeral)
 
 		avail := nd.Resources.CPU.Quantity.Available()
-		invNode.Available.CPU = uint64(avail.MilliValue()) // nolint: gosec
+		invNode.Available.CPU = safeMilliQuantityToUint64(ndLog, avail, stageAvailableCPU)
 		cpuAvailable += invNode.Available.CPU
 
 		avail = nd.Resources.GPU.Quantity.Available()
-		invNode.Available.GPU = uint64(avail.Value()) // nolint: gosec
+		if nd.Resources.GPU.Quantity.Allocatable != nil && nd.Resources.GPU.Quantity.Allocatable.Value() < 0 {
+			ndLog.Error(errNegativeQuantityClamped, stageAvailableGPU+" clamped: allocatable negative (device plugin)", "allocatable", nd.Resources.GPU.Quantity.Allocatable.Value())
+			invNode.Available.GPU = 0
+		} else {
+			allocatableVal := int64(0)
+			allocatedVal := int64(0)
+			if nd.Resources.GPU.Quantity.Allocatable != nil {
+				allocatableVal = nd.Resources.GPU.Quantity.Allocatable.Value()
+			}
+			if nd.Resources.GPU.Quantity.Allocated != nil {
+				allocatedVal = nd.Resources.GPU.Quantity.Allocated.Value()
+			}
+			invNode.Available.GPU = safeQuantityToUint64(ndLog, avail, stageAvailableGPU, "allocatable", allocatableVal, "allocated", allocatedVal)
+		}
 		gpuAvailable += invNode.Available.GPU
 
 		avail = nd.Resources.Memory.Quantity.Available()
-		invNode.Available.Memory = uint64(avail.Value()) // nolint: gosec
+		invNode.Available.Memory = safeQuantityToUint64(ndLog, avail, stageAvailableMemory)
 		memoryAvailable += invNode.Available.Memory
 
 		avail = nd.Resources.EphemeralStorage.Available()
-		invNode.Available.StorageEphemeral = uint64(avail.Value()) // nolint: gosec
+		invNode.Available.StorageEphemeral = safeQuantityToUint64(ndLog, avail, stageAvailableStorageEphemeral)
 		storageEphemeralAvailable += invNode.Available.StorageEphemeral
 
 		ret.Nodes = append(ret.Nodes, invNode)
 	}
 
 	for _, class := range inv.Storage {
-		tmp := class.Quantity.Allocatable.DeepCopy()
-		storageTotal[class.Info.Class] = uint64(tmp.Value()) //nolint: gosec
+		classLog := log.WithValues("storageClass", class.Info.Class)
+		storageTotal[class.Info.Class] = safeQuantityToUint64(classLog, class.Quantity.Allocatable, stageAllocatableStorage)
 
-		tmp = *class.Quantity.Available()
-		storageAvailable[class.Info.Class] = uint64(tmp.Value()) //nolint: gosec
+		tmp := class.Quantity.Available()
+		storageAvailable[class.Info.Class] = safeQuantityToUint64(classLog, tmp, stageAvailableStorage)
 	}
 
 	ret.TotalAllocatable = inventoryV1.MetricTotal{

--- a/cluster/kube/operators/clients/inventory/inventory.go
+++ b/cluster/kube/operators/clients/inventory/inventory.go
@@ -49,17 +49,16 @@ func clampAvailableUint64(log logr.Logger, allocatable *resource.Quantity, v int
 }
 
 func newInventory(ctx context.Context, clState inventoryV1.Cluster) *inventory {
-	log := fromctx.LogrFromCtx(ctx).WithName("inventory")
 	return &inventory{
 		Cluster: clState,
-		log:     log,
+		ctx:     ctx,
 	}
 }
 
 func (inv *inventory) dup() inventory {
 	return inventory{
 		Cluster: *inv.Cluster.Dup(),
-		log:     inv.log,
+		ctx:     inv.ctx,
 	}
 }
 
@@ -361,7 +360,7 @@ func (inv *inventory) Metrics() inventoryV1.Metrics {
 		Nodes: make([]inventoryV1.NodeMetrics, 0, len(inv.Nodes)),
 	}
 
-	log := inv.log
+	log := fromctx.LogrFromCtx(inv.ctx).WithName("inventory.metrics")
 	for _, nd := range inv.Nodes {
 		ndLog := log.WithValues("node", nd.Name)
 

--- a/cluster/kube/operators/clients/inventory/inventory.go
+++ b/cluster/kube/operators/clients/inventory/inventory.go
@@ -23,48 +23,29 @@ import (
 )
 
 var (
-	errNegativeQuantityClamped = errors.New("inventory resource quantity was negative (device plugin or allocation bug), clamped to 0 to prevent uint64 overflow")
+	_ ctypes.Inventory = (*inventory)(nil)
+
+	errNegativeQuantity = errors.New("negative resource quantity clamped to 0")
+	quantityZero        = resource.NewQuantity(0, resource.DecimalSI)
 )
 
-const (
-	stageAllocatableCPU              = "allocatable_cpu"
-	stageAllocatableGPU              = "allocatable_gpu"
-	stageAllocatableMemory           = "allocatable_memory"
-	stageAllocatableStorage          = "allocatable_storage"
-	stageAllocatableStorageEphemeral = "allocatable_storage_ephemeral"
-	stageAvailableCPU                = "available_cpu"
-	stageAvailableGPU                = "available_gpu"
-	stageAvailableMemory             = "available_memory"
-	stageAvailableStorage            = "available_storage"
-	stageAvailableStorageEphemeral   = "available_storage_ephemeral"
-)
-
-var _ ctypes.Inventory = (*inventory)(nil)
-
-func safeQuantityToUint64(log logr.Logger, q *resource.Quantity, stage string, keysAndValues ...interface{}) uint64 {
-	if q == nil {
-		return 0
-	}
-	v := q.Value()
+func clampUint64(log logr.Logger, v int64, what string) uint64 {
 	if v < 0 {
-		kvs := append([]interface{}{"stage", stage, "value", v}, keysAndValues...)
-		log.Error(errNegativeQuantityClamped, "negative quantity clamped", kvs...)
+		log.Error(errNegativeQuantity, "clamped to 0", "what", what, "value", v)
 		return 0
 	}
 	return uint64(v)
 }
 
-func safeMilliQuantityToUint64(log logr.Logger, q *resource.Quantity, stage string, keysAndValues ...interface{}) uint64 {
-	if q == nil {
+// clampAvailableUint64 guards against ResourcePair.Available() returning MaxInt64
+// when allocatable is -1 (the "unlimited" sentinel). If allocatable is negative
+// for any reason, the Available() result is unreliable.
+func clampAvailableUint64(log logr.Logger, allocatable *resource.Quantity, v int64, what string) uint64 {
+	if allocatable.Cmp(*quantityZero) < 0 {
+		log.Error(errNegativeQuantity, "available clamped: negative allocatable", "what", what)
 		return 0
 	}
-	v := q.MilliValue()
-	if v < 0 {
-		kvs := append([]interface{}{"stage", stage, "milliValue", v}, keysAndValues...)
-		log.Error(errNegativeQuantityClamped, "negative quantity clamped", kvs...)
-		return 0
-	}
-	return uint64(v)
+	return clampUint64(log, v, what)
 }
 
 func newInventory(ctx context.Context, clState inventoryV1.Cluster) *inventory {
@@ -383,49 +364,37 @@ func (inv *inventory) Metrics() inventoryV1.Metrics {
 	log := inv.log
 	for _, nd := range inv.Nodes {
 		ndLog := log.WithValues("node", nd.Name)
-		gpuAllocatable := safeQuantityToUint64(ndLog, nd.Resources.GPU.Quantity.Allocatable, stageAllocatableGPU)
+
+		cpuAllocatable := clampUint64(ndLog, nd.Resources.CPU.Quantity.Allocatable.MilliValue(), "allocatable_cpu")
+		gpuAllocatable := clampUint64(ndLog, nd.Resources.GPU.Quantity.Allocatable.Value(), "allocatable_gpu")
+		memoryAllocatable := clampUint64(ndLog, nd.Resources.Memory.Quantity.Allocatable.Value(), "allocatable_memory")
+		storageEphAllocatable := clampUint64(ndLog, nd.Resources.EphemeralStorage.Allocatable.Value(), "allocatable_storage_ephemeral")
+
 		invNode := inventoryV1.NodeMetrics{
 			Name: nd.Name,
 			Allocatable: inventoryV1.ResourcesMetric{
-				CPU:              safeMilliQuantityToUint64(ndLog, nd.Resources.CPU.Quantity.Allocatable, stageAllocatableCPU),
+				CPU:              cpuAllocatable,
 				GPU:              gpuAllocatable,
-				Memory:           safeQuantityToUint64(ndLog, nd.Resources.Memory.Quantity.Allocatable, stageAllocatableMemory),
-				StorageEphemeral: safeQuantityToUint64(ndLog, nd.Resources.EphemeralStorage.Allocatable, stageAllocatableStorageEphemeral),
+				Memory:           memoryAllocatable,
+				StorageEphemeral: storageEphAllocatable,
 			},
 		}
 
-		cpuTotal += safeMilliQuantityToUint64(ndLog, nd.Resources.CPU.Quantity.Allocatable, stageAllocatableCPU)
+		cpuTotal += cpuAllocatable
 		gpuTotal += gpuAllocatable
-		memoryTotal += safeQuantityToUint64(ndLog, nd.Resources.Memory.Quantity.Allocatable, stageAllocatableMemory)
-		storageEphemeralTotal += safeQuantityToUint64(ndLog, nd.Resources.EphemeralStorage.Allocatable, stageAllocatableStorageEphemeral)
+		memoryTotal += memoryAllocatable
+		storageEphemeralTotal += storageEphAllocatable
 
-		avail := nd.Resources.CPU.Quantity.Available()
-		invNode.Available.CPU = safeMilliQuantityToUint64(ndLog, avail, stageAvailableCPU)
+		invNode.Available.CPU = clampAvailableUint64(ndLog, nd.Resources.CPU.Quantity.Allocatable, nd.Resources.CPU.Quantity.Available().MilliValue(), "available_cpu")
 		cpuAvailable += invNode.Available.CPU
 
-		avail = nd.Resources.GPU.Quantity.Available()
-		if nd.Resources.GPU.Quantity.Allocatable != nil && nd.Resources.GPU.Quantity.Allocatable.Value() < 0 {
-			ndLog.Error(errNegativeQuantityClamped, stageAvailableGPU+" clamped: allocatable negative (device plugin)", "allocatable", nd.Resources.GPU.Quantity.Allocatable.Value())
-			invNode.Available.GPU = 0
-		} else {
-			allocatableVal := int64(0)
-			allocatedVal := int64(0)
-			if nd.Resources.GPU.Quantity.Allocatable != nil {
-				allocatableVal = nd.Resources.GPU.Quantity.Allocatable.Value()
-			}
-			if nd.Resources.GPU.Quantity.Allocated != nil {
-				allocatedVal = nd.Resources.GPU.Quantity.Allocated.Value()
-			}
-			invNode.Available.GPU = safeQuantityToUint64(ndLog, avail, stageAvailableGPU, "allocatable", allocatableVal, "allocated", allocatedVal)
-		}
+		invNode.Available.GPU = clampAvailableUint64(ndLog, nd.Resources.GPU.Quantity.Allocatable, nd.Resources.GPU.Quantity.Available().Value(), "available_gpu")
 		gpuAvailable += invNode.Available.GPU
 
-		avail = nd.Resources.Memory.Quantity.Available()
-		invNode.Available.Memory = safeQuantityToUint64(ndLog, avail, stageAvailableMemory)
+		invNode.Available.Memory = clampAvailableUint64(ndLog, nd.Resources.Memory.Quantity.Allocatable, nd.Resources.Memory.Quantity.Available().Value(), "available_memory")
 		memoryAvailable += invNode.Available.Memory
 
-		avail = nd.Resources.EphemeralStorage.Available()
-		invNode.Available.StorageEphemeral = safeQuantityToUint64(ndLog, avail, stageAvailableStorageEphemeral)
+		invNode.Available.StorageEphemeral = clampAvailableUint64(ndLog, nd.Resources.EphemeralStorage.Allocatable, nd.Resources.EphemeralStorage.Available().Value(), "available_storage_ephemeral")
 		storageEphemeralAvailable += invNode.Available.StorageEphemeral
 
 		ret.Nodes = append(ret.Nodes, invNode)
@@ -433,10 +402,8 @@ func (inv *inventory) Metrics() inventoryV1.Metrics {
 
 	for _, class := range inv.Storage {
 		classLog := log.WithValues("storageClass", class.Info.Class)
-		storageTotal[class.Info.Class] = safeQuantityToUint64(classLog, class.Quantity.Allocatable, stageAllocatableStorage)
-
-		tmp := class.Quantity.Available()
-		storageAvailable[class.Info.Class] = safeQuantityToUint64(classLog, tmp, stageAvailableStorage)
+		storageTotal[class.Info.Class] = clampUint64(classLog, class.Quantity.Allocatable.Value(), "allocatable_storage")
+		storageAvailable[class.Info.Class] = clampAvailableUint64(classLog, class.Quantity.Allocatable, class.Quantity.Available().Value(), "available_storage")
 	}
 
 	ret.TotalAllocatable = inventoryV1.MetricTotal{

--- a/cluster/kube/operators/clients/inventory/inventory.go
+++ b/cluster/kube/operators/clients/inventory/inventory.go
@@ -25,7 +25,7 @@ import (
 var (
 	_ ctypes.Inventory = (*inventory)(nil)
 
-	errNegativeQuantity = errors.New("negative resource quantity clamped to 0")
+	errNegativeQuantity = errors.New("negative resource quantity")
 	quantityZero        = resource.NewQuantity(0, resource.DecimalSI)
 )
 
@@ -37,12 +37,13 @@ func clampUint64(log logr.Logger, v int64, what string) uint64 {
 	return uint64(v)
 }
 
-// clampAvailableUint64 guards against ResourcePair.Available() returning MaxInt64
-// when allocatable is -1 (the "unlimited" sentinel). If allocatable is negative
-// for any reason, the Available() result is unreliable.
+// clampAvailableUint64 is a defense-in-depth guard for ResourcePair.Available().
+// Available() treats allocatable == -1 as an "unlimited" sentinel and returns MaxInt64.
+// Normal code path sanitizes inputs so -1 never reaches here, but if it did
+// (e.g. skipped sanitization), the uint64 result would be catastrophically wrong.
 func clampAvailableUint64(log logr.Logger, allocatable *resource.Quantity, v int64, what string) uint64 {
 	if allocatable.Cmp(*quantityZero) < 0 {
-		log.Error(errNegativeQuantity, "available clamped: negative allocatable", "what", what)
+		log.Error(errNegativeQuantity, "allocatable is negative, available clamped to 0", "what", what, "allocatable", allocatable.String())
 		return 0
 	}
 	return clampUint64(log, v, what)

--- a/cluster/kube/operators/clients/inventory/inventory.go
+++ b/cluster/kube/operators/clients/inventory/inventory.go
@@ -1,15 +1,11 @@
 package inventory
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/resource"
-
 	inventoryV1 "pkg.akt.dev/go/inventory/v1"
 	dvbeta "pkg.akt.dev/go/node/deployment/v1beta4"
 	attrtypes "pkg.akt.dev/go/node/types/attributes/v1"
@@ -19,54 +15,80 @@ import (
 	ctypes "github.com/akash-network/provider/cluster/types/v1beta3"
 	cinventory "github.com/akash-network/provider/cluster/types/v1beta3/clients/inventory"
 	crd "github.com/akash-network/provider/pkg/apis/akash.network/v2beta2"
-	"github.com/akash-network/provider/tools/fromctx"
 )
 
 var (
 	_ ctypes.Inventory = (*inventory)(nil)
 
-	errNegativeQuantity = errors.New("negative resource quantity")
-	quantityZero        = resource.NewQuantity(0, resource.DecimalSI)
+	quantityZero = resource.NewQuantity(0, resource.DecimalSI)
 )
 
-func clampUint64(log logr.Logger, v int64, what string) uint64 {
-	if v < 0 {
-		log.Error(errNegativeQuantity, "clamped to 0", "what", what, "value", v)
-		return 0
-	}
-	return uint64(v)
-}
+func newInventory(clState inventoryV1.Cluster) *inventory {
+	raw := *clState.Dup()
+	safe := *clState.Dup()
+	sanitizeCluster(&safe)
 
-// clampAvailableUint64 is a defense-in-depth guard for ResourcePair.Available().
-// Available() treats allocatable == -1 as an "unlimited" sentinel and returns MaxInt64.
-// Normal code path sanitizes inputs so -1 never reaches here, but if it did
-// (e.g. skipped sanitization), the uint64 result would be catastrophically wrong.
-func clampAvailableUint64(log logr.Logger, allocatable *resource.Quantity, v int64, what string) uint64 {
-	if allocatable.Cmp(*quantityZero) < 0 {
-		log.Error(errNegativeQuantity, "allocatable is negative, available clamped to 0", "what", what, "allocatable", allocatable.String())
-		return 0
+	inv := &inventory{
+		Cluster: raw,
+		safe:    safe,
 	}
-	return clampUint64(log, v, what)
-}
 
-func newInventory(ctx context.Context, clState inventoryV1.Cluster) *inventory {
-	return &inventory{
-		Cluster: clState,
-		ctx:     ctx,
-	}
+	return inv
 }
 
 func (inv *inventory) dup() inventory {
-	return inventory{
+	dup := inventory{
 		Cluster: *inv.Cluster.Dup(),
-		ctx:     inv.ctx,
+		safe:    *inv.safe.Dup(),
 	}
+
+	return dup
+}
+
+func (inv *inventory) safeDup() inventory {
+	dup := inventory{
+		Cluster: *inv.safe.Dup(),
+		safe:    *inv.safe.Dup(),
+	}
+
+	return dup
 }
 
 func (inv *inventory) Dup() ctypes.Inventory {
 	dup := inv.dup()
 
 	return &dup
+}
+
+func sanitizeCluster(cluster *inventoryV1.Cluster) {
+	for idx := range cluster.Nodes {
+		sanitizeNodeResources(&cluster.Nodes[idx].Resources)
+	}
+
+	for idx := range cluster.Storage {
+		sanitizeResourcePair(&cluster.Storage[idx].Quantity)
+	}
+}
+
+func sanitizeNodeResources(resources *inventoryV1.NodeResources) {
+	sanitizeResourcePair(&resources.CPU.Quantity)
+	sanitizeResourcePair(&resources.Memory.Quantity)
+	sanitizeResourcePair(&resources.GPU.Quantity)
+	sanitizeResourcePair(&resources.EphemeralStorage)
+	sanitizeResourcePair(&resources.VolumesAttached)
+	sanitizeResourcePair(&resources.VolumesMounted)
+}
+
+func sanitizeResourcePair(pair *inventoryV1.ResourcePair) {
+	sanitizeQuantity(pair.Capacity)
+	sanitizeQuantity(pair.Allocatable)
+	sanitizeQuantity(pair.Allocated)
+}
+
+func sanitizeQuantity(quantity *resource.Quantity) {
+	if quantity.Cmp(*quantityZero) < 0 {
+		quantity.Set(0)
+	}
 }
 
 // tryAdjust cluster inventory
@@ -264,7 +286,7 @@ func (inv *inventory) Adjust(reservation ctypes.ReservationGroup, opts ...ctypes
 
 	cparams := make(crd.ReservationClusterSettings)
 
-	currInventory := inv.dup()
+	currInventory := inv.safeDup()
 
 	var err error
 
@@ -324,7 +346,7 @@ nodes:
 
 	if len(resources) == 0 {
 		if !cfg.DryRun {
-			*inv = currInventory
+			inv.safe = *currInventory.Cluster.Dup()
 		}
 
 		reservation.SetAllocatedResources(adjustedResources)
@@ -341,10 +363,12 @@ nodes:
 }
 
 func (inv *inventory) Snapshot() inventoryV1.Cluster {
-	return *inv.Cluster.Dup()
+	return *inv.safe.Dup()
 }
 
 func (inv *inventory) Metrics() inventoryV1.Metrics {
+	safe := inv.safeDup()
+
 	cpuTotal := uint64(0)
 	gpuTotal := uint64(0)
 	memoryTotal := uint64(0)
@@ -358,52 +382,50 @@ func (inv *inventory) Metrics() inventoryV1.Metrics {
 	storageAvailable := make(map[string]uint64)
 
 	ret := inventoryV1.Metrics{
-		Nodes: make([]inventoryV1.NodeMetrics, 0, len(inv.Nodes)),
+		Nodes: make([]inventoryV1.NodeMetrics, 0, len(safe.Nodes)),
 	}
 
-	log := fromctx.LogrFromCtx(inv.ctx).WithName("inventory.metrics")
-	for _, nd := range inv.Nodes {
-		ndLog := log.WithValues("node", nd.Name)
-
-		cpuAllocatable := clampUint64(ndLog, nd.Resources.CPU.Quantity.Allocatable.MilliValue(), "allocatable_cpu")
-		gpuAllocatable := clampUint64(ndLog, nd.Resources.GPU.Quantity.Allocatable.Value(), "allocatable_gpu")
-		memoryAllocatable := clampUint64(ndLog, nd.Resources.Memory.Quantity.Allocatable.Value(), "allocatable_memory")
-		storageEphAllocatable := clampUint64(ndLog, nd.Resources.EphemeralStorage.Allocatable.Value(), "allocatable_storage_ephemeral")
-
+	for _, nd := range safe.Nodes {
 		invNode := inventoryV1.NodeMetrics{
 			Name: nd.Name,
 			Allocatable: inventoryV1.ResourcesMetric{
-				CPU:              cpuAllocatable,
-				GPU:              gpuAllocatable,
-				Memory:           memoryAllocatable,
-				StorageEphemeral: storageEphAllocatable,
+				CPU:              uint64(nd.Resources.CPU.Quantity.Allocatable.MilliValue()), // nolint: gosec
+				GPU:              uint64(nd.Resources.GPU.Quantity.Allocatable.Value()),      // nolint: gosec
+				Memory:           uint64(nd.Resources.Memory.Quantity.Allocatable.Value()),   // nolint: gosec
+				StorageEphemeral: uint64(nd.Resources.EphemeralStorage.Allocatable.Value()),  // nolint: gosec
 			},
 		}
 
-		cpuTotal += cpuAllocatable
-		gpuTotal += gpuAllocatable
-		memoryTotal += memoryAllocatable
-		storageEphemeralTotal += storageEphAllocatable
+		cpuTotal += uint64(nd.Resources.CPU.Quantity.Allocatable.MilliValue())             // nolint: gosec
+		gpuTotal += uint64(nd.Resources.GPU.Quantity.Allocatable.Value())                  // nolint: gosec
+		memoryTotal += uint64(nd.Resources.Memory.Quantity.Allocatable.Value())            // nolint: gosec
+		storageEphemeralTotal += uint64(nd.Resources.EphemeralStorage.Allocatable.Value()) // nolint: gosec
 
-		invNode.Available.CPU = clampAvailableUint64(ndLog, nd.Resources.CPU.Quantity.Allocatable, nd.Resources.CPU.Quantity.Available().MilliValue(), "available_cpu")
+		avail := nd.Resources.CPU.Quantity.Available()
+		invNode.Available.CPU = uint64(avail.MilliValue()) // nolint: gosec
 		cpuAvailable += invNode.Available.CPU
 
-		invNode.Available.GPU = clampAvailableUint64(ndLog, nd.Resources.GPU.Quantity.Allocatable, nd.Resources.GPU.Quantity.Available().Value(), "available_gpu")
+		avail = nd.Resources.GPU.Quantity.Available()
+		invNode.Available.GPU = uint64(avail.Value()) // nolint: gosec
 		gpuAvailable += invNode.Available.GPU
 
-		invNode.Available.Memory = clampAvailableUint64(ndLog, nd.Resources.Memory.Quantity.Allocatable, nd.Resources.Memory.Quantity.Available().Value(), "available_memory")
+		avail = nd.Resources.Memory.Quantity.Available()
+		invNode.Available.Memory = uint64(avail.Value()) // nolint: gosec
 		memoryAvailable += invNode.Available.Memory
 
-		invNode.Available.StorageEphemeral = clampAvailableUint64(ndLog, nd.Resources.EphemeralStorage.Allocatable, nd.Resources.EphemeralStorage.Available().Value(), "available_storage_ephemeral")
+		avail = nd.Resources.EphemeralStorage.Available()
+		invNode.Available.StorageEphemeral = uint64(avail.Value()) // nolint: gosec
 		storageEphemeralAvailable += invNode.Available.StorageEphemeral
 
 		ret.Nodes = append(ret.Nodes, invNode)
 	}
 
-	for _, class := range inv.Storage {
-		classLog := log.WithValues("storageClass", class.Info.Class)
-		storageTotal[class.Info.Class] = clampUint64(classLog, class.Quantity.Allocatable.Value(), "allocatable_storage")
-		storageAvailable[class.Info.Class] = clampAvailableUint64(classLog, class.Quantity.Allocatable, class.Quantity.Available().Value(), "available_storage")
+	for _, class := range safe.Storage {
+		tmp := class.Quantity.Allocatable.DeepCopy()
+		storageTotal[class.Info.Class] = uint64(tmp.Value()) //nolint: gosec
+
+		tmp = *class.Quantity.Available()
+		storageAvailable[class.Info.Class] = uint64(tmp.Value()) //nolint: gosec
 	}
 
 	ret.TotalAllocatable = inventoryV1.MetricTotal{

--- a/operator/inventory/ceph.go
+++ b/operator/inventory/ceph.go
@@ -336,7 +336,13 @@ func (c *ceph) run(startch chan<- struct{}) error {
 
 						delete(pvMap, obj.Name)
 
-						scs[obj.Spec.StorageClassName].allocated.Sub(res)
+						sc, exists := scs[obj.Spec.StorageClassName]
+						if !exists {
+							log.Error(fmt.Errorf("storage class %q is not tracked", obj.Spec.StorageClassName), "persistent volume delete event references untracked storage class", "driver", "ceph", "storage_class", obj.Spec.StorageClassName, "persistent_volume", obj.Name, "persistent_volume_id", string(obj.UID))
+							break
+						}
+
+						subStorageAllocatedResource(log, "ceph", obj.Spec.StorageClassName, obj.Name, string(obj.UID), sc.allocated, res, cephStorageInventoryLogValue(scs))
 					}
 					signalScrape()
 				}

--- a/operator/inventory/diagnostics.go
+++ b/operator/inventory/diagnostics.go
@@ -1,0 +1,199 @@
+package inventory
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/resource"
+	inventoryV1 "pkg.akt.dev/go/inventory/v1"
+)
+
+var (
+	errNegativeAllocatedResource = errors.New("inventory allocated resource went negative")
+	errNegativeInventoryResource = errors.New("inventory resource went negative")
+	quantityZero                 = resource.NewQuantity(0, resource.DecimalSI)
+)
+
+type allocatedStorageChange struct {
+	Driver             string `json:"driver"`
+	StorageClass       string `json:"storage_class"`
+	PersistentVolume   string `json:"persistent_volume"`
+	PersistentVolumeID string `json:"persistent_volume_id"`
+	AllocatedBefore    string `json:"allocated_before"`
+	Subtracted         string `json:"subtracted"`
+	AllocatedAfter     string `json:"allocated_after"`
+}
+
+type negativeInventoryResource struct {
+	Scope        string `json:"scope"`
+	Node         string `json:"node,omitempty"`
+	StorageClass string `json:"storage_class,omitempty"`
+	Resource     string `json:"resource"`
+	Field        string `json:"field"`
+	Value        string `json:"value"`
+}
+
+type storageAccountingLogEntry struct {
+	Driver         string `json:"driver"`
+	Class          string `json:"class"`
+	Allocated      string `json:"allocated"`
+	IsCeph         bool   `json:"is_ceph,omitempty"`
+	IsRancher      bool   `json:"is_rancher,omitempty"`
+	IsAkashManaged bool   `json:"is_akash_managed"`
+	Pool           string `json:"pool,omitempty"`
+	ClusterID      string `json:"cluster_id,omitempty"`
+}
+
+func jsonLogValue(value interface{}) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("json marshal error %v", err)
+	}
+
+	return string(data)
+}
+
+func subStorageAllocatedResource(
+	log logr.Logger,
+	driver string,
+	class string,
+	persistentVolume string,
+	persistentVolumeID string,
+	allocated *resource.Quantity,
+	val resource.Quantity,
+	inventoryBefore interface{},
+) {
+	before := allocated.DeepCopy()
+	after := allocated.DeepCopy()
+	after.Sub(val)
+
+	if after.Cmp(*quantityZero) < 0 {
+		change := allocatedStorageChange{
+			Driver:             driver,
+			StorageClass:       class,
+			PersistentVolume:   persistentVolume,
+			PersistentVolumeID: persistentVolumeID,
+			AllocatedBefore:    before.String(),
+			Subtracted:         val.String(),
+			AllocatedAfter:     after.String(),
+		}
+
+		log.Error(errNegativeAllocatedResource, "inventory storage allocated resource went negative",
+			"driver", driver,
+			"storage_class", class,
+			"persistent_volume", persistentVolume,
+			"persistent_volume_id", persistentVolumeID,
+			"inventory_before", jsonLogValue(inventoryBefore),
+			"change", jsonLogValue(change))
+	}
+
+	*allocated = after
+}
+
+func logNegativeClusterInventory(log logr.Logger, cluster *inventoryV1.Cluster, source string) {
+	negatives := negativeInventoryResources(cluster)
+	if len(negatives) == 0 {
+		return
+	}
+
+	log.Error(errNegativeInventoryResource, "inventory contains negative resource quantity",
+		"source", source,
+		"inventory", jsonLogValue(cluster),
+		"negative_resources", jsonLogValue(negatives))
+}
+
+func negativeInventoryResources(cluster *inventoryV1.Cluster) []negativeInventoryResource {
+	var result []negativeInventoryResource
+
+	for _, node := range cluster.Nodes {
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "cpu", &node.Resources.CPU.Quantity)
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "memory", &node.Resources.Memory.Quantity)
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "gpu", &node.Resources.GPU.Quantity)
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "ephemeral_storage", &node.Resources.EphemeralStorage)
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "volumes_attached", &node.Resources.VolumesAttached)
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "volumes_mounted", &node.Resources.VolumesMounted)
+	}
+
+	for _, storage := range cluster.Storage {
+		result = appendNegativeResourcePair(result, "storage", "", storage.Info.Class, "storage", &storage.Quantity)
+	}
+
+	return result
+}
+
+func appendNegativeResourcePair(result []negativeInventoryResource, scope, node, class, name string, pair *inventoryV1.ResourcePair) []negativeInventoryResource {
+	result = appendNegativeQuantity(result, scope, node, class, name, "capacity", pair.Capacity)
+	result = appendNegativeQuantity(result, scope, node, class, name, "allocatable", pair.Allocatable)
+	result = appendNegativeQuantity(result, scope, node, class, name, "allocated", pair.Allocated)
+
+	return result
+}
+
+func appendNegativeQuantity(result []negativeInventoryResource, scope, node, class, name, field string, quantity *resource.Quantity) []negativeInventoryResource {
+	if quantity == nil || quantity.Cmp(*quantityZero) >= 0 {
+		return result
+	}
+
+	return append(result, negativeInventoryResource{
+		Scope:        scope,
+		Node:         node,
+		StorageClass: class,
+		Resource:     name,
+		Field:        field,
+		Value:        quantity.String(),
+	})
+}
+
+func cephStorageInventoryLogValue(scs cephStorageClasses) []storageAccountingLogEntry {
+	classes := make([]string, 0, len(scs))
+	for class := range scs {
+		classes = append(classes, class)
+	}
+	sort.Strings(classes)
+
+	result := make([]storageAccountingLogEntry, 0, len(classes))
+	for _, class := range classes {
+		params := scs[class]
+		allocated := ""
+		if params.allocated != nil {
+			allocated = params.allocated.String()
+		}
+
+		result = append(result, storageAccountingLogEntry{
+			Driver:         "ceph",
+			Class:          class,
+			Allocated:      allocated,
+			IsCeph:         params.isCeph,
+			IsAkashManaged: params.isAkashManaged,
+			Pool:           params.pool,
+			ClusterID:      params.clusterID,
+		})
+	}
+
+	return result
+}
+
+func rancherStorageInventoryLogValue(scs rancherStorageClasses) []storageAccountingLogEntry {
+	classes := make([]string, 0, len(scs))
+	for class := range scs {
+		classes = append(classes, class)
+	}
+	sort.Strings(classes)
+
+	result := make([]storageAccountingLogEntry, 0, len(classes))
+	for _, class := range classes {
+		params := scs[class]
+		result = append(result, storageAccountingLogEntry{
+			Driver:         "rancher",
+			Class:          class,
+			Allocated:      params.allocated.String(),
+			IsRancher:      params.isRancher,
+			IsAkashManaged: params.isAkashManaged,
+		})
+	}
+
+	return result
+}

--- a/operator/inventory/diagnostics_test.go
+++ b/operator/inventory/diagnostics_test.go
@@ -1,0 +1,119 @@
+package inventory
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	inventoryV1 "pkg.akt.dev/go/inventory/v1"
+)
+
+func TestSubStorageAllocatedResourceLogsAndKeepsNegative(t *testing.T) {
+	allocated := resource.MustParse("1")
+	subtracted := resource.MustParse("2")
+	inventoryBefore := map[string]string{
+		"class":     "local-path",
+		"allocated": "1",
+	}
+
+	entries := make([]capturedLogEntry, 0, 1)
+	log := logr.New(&captureSink{entries: &entries})
+
+	subStorageAllocatedResource(log, "rancher", "local-path", "pv-1", "pv-uid", &allocated, subtracted, inventoryBefore)
+
+	require.Negative(t, allocated.Value())
+	require.Len(t, entries, 1)
+	require.ErrorIs(t, entries[0].err, errNegativeAllocatedResource)
+
+	values := logValues(entries[0].values)
+	require.Equal(t, "rancher", values["driver"])
+	require.Equal(t, "local-path", values["storage_class"])
+	require.Equal(t, "pv-1", values["persistent_volume"])
+	require.Equal(t, "pv-uid", values["persistent_volume_id"])
+
+	var before map[string]string
+	require.NoError(t, json.Unmarshal([]byte(values["inventory_before"].(string)), &before))
+	require.Equal(t, inventoryBefore, before)
+
+	var change allocatedStorageChange
+	require.NoError(t, json.Unmarshal([]byte(values["change"].(string)), &change))
+	require.Equal(t, "rancher", change.Driver)
+	require.Equal(t, "local-path", change.StorageClass)
+	require.Equal(t, "pv-1", change.PersistentVolume)
+	require.Equal(t, "pv-uid", change.PersistentVolumeID)
+	require.Equal(t, "1", change.AllocatedBefore)
+	require.Equal(t, "2", change.Subtracted)
+	require.Equal(t, "-1", change.AllocatedAfter)
+}
+
+func TestLogNegativeClusterInventory(t *testing.T) {
+	cluster := inventoryV1.Cluster{
+		Nodes: inventoryV1.Nodes{
+			{
+				Name: "node1",
+				Resources: inventoryV1.NodeResources{
+					CPU: inventoryV1.CPU{
+						Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, -250, resource.DecimalSI),
+					},
+					Memory: inventoryV1.Memory{
+						Quantity: inventoryV1.NewResourcePair(1024, -1, 0, resource.DecimalSI),
+					},
+					GPU:              inventoryV1.GPU{Quantity: inventoryV1.NewResourcePair(1, 1, 0, resource.DecimalSI)},
+					EphemeralStorage: inventoryV1.NewResourcePair(10, 10, 0, resource.DecimalSI),
+					VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+					VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+				},
+			},
+		},
+		Storage: inventoryV1.ClusterStorage{
+			{
+				Quantity: inventoryV1.NewResourcePair(10, -1, 0, resource.DecimalSI),
+				Info:     inventoryV1.StorageInfo{Class: "default"},
+			},
+		},
+	}
+
+	entries := make([]capturedLogEntry, 0, 1)
+	log := logr.New(&captureSink{entries: &entries})
+
+	logNegativeClusterInventory(log, &cluster, "unit-test")
+
+	require.Len(t, entries, 1)
+	require.ErrorIs(t, entries[0].err, errNegativeInventoryResource)
+
+	values := logValues(entries[0].values)
+	require.Equal(t, "unit-test", values["source"])
+
+	var loggedCluster inventoryV1.Cluster
+	require.NoError(t, json.Unmarshal([]byte(values["inventory"].(string)), &loggedCluster))
+	require.Equal(t, int64(-250), loggedCluster.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
+	require.Equal(t, int64(-1), loggedCluster.Storage[0].Quantity.Allocatable.Value())
+
+	var negatives []negativeInventoryResource
+	require.NoError(t, json.Unmarshal([]byte(values["negative_resources"].(string)), &negatives))
+	require.ElementsMatch(t, []negativeInventoryResource{
+		{
+			Scope:    "node",
+			Node:     "node1",
+			Resource: "cpu",
+			Field:    "allocated",
+			Value:    "-250m",
+		},
+		{
+			Scope:    "node",
+			Node:     "node1",
+			Resource: "memory",
+			Field:    "allocatable",
+			Value:    "-1",
+		},
+		{
+			Scope:        "storage",
+			StorageClass: "default",
+			Resource:     "storage",
+			Field:        "allocatable",
+			Value:        "-1",
+		},
+	}, negatives)
+}

--- a/operator/inventory/node-discovery.go
+++ b/operator/inventory/node-discovery.go
@@ -33,8 +33,9 @@ import (
 )
 
 var (
-	errWorkerExit         = errors.New("worker finished")
-	errInvalidGPUQuantity = errors.New("invalid GPU quantity from node, clamping to 0")
+	errWorkerExit              = errors.New("worker finished")
+	errInvalidGPUQuantity      = errors.New("invalid GPU quantity from node, clamping to 0")
+	errAllocatedUnderflowClamp = errors.New("allocated underflow (event reorder or duplicate delete), clamped to 0")
 
 	labelNvidiaComGPUPresent = fmt.Sprintf("%s.present", builder.ResourceGPUNvidia)
 )
@@ -351,6 +352,10 @@ initloop:
 	}
 }
 
+func podKey(pod *corev1.Pod) string {
+	return pod.Namespace + "/" + pod.Name
+}
+
 func isPodAllocated(status corev1.PodStatus) bool {
 	for _, condition := range status.Conditions {
 		if condition.Type == corev1.PodScheduled {
@@ -429,10 +434,8 @@ func (dp *nodeDiscovery) monitor() error {
 
 	restartPodsWatcher := func() error {
 		if podsWatch != nil {
-			select {
-			case <-podsWatch.ResultChan():
-			default:
-			}
+			podsWatch.Stop()
+			podsWatch = nil
 		}
 
 		var terr error
@@ -465,7 +468,7 @@ func (dp *nodeDiscovery) monitor() error {
 
 			addPodAllocatedResources(&node, pod)
 
-			currPods[pod.Name] = *pod
+			currPods[podKey(pod)] = *pod
 		}
 
 		return nil
@@ -528,21 +531,22 @@ func (dp *nodeDiscovery) monitor() error {
 			evt := rEvt.(watch.Event)
 			switch obj := evt.Object.(type) {
 			case *corev1.Node:
-				if obj.Name == dp.name {
-					switch evt.Type {
-					case watch.Modified:
-						if nodeAllocatableChanged(knode, obj) {
-							updateNodeInfo(ctx, obj, &node)
-							if err = restartPodsWatcher(); err != nil {
-								return err
-							}
-						}
-
-						signalLabels()
-					}
-
-					knode = obj.DeepCopy()
+				if obj.Name != dp.name {
+					continue
 				}
+				switch evt.Type {
+				case watch.Added:
+					fallthrough
+				case watch.Modified:
+					if evt.Type == watch.Added || (knode != nil && nodeAllocatableChanged(knode, obj)) {
+						updateNodeInfo(ctx, obj, &node)
+						if err = restartPodsWatcher(); err != nil {
+							return err
+						}
+					}
+					signalLabels()
+				}
+				knode = obj.DeepCopy()
 			}
 		case res, isopen := <-podsWatch.ResultChan():
 			if !isopen {
@@ -555,24 +559,25 @@ func (dp *nodeDiscovery) monitor() error {
 			}
 
 			obj := res.Object.(*corev1.Pod)
+			key := podKey(obj)
 			switch res.Type {
 			case watch.Added:
 				fallthrough
 			case watch.Modified:
-				if _, exists := currPods[obj.Name]; !exists && isPodAllocated(obj.Status) {
-					currPods[obj.Name] = *obj.DeepCopy()
+				if _, exists := currPods[key]; !exists && isPodAllocated(obj.Status) {
+					currPods[key] = *obj.DeepCopy()
 					addPodAllocatedResources(&node, obj)
 				}
 			case watch.Deleted:
-				pod, exists := currPods[obj.Name]
+				pod, exists := currPods[key]
 				if !exists {
 					log.Info("received pod delete event for item that does not exist. check node inventory logic, it's might have bug in it!")
 					break
 				}
 
-				subPodAllocatedResources(&node, &pod)
+				subPodAllocatedResources(log, &node, &pod)
 
-				delete(currPods, obj.Name)
+				delete(currPods, key)
 			}
 			signalState()
 		case <-statech:
@@ -745,29 +750,31 @@ func addPodAllocatedResources(node *v1.Node, pod *corev1.Pod) {
 	}
 }
 
-func subAllocatedNLZ(allocated *resource.Quantity, val resource.Quantity) {
-	newVal := allocated.Value() - val.Value()
-	if newVal < 0 {
-		newVal = 0
+func subAllocatedNLZ(log logr.Logger, nodeName, resourceName string, allocated *resource.Quantity, val resource.Quantity) {
+	before := allocated.DeepCopy()
+	allocated.Sub(val)
+	zero := resource.NewQuantity(0, resource.DecimalSI)
+	if allocated.Cmp(*zero) < 0 {
+		log.Error(errAllocatedUnderflowClamp, "allocated underflow clamped", "node", nodeName, "resource", resourceName, "allocated_before", before.String(), "subtracted", val.String())
+		allocated.Set(0)
 	}
-
-	allocated.Set(newVal)
 }
 
-func subPodAllocatedResources(node *v1.Node, pod *corev1.Pod) {
+func subPodAllocatedResources(log logr.Logger, node *v1.Node, pod *corev1.Pod) {
+	nodeName := node.Name
 	for _, container := range pod.Spec.Containers {
 		for name, quantity := range container.Resources.Requests {
 			switch name {
 			case corev1.ResourceCPU:
-				subAllocatedNLZ(node.Resources.CPU.Quantity.Allocated, quantity)
+				subAllocatedNLZ(log, nodeName, string(corev1.ResourceCPU), node.Resources.CPU.Quantity.Allocated, quantity)
 			case corev1.ResourceMemory:
-				subAllocatedNLZ(node.Resources.Memory.Quantity.Allocated, quantity)
+				subAllocatedNLZ(log, nodeName, string(corev1.ResourceMemory), node.Resources.Memory.Quantity.Allocated, quantity)
 			case corev1.ResourceEphemeralStorage:
-				subAllocatedNLZ(node.Resources.EphemeralStorage.Allocated, quantity)
+				subAllocatedNLZ(log, nodeName, string(corev1.ResourceEphemeralStorage), node.Resources.EphemeralStorage.Allocated, quantity)
 			case builder.ResourceGPUNvidia:
 				fallthrough
 			case builder.ResourceGPUAMD:
-				subAllocatedNLZ(node.Resources.GPU.Quantity.Allocated, quantity)
+				subAllocatedNLZ(log, nodeName, string(name), node.Resources.GPU.Quantity.Allocated, quantity)
 			}
 		}
 
@@ -776,7 +783,7 @@ func subPodAllocatedResources(node *v1.Node, pod *corev1.Pod) {
 				continue
 			}
 
-			subAllocatedNLZ(node.Resources.Memory.Quantity.Allocated, *vol.EmptyDir.SizeLimit)
+			subAllocatedNLZ(log, nodeName, "memory.emptydir", node.Resources.Memory.Quantity.Allocated, *vol.EmptyDir.SizeLimit)
 		}
 	}
 }

--- a/operator/inventory/node-discovery.go
+++ b/operator/inventory/node-discovery.go
@@ -34,15 +34,18 @@ import (
 
 var (
 	errWorkerExit              = errors.New("worker finished")
-	errInvalidGPUQuantity      = errors.New("invalid GPU quantity from node, clamping to 0")
+	errInvalidResourceQuantity = errors.New("invalid resource quantity from node, clamping to 0")
 	errAllocatedUnderflowClamp = errors.New("allocated underflow (event reorder or duplicate delete), clamped to 0")
+	errGPUExceedsCapacity      = errors.New("GPU allocatable exceeds capacity")
+
+	quantityZero = resource.NewQuantity(0, resource.DecimalSI)
 
 	labelNvidiaComGPUPresent = fmt.Sprintf("%s.present", builder.ResourceGPUNvidia)
 )
 
-func sanitizeGPUQuantity(log logr.Logger, nodeName, resourceName string, val int64) int64 {
+func sanitizeResourceQuantity(log logr.Logger, nodeName, resourceName string, val int64) int64 {
 	if val < 0 {
-		log.Error(errInvalidGPUQuantity, "invalid GPU quantity from node, clamping to 0", "node", nodeName, "resource", resourceName, "value", val)
+		log.Error(errInvalidResourceQuantity, "clamping to 0", "node", nodeName, "resource", resourceName, "value", val)
 		return 0
 	}
 	return val
@@ -685,31 +688,39 @@ func updateNodeInfo(ctx context.Context, knode *corev1.Node, node *v1.Node) {
 	for name, r := range knode.Status.Allocatable {
 		switch name {
 		case corev1.ResourceCPU:
-			node.Resources.CPU.Quantity.Allocatable.SetMilli(r.MilliValue())
+			node.Resources.CPU.Quantity.Allocatable.SetMilli(sanitizeResourceQuantity(log, knode.Name, string(name), r.MilliValue()))
 		case corev1.ResourceMemory:
-			node.Resources.Memory.Quantity.Allocatable.Set(r.Value())
+			node.Resources.Memory.Quantity.Allocatable.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
 		case corev1.ResourceEphemeralStorage:
-			node.Resources.EphemeralStorage.Allocatable.Set(r.Value())
+			node.Resources.EphemeralStorage.Allocatable.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
 		case builder.ResourceGPUNvidia:
 			fallthrough
 		case builder.ResourceGPUAMD:
-			node.Resources.GPU.Quantity.Allocatable.Set(sanitizeGPUQuantity(log, knode.Name, string(name), r.Value()))
+			node.Resources.GPU.Quantity.Allocatable.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
 		}
 	}
 
 	for name, r := range knode.Status.Capacity {
 		switch name {
 		case corev1.ResourceCPU:
-			node.Resources.CPU.Quantity.Capacity.SetMilli(r.MilliValue())
+			node.Resources.CPU.Quantity.Capacity.SetMilli(sanitizeResourceQuantity(log, knode.Name, string(name), r.MilliValue()))
 		case corev1.ResourceMemory:
-			node.Resources.Memory.Quantity.Capacity.Set(r.Value())
+			node.Resources.Memory.Quantity.Capacity.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
 		case corev1.ResourceEphemeralStorage:
-			node.Resources.EphemeralStorage.Capacity.Set(r.Value())
+			node.Resources.EphemeralStorage.Capacity.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
 		case builder.ResourceGPUNvidia:
 			fallthrough
 		case builder.ResourceGPUAMD:
-			node.Resources.GPU.Quantity.Capacity.Set(sanitizeGPUQuantity(log, knode.Name, string(name), r.Value()))
+			node.Resources.GPU.Quantity.Capacity.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
 		}
+	}
+
+	gpuAllocatable := node.Resources.GPU.Quantity.Allocatable.Value()
+	gpuCapacity := node.Resources.GPU.Quantity.Capacity.Value()
+	if gpuCapacity > 0 && gpuAllocatable > gpuCapacity {
+		log.Error(errGPUExceedsCapacity, "clamping allocatable to capacity",
+			"node", knode.Name, "allocatable", gpuAllocatable, "capacity", gpuCapacity)
+		node.Resources.GPU.Quantity.Allocatable.Set(gpuCapacity)
 	}
 }
 
@@ -753,8 +764,7 @@ func addPodAllocatedResources(node *v1.Node, pod *corev1.Pod) {
 func subAllocatedNLZ(log logr.Logger, nodeName, resourceName string, allocated *resource.Quantity, val resource.Quantity) {
 	before := allocated.DeepCopy()
 	allocated.Sub(val)
-	zero := resource.NewQuantity(0, resource.DecimalSI)
-	if allocated.Cmp(*zero) < 0 {
+	if allocated.Cmp(*quantityZero) < 0 {
 		log.Error(errAllocatedUnderflowClamp, "allocated underflow clamped", "node", nodeName, "resource", resourceName, "allocated_before", before.String(), "subtracted", val.String())
 		allocated.Set(0)
 	}

--- a/operator/inventory/node-discovery.go
+++ b/operator/inventory/node-discovery.go
@@ -685,6 +685,17 @@ func (dp *nodeDiscovery) initNodeInfo(gpusIDs RegistryGPUVendors, knode *corev1.
 func updateNodeInfo(ctx context.Context, knode *corev1.Node, node *v1.Node) {
 	log := fromctx.LogrFromCtx(ctx).WithName("node.monitor")
 
+	// Reset all fields before repopulating from knode so that resources
+	// removed between updates (e.g. GPU device plugin unregistered) don't leave stale values.
+	node.Resources.CPU.Quantity.Allocatable.SetMilli(0)
+	node.Resources.CPU.Quantity.Capacity.SetMilli(0)
+	node.Resources.Memory.Quantity.Allocatable.Set(0)
+	node.Resources.Memory.Quantity.Capacity.Set(0)
+	node.Resources.EphemeralStorage.Allocatable.Set(0)
+	node.Resources.EphemeralStorage.Capacity.Set(0)
+	node.Resources.GPU.Quantity.Allocatable.Set(0)
+	node.Resources.GPU.Quantity.Capacity.Set(0)
+
 	for name, r := range knode.Status.Allocatable {
 		switch name {
 		case corev1.ResourceCPU:
@@ -717,7 +728,7 @@ func updateNodeInfo(ctx context.Context, knode *corev1.Node, node *v1.Node) {
 
 	gpuAllocatable := node.Resources.GPU.Quantity.Allocatable.Value()
 	gpuCapacity := node.Resources.GPU.Quantity.Capacity.Value()
-	if gpuCapacity > 0 && gpuAllocatable > gpuCapacity {
+	if gpuAllocatable > gpuCapacity {
 		log.Error(errGPUExceedsCapacity, "clamping allocatable to capacity",
 			"node", knode.Name, "allocatable", gpuAllocatable, "capacity", gpuCapacity)
 		node.Resources.GPU.Quantity.Allocatable.Set(gpuCapacity)

--- a/operator/inventory/node-discovery.go
+++ b/operator/inventory/node-discovery.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/jaypipes/ghw/pkg/cpu"
 	"github.com/jaypipes/ghw/pkg/gpu"
 	"github.com/jaypipes/ghw/pkg/memory"
@@ -32,10 +33,19 @@ import (
 )
 
 var (
-	errWorkerExit = errors.New("worker finished")
+	errWorkerExit         = errors.New("worker finished")
+	errInvalidGPUQuantity = errors.New("invalid GPU quantity from node, clamping to 0")
 
 	labelNvidiaComGPUPresent = fmt.Sprintf("%s.present", builder.ResourceGPUNvidia)
 )
+
+func sanitizeGPUQuantity(log logr.Logger, nodeName, resourceName string, val int64) int64 {
+	if val < 0 {
+		log.Error(errInvalidGPUQuantity, "invalid GPU quantity from node, clamping to 0", "node", nodeName, "resource", resourceName, "value", val)
+		return 0
+	}
+	return val
+}
 
 type k8sPatch struct {
 	Op    string      `json:"op"`
@@ -522,7 +532,7 @@ func (dp *nodeDiscovery) monitor() error {
 					switch evt.Type {
 					case watch.Modified:
 						if nodeAllocatableChanged(knode, obj) {
-							updateNodeInfo(obj, &node)
+							updateNodeInfo(ctx, obj, &node)
 							if err = restartPodsWatcher(); err != nil {
 								return err
 							}
@@ -659,12 +669,14 @@ func (dp *nodeDiscovery) initNodeInfo(gpusIDs RegistryGPUVendors, knode *corev1.
 		},
 	}
 
-	updateNodeInfo(knode, &res)
+	updateNodeInfo(dp.ctx, knode, &res)
 
 	return res
 }
 
-func updateNodeInfo(knode *corev1.Node, node *v1.Node) {
+func updateNodeInfo(ctx context.Context, knode *corev1.Node, node *v1.Node) {
+	log := fromctx.LogrFromCtx(ctx).WithName("node.monitor")
+
 	for name, r := range knode.Status.Allocatable {
 		switch name {
 		case corev1.ResourceCPU:
@@ -676,7 +688,7 @@ func updateNodeInfo(knode *corev1.Node, node *v1.Node) {
 		case builder.ResourceGPUNvidia:
 			fallthrough
 		case builder.ResourceGPUAMD:
-			node.Resources.GPU.Quantity.Allocatable.Set(r.Value())
+			node.Resources.GPU.Quantity.Allocatable.Set(sanitizeGPUQuantity(log, knode.Name, string(name), r.Value()))
 		}
 	}
 
@@ -691,7 +703,7 @@ func updateNodeInfo(knode *corev1.Node, node *v1.Node) {
 		case builder.ResourceGPUNvidia:
 			fallthrough
 		case builder.ResourceGPUAMD:
-			node.Resources.GPU.Quantity.Capacity.Set(r.Value())
+			node.Resources.GPU.Quantity.Capacity.Set(sanitizeGPUQuantity(log, knode.Name, string(name), r.Value()))
 		}
 	}
 }

--- a/operator/inventory/node-discovery.go
+++ b/operator/inventory/node-discovery.go
@@ -541,8 +541,8 @@ func (dp *nodeDiscovery) monitor() error {
 				case watch.Added:
 					fallthrough
 				case watch.Modified:
+					updateNodeInfo(ctx, obj, &node)
 					if evt.Type == watch.Added || (knode != nil && nodeAllocatableChanged(knode, obj)) {
-						updateNodeInfo(ctx, obj, &node)
 						if err = restartPodsWatcher(); err != nil {
 							return err
 						}
@@ -642,7 +642,7 @@ func nodeAllocatableChanged(prev *corev1.Node, curr *corev1.Node) bool {
 	if !changed {
 		for pres, pval := range prev.Status.Allocatable {
 			cval, exists := curr.Status.Allocatable[pres]
-			if !exists || (pval.Value() != cval.Value()) {
+			if !exists || pval.Cmp(cval) != 0 {
 				changed = true
 				break
 			}

--- a/operator/inventory/node-discovery.go
+++ b/operator/inventory/node-discovery.go
@@ -33,23 +33,10 @@ import (
 )
 
 var (
-	errWorkerExit              = errors.New("worker finished")
-	errInvalidResourceQuantity = errors.New("invalid resource quantity from node, clamping to 0")
-	errAllocatedUnderflowClamp = errors.New("allocated underflow (event reorder or duplicate delete), clamped to 0")
-	errGPUExceedsCapacity      = errors.New("GPU allocatable exceeds capacity")
-
-	quantityZero = resource.NewQuantity(0, resource.DecimalSI)
+	errWorkerExit = errors.New("worker finished")
 
 	labelNvidiaComGPUPresent = fmt.Sprintf("%s.present", builder.ResourceGPUNvidia)
 )
-
-func sanitizeResourceQuantity(log logr.Logger, nodeName, resourceName string, val int64) int64 {
-	if val < 0 {
-		log.Error(errInvalidResourceQuantity, "clamping to 0", "node", nodeName, "resource", resourceName, "value", val)
-		return 0
-	}
-	return val
-}
 
 type k8sPatch struct {
 	Op    string      `json:"op"`
@@ -440,8 +427,10 @@ func (dp *nodeDiscovery) monitor() error {
 
 	restartPodsWatcher := func() error {
 		if podsWatch != nil {
-			podsWatch.Stop()
-			podsWatch = nil
+			select {
+			case <-podsWatch.ResultChan():
+			default:
+			}
 		}
 
 		var terr error
@@ -537,20 +526,21 @@ func (dp *nodeDiscovery) monitor() error {
 			evt := rEvt.(watch.Event)
 			switch obj := evt.Object.(type) {
 			case *corev1.Node:
-				if obj.Name != dp.name {
-					continue
-				}
-				switch evt.Type {
-				case watch.Added, watch.Modified:
-					updateNodeInfo(ctx, obj, &node)
-					if evt.Type == watch.Added || (knode != nil && nodeAllocatableChanged(knode, obj)) {
-						if err = restartPodsWatcher(); err != nil {
-							return err
+				if obj.Name == dp.name {
+					switch evt.Type {
+					case watch.Modified:
+						if nodeAllocatableChanged(knode, obj) {
+							updateNodeInfo(obj, &node)
+							if err = restartPodsWatcher(); err != nil {
+								return err
+							}
 						}
+
+						signalLabels()
 					}
-					signalLabels()
+
+					knode = obj.DeepCopy()
 				}
-				knode = obj.DeepCopy()
 			}
 		case res, isopen := <-podsWatch.ResultChan():
 			if !isopen {
@@ -643,7 +633,7 @@ func nodeAllocatableChanged(prev *corev1.Node, curr *corev1.Node) bool {
 	if !changed {
 		for pres, pval := range prev.Status.Allocatable {
 			cval, exists := curr.Status.Allocatable[pres]
-			if !exists || pval.Cmp(cval) != 0 {
+			if !exists || (pval.Value() != cval.Value()) {
 				changed = true
 				break
 			}
@@ -678,61 +668,40 @@ func (dp *nodeDiscovery) initNodeInfo(gpusIDs RegistryGPUVendors, knode *corev1.
 		},
 	}
 
-	updateNodeInfo(dp.ctx, knode, &res)
+	updateNodeInfo(knode, &res)
 
 	return res
 }
 
-func updateNodeInfo(ctx context.Context, knode *corev1.Node, node *v1.Node) {
-	log := fromctx.LogrFromCtx(ctx).WithName("node.monitor")
-
-	// Reset the fields owned by node status before repopulating from knode.
-	// Pod allocation state and CPU/GPU info are maintained elsewhere.
-	node.Resources.CPU.Quantity.Allocatable.SetMilli(0)
-	node.Resources.CPU.Quantity.Capacity.SetMilli(0)
-	node.Resources.Memory.Quantity.Allocatable.Set(0)
-	node.Resources.Memory.Quantity.Capacity.Set(0)
-	node.Resources.EphemeralStorage.Allocatable.Set(0)
-	node.Resources.EphemeralStorage.Capacity.Set(0)
-	node.Resources.GPU.Quantity.Allocatable.Set(0)
-	node.Resources.GPU.Quantity.Capacity.Set(0)
-
+func updateNodeInfo(knode *corev1.Node, node *v1.Node) {
 	for name, r := range knode.Status.Allocatable {
 		switch name {
 		case corev1.ResourceCPU:
-			node.Resources.CPU.Quantity.Allocatable.SetMilli(sanitizeResourceQuantity(log, knode.Name, string(name), r.MilliValue()))
+			node.Resources.CPU.Quantity.Allocatable.SetMilli(r.MilliValue())
 		case corev1.ResourceMemory:
-			node.Resources.Memory.Quantity.Allocatable.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
+			node.Resources.Memory.Quantity.Allocatable.Set(r.Value())
 		case corev1.ResourceEphemeralStorage:
-			node.Resources.EphemeralStorage.Allocatable.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
+			node.Resources.EphemeralStorage.Allocatable.Set(r.Value())
 		case builder.ResourceGPUNvidia:
 			fallthrough
 		case builder.ResourceGPUAMD:
-			node.Resources.GPU.Quantity.Allocatable.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
+			node.Resources.GPU.Quantity.Allocatable.Set(r.Value())
 		}
 	}
 
 	for name, r := range knode.Status.Capacity {
 		switch name {
 		case corev1.ResourceCPU:
-			node.Resources.CPU.Quantity.Capacity.SetMilli(sanitizeResourceQuantity(log, knode.Name, string(name), r.MilliValue()))
+			node.Resources.CPU.Quantity.Capacity.SetMilli(r.MilliValue())
 		case corev1.ResourceMemory:
-			node.Resources.Memory.Quantity.Capacity.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
+			node.Resources.Memory.Quantity.Capacity.Set(r.Value())
 		case corev1.ResourceEphemeralStorage:
-			node.Resources.EphemeralStorage.Capacity.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
+			node.Resources.EphemeralStorage.Capacity.Set(r.Value())
 		case builder.ResourceGPUNvidia:
 			fallthrough
 		case builder.ResourceGPUAMD:
-			node.Resources.GPU.Quantity.Capacity.Set(sanitizeResourceQuantity(log, knode.Name, string(name), r.Value()))
+			node.Resources.GPU.Quantity.Capacity.Set(r.Value())
 		}
-	}
-
-	gpuAllocatable := node.Resources.GPU.Quantity.Allocatable.Value()
-	gpuCapacity := node.Resources.GPU.Quantity.Capacity.Value()
-	if gpuAllocatable > gpuCapacity {
-		log.Error(errGPUExceedsCapacity, "clamping allocatable to capacity",
-			"node", knode.Name, "allocatable", gpuAllocatable, "capacity", gpuCapacity)
-		node.Resources.GPU.Quantity.Allocatable.Set(gpuCapacity)
 	}
 }
 
@@ -773,30 +742,57 @@ func addPodAllocatedResources(node *v1.Node, pod *corev1.Pod) {
 	}
 }
 
-func subAllocatedNLZ(log logr.Logger, nodeName, resourceName string, allocated *resource.Quantity, val resource.Quantity) {
+type allocatedResourceChange struct {
+	Node            string `json:"node"`
+	Pod             string `json:"pod"`
+	PodID           string `json:"pod_id"`
+	Resource        string `json:"resource"`
+	AllocatedBefore string `json:"allocated_before"`
+	Subtracted      string `json:"subtracted"`
+	AllocatedAfter  string `json:"allocated_after"`
+}
+
+func subAllocatedResource(log logr.Logger, node *v1.Node, pod *corev1.Pod, resourceName string, allocated *resource.Quantity, val resource.Quantity) {
 	before := allocated.DeepCopy()
-	allocated.Sub(val)
-	if allocated.Cmp(*quantityZero) < 0 {
-		log.Error(errAllocatedUnderflowClamp, "allocated underflow clamped", "node", nodeName, "resource", resourceName, "allocated_before", before.String(), "subtracted", val.String())
-		allocated.Set(0)
+	after := allocated.DeepCopy()
+	after.Sub(val)
+
+	if after.Cmp(*quantityZero) < 0 {
+		change := allocatedResourceChange{
+			Node:            node.Name,
+			Pod:             podKey(pod),
+			PodID:           string(pod.UID),
+			Resource:        resourceName,
+			AllocatedBefore: before.String(),
+			Subtracted:      val.String(),
+			AllocatedAfter:  after.String(),
+		}
+
+		log.Error(errNegativeAllocatedResource, "inventory allocated resource went negative",
+			"node", node.Name,
+			"pod", change.Pod,
+			"pod_id", change.PodID,
+			"inventory_before", jsonLogValue(node),
+			"change", jsonLogValue(change))
 	}
+
+	*allocated = after
 }
 
 func subPodAllocatedResources(log logr.Logger, node *v1.Node, pod *corev1.Pod) {
-	nodeName := node.Name
 	for _, container := range pod.Spec.Containers {
 		for name, quantity := range container.Resources.Requests {
 			switch name {
 			case corev1.ResourceCPU:
-				subAllocatedNLZ(log, nodeName, string(corev1.ResourceCPU), node.Resources.CPU.Quantity.Allocated, quantity)
+				subAllocatedResource(log, node, pod, string(corev1.ResourceCPU), node.Resources.CPU.Quantity.Allocated, quantity)
 			case corev1.ResourceMemory:
-				subAllocatedNLZ(log, nodeName, string(corev1.ResourceMemory), node.Resources.Memory.Quantity.Allocated, quantity)
+				subAllocatedResource(log, node, pod, string(corev1.ResourceMemory), node.Resources.Memory.Quantity.Allocated, quantity)
 			case corev1.ResourceEphemeralStorage:
-				subAllocatedNLZ(log, nodeName, string(corev1.ResourceEphemeralStorage), node.Resources.EphemeralStorage.Allocated, quantity)
+				subAllocatedResource(log, node, pod, string(corev1.ResourceEphemeralStorage), node.Resources.EphemeralStorage.Allocated, quantity)
 			case builder.ResourceGPUNvidia:
 				fallthrough
 			case builder.ResourceGPUAMD:
-				subAllocatedNLZ(log, nodeName, string(name), node.Resources.GPU.Quantity.Allocated, quantity)
+				subAllocatedResource(log, node, pod, string(name), node.Resources.GPU.Quantity.Allocated, quantity)
 			}
 		}
 
@@ -805,7 +801,7 @@ func subPodAllocatedResources(log logr.Logger, node *v1.Node, pod *corev1.Pod) {
 				continue
 			}
 
-			subAllocatedNLZ(log, nodeName, "memory.emptydir", node.Resources.Memory.Quantity.Allocated, *vol.EmptyDir.SizeLimit)
+			subAllocatedResource(log, node, pod, "memory.emptydir", node.Resources.Memory.Quantity.Allocated, *vol.EmptyDir.SizeLimit)
 		}
 	}
 }

--- a/operator/inventory/node-discovery.go
+++ b/operator/inventory/node-discovery.go
@@ -356,7 +356,10 @@ initloop:
 }
 
 func podKey(pod *corev1.Pod) string {
-	return pod.Namespace + "/" + pod.Name
+	return k8stypes.NamespacedName{
+		Namespace: pod.Namespace,
+		Name:      pod.Name,
+	}.String()
 }
 
 func isPodAllocated(status corev1.PodStatus) bool {
@@ -538,9 +541,7 @@ func (dp *nodeDiscovery) monitor() error {
 					continue
 				}
 				switch evt.Type {
-				case watch.Added:
-					fallthrough
-				case watch.Modified:
+				case watch.Added, watch.Modified:
 					updateNodeInfo(ctx, obj, &node)
 					if evt.Type == watch.Added || (knode != nil && nodeAllocatableChanged(knode, obj)) {
 						if err = restartPodsWatcher(); err != nil {
@@ -685,8 +686,8 @@ func (dp *nodeDiscovery) initNodeInfo(gpusIDs RegistryGPUVendors, knode *corev1.
 func updateNodeInfo(ctx context.Context, knode *corev1.Node, node *v1.Node) {
 	log := fromctx.LogrFromCtx(ctx).WithName("node.monitor")
 
-	// Reset all fields before repopulating from knode so that resources
-	// removed between updates (e.g. GPU device plugin unregistered) don't leave stale values.
+	// Reset the fields owned by node status before repopulating from knode.
+	// Pod allocation state and CPU/GPU info are maintained elsewhere.
 	node.Resources.CPU.Quantity.Allocatable.SetMilli(0)
 	node.Resources.CPU.Quantity.Capacity.SetMilli(0)
 	node.Resources.Memory.Quantity.Allocatable.Set(0)

--- a/operator/inventory/node-discovery_test.go
+++ b/operator/inventory/node-discovery_test.go
@@ -9,12 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func TestSanitizeGPUQuantity(t *testing.T) {
+func TestSanitizeResourceQuantity(t *testing.T) {
 	log := logr.Discard()
 
-	assert.Equal(t, int64(10000), sanitizeGPUQuantity(log, "node1", "nvidia.com/gpu", 10000))
-	assert.Equal(t, int64(0), sanitizeGPUQuantity(log, "node1", "nvidia.com/gpu", -1))
-	assert.Equal(t, int64(0), sanitizeGPUQuantity(log, "node1", "nvidia.com/gpu", -1000))
+	assert.Equal(t, int64(10000), sanitizeResourceQuantity(log, "node1", "nvidia.com/gpu", 10000))
+	assert.Equal(t, int64(0), sanitizeResourceQuantity(log, "node1", "nvidia.com/gpu", -1))
+	assert.Equal(t, int64(0), sanitizeResourceQuantity(log, "node1", "memory", -1000))
+	assert.Equal(t, int64(0), sanitizeResourceQuantity(log, "node1", "cpu", 0))
 }
 
 func TestSubAllocatedNLZ_underflow_clamped(t *testing.T) {

--- a/operator/inventory/node-discovery_test.go
+++ b/operator/inventory/node-discovery_test.go
@@ -1,0 +1,19 @@
+package inventory
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeGPUQuantity(t *testing.T) {
+	log := logr.Discard()
+
+	// positive values should be returned as is
+	assert.Equal(t, int64(10000), sanitizeGPUQuantity(log, "node1", "nvidia.com/gpu", 10000))
+
+	// negative values should be clamped to 0
+	assert.Equal(t, int64(0), sanitizeGPUQuantity(log, "node1", "nvidia.com/gpu", -1))
+	assert.Equal(t, int64(0), sanitizeGPUQuantity(log, "node1", "nvidia.com/gpu", -1000))
+}

--- a/operator/inventory/node-discovery_test.go
+++ b/operator/inventory/node-discovery_test.go
@@ -5,15 +5,25 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestSanitizeGPUQuantity(t *testing.T) {
 	log := logr.Discard()
 
-	// positive values should be returned as is
 	assert.Equal(t, int64(10000), sanitizeGPUQuantity(log, "node1", "nvidia.com/gpu", 10000))
-
-	// negative values should be clamped to 0
 	assert.Equal(t, int64(0), sanitizeGPUQuantity(log, "node1", "nvidia.com/gpu", -1))
 	assert.Equal(t, int64(0), sanitizeGPUQuantity(log, "node1", "nvidia.com/gpu", -1000))
+}
+
+func TestSubAllocatedNLZ_underflow_clamped(t *testing.T) {
+	log := logr.Discard()
+
+	allocated := resource.NewQuantity(2, resource.DecimalSI)
+	val := resource.NewQuantity(5, resource.DecimalSI)
+
+	subAllocatedNLZ(log, "node1", "nvidia.com/gpu", allocated, *val)
+
+	require.Equal(t, int64(0), allocated.Value(), "allocated underflow must be clamped to 0")
 }

--- a/operator/inventory/node-discovery_test.go
+++ b/operator/inventory/node-discovery_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -27,4 +28,23 @@ func TestSubAllocatedNLZ_underflow_clamped(t *testing.T) {
 	subAllocatedNLZ(log, "node1", "nvidia.com/gpu", allocated, *val)
 
 	require.Equal(t, int64(0), allocated.Value(), "allocated underflow must be clamped to 0")
+}
+
+func TestNodeAllocatableChanged_detectsMilliCPUChange(t *testing.T) {
+	prev := &corev1.Node{
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("500m"),
+			},
+		},
+	}
+	curr := &corev1.Node{
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("750m"),
+			},
+		},
+	}
+
+	require.True(t, nodeAllocatableChanged(prev, curr))
 }

--- a/operator/inventory/node-discovery_test.go
+++ b/operator/inventory/node-discovery_test.go
@@ -1,50 +1,204 @@
 package inventory
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/go-logr/logr"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	v1 "pkg.akt.dev/go/inventory/v1"
+
+	"github.com/akash-network/provider/cluster/kube/builder"
 )
 
-func TestSanitizeResourceQuantity(t *testing.T) {
-	log := logr.Discard()
-
-	assert.Equal(t, int64(10000), sanitizeResourceQuantity(log, "node1", "nvidia.com/gpu", 10000))
-	assert.Equal(t, int64(0), sanitizeResourceQuantity(log, "node1", "nvidia.com/gpu", -1))
-	assert.Equal(t, int64(0), sanitizeResourceQuantity(log, "node1", "memory", -1000))
-	assert.Equal(t, int64(0), sanitizeResourceQuantity(log, "node1", "cpu", 0))
+type capturedLogEntry struct {
+	err    error
+	msg    string
+	values []interface{}
 }
 
-func TestSubAllocatedNLZ_underflow_clamped(t *testing.T) {
-	log := logr.Discard()
-
-	allocated := resource.NewQuantity(2, resource.DecimalSI)
-	val := resource.NewQuantity(5, resource.DecimalSI)
-
-	subAllocatedNLZ(log, "node1", "nvidia.com/gpu", allocated, *val)
-
-	require.Equal(t, int64(0), allocated.Value(), "allocated underflow must be clamped to 0")
+type captureSink struct {
+	entries *[]capturedLogEntry
+	values  []interface{}
 }
 
-func TestNodeAllocatableChanged_detectsMilliCPUChange(t *testing.T) {
-	prev := &corev1.Node{
-		Status: corev1.NodeStatus{
-			Allocatable: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse("500m"),
+func (s *captureSink) Init(logr.RuntimeInfo) {}
+
+func (s *captureSink) Enabled(int) bool {
+	return true
+}
+
+func (s *captureSink) Info(int, string, ...interface{}) {}
+
+func (s *captureSink) Error(err error, msg string, keysAndValues ...interface{}) {
+	values := append([]interface{}{}, s.values...)
+	values = append(values, keysAndValues...)
+	*s.entries = append(*s.entries, capturedLogEntry{
+		err:    err,
+		msg:    msg,
+		values: values,
+	})
+}
+
+func (s *captureSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	values := append([]interface{}{}, s.values...)
+	values = append(values, keysAndValues...)
+
+	return &captureSink{
+		entries: s.entries,
+		values:  values,
+	}
+}
+
+func (s *captureSink) WithName(string) logr.LogSink {
+	return &captureSink{
+		entries: s.entries,
+		values:  append([]interface{}{}, s.values...),
+	}
+}
+
+func logValues(values []interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for i := 0; i+1 < len(values); i += 2 {
+		key, ok := values[i].(string)
+		if !ok {
+			continue
+		}
+		result[key] = values[i+1]
+	}
+	return result
+}
+
+func TestSubPodAllocatedResourcesLogsAndKeepsNegative(t *testing.T) {
+	tests := []struct {
+		name            string
+		resourceName    corev1.ResourceName
+		requestQuantity string
+		changeResource  string
+		before          string
+		subtracted      string
+		after           string
+		setAllocated    func(*v1.Node)
+		allocated       func(*v1.Node) int64
+	}{
+		{
+			name:            "cpu",
+			resourceName:    corev1.ResourceCPU,
+			requestQuantity: "750m",
+			changeResource:  "cpu",
+			before:          "500m",
+			subtracted:      "750m",
+			after:           "-250m",
+			setAllocated: func(node *v1.Node) {
+				node.Resources.CPU.Quantity.Allocated.SetMilli(500)
+			},
+			allocated: func(node *v1.Node) int64 {
+				return node.Resources.CPU.Quantity.Allocated.MilliValue()
+			},
+		},
+		{
+			name:            "gpu",
+			resourceName:    builder.ResourceGPUNvidia,
+			requestQuantity: "2",
+			changeResource:  string(builder.ResourceGPUNvidia),
+			before:          "1",
+			subtracted:      "2",
+			after:           "-1",
+			setAllocated: func(node *v1.Node) {
+				node.Resources.GPU.Quantity.Allocated.Set(1)
+			},
+			allocated: func(node *v1.Node) int64 {
+				return node.Resources.GPU.Quantity.Allocated.Value()
+			},
+		},
+		{
+			name:            "memory",
+			resourceName:    corev1.ResourceMemory,
+			requestQuantity: "2",
+			changeResource:  "memory",
+			before:          "1",
+			subtracted:      "2",
+			after:           "-1",
+			setAllocated: func(node *v1.Node) {
+				node.Resources.Memory.Quantity.Allocated.Set(1)
+			},
+			allocated: func(node *v1.Node) int64 {
+				return node.Resources.Memory.Quantity.Allocated.Value()
 			},
 		},
 	}
-	curr := &corev1.Node{
-		Status: corev1.NodeStatus{
-			Allocatable: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse("750m"),
-			},
-		},
-	}
 
-	require.True(t, nodeAllocatableChanged(prev, curr))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &v1.Node{
+				Name: "node1",
+				Resources: v1.NodeResources{
+					CPU: v1.CPU{
+						Quantity: v1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
+					},
+					Memory: v1.Memory{
+						Quantity: v1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
+					},
+					GPU: v1.GPU{
+						Quantity: v1.NewResourcePair(4, 4, 0, resource.DecimalSI),
+					},
+					EphemeralStorage: v1.NewResourcePair(100, 100, 0, resource.DecimalSI),
+					VolumesAttached:  v1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+					VolumesMounted:   v1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+				},
+			}
+			tt.setAllocated(node)
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "lease-ns",
+					Name:      "web-0",
+					UID:       k8stypes.UID("pod-uid"),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "web",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									tt.resourceName: resource.MustParse(tt.requestQuantity),
+								},
+							},
+						},
+					},
+				},
+			}
+			entries := make([]capturedLogEntry, 0, 1)
+			log := logr.New(&captureSink{entries: &entries})
+
+			subPodAllocatedResources(log, node, pod)
+
+			require.Negative(t, tt.allocated(node))
+			require.Len(t, entries, 1)
+			require.ErrorIs(t, entries[0].err, errNegativeAllocatedResource)
+
+			values := logValues(entries[0].values)
+			require.Equal(t, "node1", values["node"])
+			require.Equal(t, "lease-ns/web-0", values["pod"])
+			require.Equal(t, "pod-uid", values["pod_id"])
+
+			var before v1.Node
+			require.NoError(t, json.Unmarshal([]byte(values["inventory_before"].(string)), &before))
+			require.Positive(t, tt.allocated(&before))
+
+			var change allocatedResourceChange
+			require.NoError(t, json.Unmarshal([]byte(values["change"].(string)), &change))
+			require.Equal(t, "node1", change.Node)
+			require.Equal(t, "lease-ns/web-0", change.Pod)
+			require.Equal(t, "pod-uid", change.PodID)
+			require.Equal(t, tt.changeResource, change.Resource)
+			require.Equal(t, tt.before, change.AllocatedBefore)
+			require.Equal(t, tt.subtracted, change.Subtracted)
+			require.Equal(t, tt.after, change.AllocatedAfter)
+		})
+	}
 }

--- a/operator/inventory/rancher.go
+++ b/operator/inventory/rancher.go
@@ -29,7 +29,7 @@ type rancher struct {
 type rancherStorage struct {
 	isRancher      bool
 	isAkashManaged bool
-	allocated      uint64
+	allocated      resource.Quantity
 }
 
 type rancherStorageClasses map[string]*rancherStorage
@@ -154,7 +154,7 @@ func (c *rancher) run(startch chan<- struct{}) error {
 
 					if _, exists = pvMap[obj.Name]; !exists {
 						pvMap[obj.Name] = *obj
-						params.allocated += uint64(res.Value()) // nolint: gosec
+						params.allocated.Add(res)
 					}
 				case watch.Deleted:
 					res, exists := obj.Spec.Capacity[corev1.ResourceStorage]
@@ -163,7 +163,14 @@ func (c *rancher) run(startch chan<- struct{}) error {
 					}
 
 					delete(pvMap, obj.Name)
-					scs[obj.Spec.StorageClassName].allocated -= uint64(res.Value()) // nolint: gosec
+
+					params, exists := scs[obj.Spec.StorageClassName]
+					if !exists {
+						log.Error(fmt.Errorf("storage class %q is not tracked", obj.Spec.StorageClassName), "persistent volume delete event references untracked storage class", "driver", "rancher", "storage_class", obj.Spec.StorageClassName, "persistent_volume", obj.Name, "persistent_volume_id", string(obj.UID))
+						break
+					}
+
+					subStorageAllocatedResource(log, "rancher", obj.Spec.StorageClassName, obj.Name, string(obj.UID), &params.allocated, res, rancherStorageInventoryLogValue(scs))
 				}
 
 				tryScrape()
@@ -229,7 +236,7 @@ func (c *rancher) run(startch chan<- struct{}) error {
 									continue
 								}
 
-								params.allocated += uint64(capacity.Value()) // nolint: gosec
+								params.allocated.Add(capacity)
 
 								pvMap[pv.Name] = pv
 							}
@@ -254,7 +261,7 @@ func (c *rancher) run(startch chan<- struct{}) error {
 			for class, params := range scs {
 				if params.isRancher && params.isAkashManaged {
 					res = append(res, inventory.Storage{
-						Quantity: inventory.NewResourcePair(allocatable, allocatable, int64(params.allocated), resource.DecimalSI), // nolint: gosec
+						Quantity: inventory.NewResourcePair(allocatable, allocatable, params.allocated.Value(), resource.DecimalSI),
 						Info: inventory.StorageInfo{
 							Class: class,
 						},

--- a/operator/inventory/state.go
+++ b/operator/inventory/state.go
@@ -30,6 +30,8 @@ func (s *clusterState) run() error {
 
 	defer bus.Unsub(datach)
 
+	log := fromctx.LogrFromCtx(s.ctx).WithName("cluster-state")
+
 	var cfg Config
 
 	trySignal := func() {
@@ -79,6 +81,7 @@ func (s *clusterState) run() error {
 				err: nil,
 			}
 		case <-signalch:
+			logNegativeClusterInventory(log, &state, "cluster-state")
 			bus.Pub(*state.Dup(), []string{topicInventoryCluster}, pubsub.WithRetain())
 		}
 	}


### PR DESCRIPTION
## Summary
Replaces https://github.com/akash-network/provider/pull/379 with a narrower fix for https://github.com/akash-network/support/issues/429.

This keeps raw operator inventory intact so negative resource accounting remains visible, while bid, metrics, and provider status consume a sanitized non-negative view.

It also logs forensic data when accounting goes negative: pod/PV identity, `inventory_before`, and the applied change. Rancher storage accounting now uses signed resource quantities instead of `uint64` arithmetic so underflows stay visible instead of becoming huge positive values.

Fixes akash-network/support#429.

## Validation
- `GOWORK=off go test ./operator/inventory -count=1`
- `GOWORK=off go test ./cluster/... ./operator/inventory -count=1`
- `git diff --check`