### PR TITLE
fix(inventory): add diagnostics for negative resource accounting

### DIFF
--- a/cluster/inventory.go
+++ b/cluster/inventory.go
@@ -48,6 +48,8 @@ var (
 	errInventoryReservation     = errors.New("inventory error")
 	errNoLeasedIPsAvailable     = fmt.Errorf("%w: no leased IPs available", errInventoryReservation)
 	errInsufficientIPs          = fmt.Errorf("%w: insufficient number of IPs", errInventoryReservation)
+
+	inventoryStatusQuantityZero = resource.NewQuantity(0, resource.DecimalSI)
 )
 
 var (
@@ -910,8 +912,11 @@ func (is *inventoryService) getStatusV1(state *inventoryServiceState) (*provider
 		return nil, errInventoryNotAvailableYet
 	}
 
+	cluster := state.inventory.Snapshot()
+	sanitizeStatusCluster(&cluster)
+
 	status := &provider.Inventory{
-		Cluster:  state.inventory.Snapshot(),
+		Cluster:  cluster,
 		LeasedIP: leasedIPStatus(state),
 		Reservations: provider.Reservations{
 			Pending: provider.ReservationsMetric{
@@ -937,6 +942,37 @@ func (is *inventoryService) getStatusV1(state *inventoryServiceState) (*provider
 	}
 
 	return status, nil
+}
+
+func sanitizeStatusCluster(cluster *inventoryV1.Cluster) {
+	for idx := range cluster.Nodes {
+		sanitizeStatusNodeResources(&cluster.Nodes[idx].Resources)
+	}
+
+	for idx := range cluster.Storage {
+		sanitizeStatusResourcePair(&cluster.Storage[idx].Quantity)
+	}
+}
+
+func sanitizeStatusNodeResources(resources *inventoryV1.NodeResources) {
+	sanitizeStatusResourcePair(&resources.CPU.Quantity)
+	sanitizeStatusResourcePair(&resources.Memory.Quantity)
+	sanitizeStatusResourcePair(&resources.GPU.Quantity)
+	sanitizeStatusResourcePair(&resources.EphemeralStorage)
+	sanitizeStatusResourcePair(&resources.VolumesAttached)
+	sanitizeStatusResourcePair(&resources.VolumesMounted)
+}
+
+func sanitizeStatusResourcePair(pair *inventoryV1.ResourcePair) {
+	sanitizeStatusQuantity(pair.Capacity)
+	sanitizeStatusQuantity(pair.Allocatable)
+	sanitizeStatusQuantity(pair.Allocated)
+}
+
+func sanitizeStatusQuantity(quantity *resource.Quantity) {
+	if quantity.Cmp(*inventoryStatusQuantityZero) < 0 {
+		quantity.Set(0)
+	}
 }
 
 func reservationCountEndpoints(reservation *reservation) uint {

--- a/cluster/inventory_test.go
+++ b/cluster/inventory_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	tpubsub "github.com/troian/pubsub"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes"
 	kfake "k8s.io/client-go/kubernetes/fake"
 
+	inventoryV1 "pkg.akt.dev/go/inventory/v1"
 	manifest "pkg.akt.dev/go/manifest/v2beta3"
 	dvbeta "pkg.akt.dev/go/node/deployment/v1beta4"
 	mtypes "pkg.akt.dev/go/node/market/v1"
@@ -33,6 +35,26 @@ import (
 	afake "github.com/akash-network/provider/pkg/client/clientset/versioned/fake"
 	"github.com/akash-network/provider/tools/fromctx"
 )
+
+type statusTestInventory struct {
+	snapshot inventoryV1.Cluster
+}
+
+func (inv statusTestInventory) Adjust(ctypes.ReservationGroup, ...ctypes.InventoryOption) error {
+	return nil
+}
+
+func (inv statusTestInventory) Metrics() inventoryV1.Metrics {
+	return inventoryV1.Metrics{}
+}
+
+func (inv statusTestInventory) Snapshot() inventoryV1.Cluster {
+	return *inv.snapshot.Dup()
+}
+
+func (inv statusTestInventory) Dup() ctypes.Inventory {
+	return statusTestInventory{snapshot: *inv.snapshot.Dup()}
+}
 
 func TestInventory_reservationAllocatable(t *testing.T) {
 	mkrg := func(cpu uint64, gpu uint64, memory uint64, storage uint64, endpointsCount uint, count uint32) dvbeta.ResourceUnit {
@@ -459,6 +481,53 @@ func TestInventory_StatusV1SaturatesLeasedIPResourcePairAvailable(t *testing.T) 
 	require.Equal(t, int64(3), leasedIP.GetAllocatable().Value())
 	require.Equal(t, int64(6), leasedIP.GetAllocated().Value())
 	require.Equal(t, int64(0), leasedIP.Available().Value())
+}
+
+func TestInventory_StatusV1SanitizesNegativeClusterSnapshot(t *testing.T) {
+	snapshot := inventoryV1.Cluster{
+		Nodes: inventoryV1.Nodes{
+			{
+				Name: "node",
+				Resources: inventoryV1.NodeResources{
+					CPU: inventoryV1.CPU{
+						Quantity: inventoryV1.NewResourcePairMilli(1000, -500, -250, resource.DecimalSI),
+					},
+					Memory: inventoryV1.Memory{
+						Quantity: inventoryV1.NewResourcePair(-1, 1024, -1, resource.DecimalSI),
+					},
+					GPU: inventoryV1.GPU{
+						Quantity: inventoryV1.NewResourcePair(4, -1, -1, resource.DecimalSI),
+					},
+					EphemeralStorage: inventoryV1.NewResourcePair(100, -1, -1, resource.DecimalSI),
+					VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+					VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+				},
+			},
+		},
+		Storage: inventoryV1.ClusterStorage{
+			{
+				Quantity: inventoryV1.NewResourcePair(50, -1, -1, resource.DecimalSI),
+				Info:     inventoryV1.StorageInfo{Class: "default"},
+			},
+		},
+	}
+
+	status, err := (&inventoryService{}).getStatusV1(&inventoryServiceState{
+		inventory: statusTestInventory{snapshot: snapshot},
+	})
+	require.NoError(t, err)
+
+	node := status.Cluster.Nodes[0]
+	require.Equal(t, int64(0), node.Resources.CPU.Quantity.Allocatable.MilliValue())
+	require.Equal(t, int64(0), node.Resources.CPU.Quantity.Allocated.MilliValue())
+	require.Equal(t, int64(0), node.Resources.Memory.Quantity.Capacity.Value())
+	require.Equal(t, int64(0), node.Resources.Memory.Quantity.Allocated.Value())
+	require.Equal(t, int64(0), node.Resources.GPU.Quantity.Allocatable.Value())
+	require.Equal(t, int64(0), node.Resources.GPU.Quantity.Allocated.Value())
+	require.Equal(t, int64(0), node.Resources.EphemeralStorage.Allocatable.Value())
+	require.Equal(t, int64(0), node.Resources.EphemeralStorage.Allocated.Value())
+	require.Equal(t, int64(0), status.Cluster.Storage[0].Quantity.Allocatable.Value())
+	require.Equal(t, int64(0), status.Cluster.Storage[0].Quantity.Allocated.Value())
 }
 
 func TestInventory_ReserveIPNoIPOperator(t *testing.T) {

--- a/cluster/kube/operators/clients/inventory/client.go
+++ b/cluster/kube/operators/clients/inventory/client.go
@@ -46,6 +46,7 @@ type client struct {
 
 type inventory struct {
 	inventoryV1.Cluster
+	safe inventoryV1.Cluster
 }
 
 type inventoryState struct {

--- a/cluster/kube/operators/clients/inventory/client.go
+++ b/cluster/kube/operators/clients/inventory/client.go
@@ -46,7 +46,8 @@ type client struct {
 
 type inventory struct {
 	inventoryV1.Cluster
-	safe inventoryV1.Cluster
+	// sanitized keeps the non-negative view used for bids, snapshots, and metrics.
+	sanitized inventoryV1.Cluster
 }
 
 type inventoryState struct {

--- a/cluster/kube/operators/clients/inventory/client_test.go
+++ b/cluster/kube/operators/clients/inventory/client_test.go
@@ -315,6 +315,131 @@ func TestInventoryZero(t *testing.T) {
 	require.Len(t, inv.Metrics().Nodes, 0)
 }
 
+func makeBaseCluster() inventoryV1.Cluster {
+	return inventoryV1.Cluster{
+		Nodes: inventoryV1.Nodes{
+			{
+				Name: "node",
+				Resources: inventoryV1.NodeResources{
+					CPU: inventoryV1.CPU{
+						Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
+					},
+					Memory: inventoryV1.Memory{
+						Quantity: inventoryV1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
+					},
+					GPU: inventoryV1.GPU{
+						Quantity: inventoryV1.NewResourcePair(4, 4, 0, resource.DecimalSI),
+					},
+					EphemeralStorage: inventoryV1.NewResourcePair(100, 100, 0, resource.DecimalSI),
+					VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+					VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+				},
+			},
+		},
+		Storage: inventoryV1.ClusterStorage{
+			{
+				Quantity: inventoryV1.NewResourcePair(50, 50, 0, resource.DecimalSI),
+				Info:     inventoryV1.StorageInfo{Class: "default"},
+			},
+		},
+	}
+}
+
+func TestInventorySnapshotSanitizesNegativeQuantities(t *testing.T) {
+	cluster := makeBaseCluster()
+	cluster.Nodes[0].Resources.CPU.Quantity.Allocatable.SetMilli(-500)
+	cluster.Nodes[0].Resources.CPU.Quantity.Allocated.SetMilli(-250)
+	cluster.Nodes[0].Resources.Memory.Quantity.Capacity.Set(-1)
+	cluster.Nodes[0].Resources.GPU.Quantity.Allocatable.Set(-1)
+	cluster.Nodes[0].Resources.EphemeralStorage.Allocated.Set(-1)
+	cluster.Storage[0].Quantity.Allocatable.Set(-1)
+
+	inv := newInventory(cluster)
+	snapshot := inv.Snapshot()
+
+	require.Equal(t, int64(0), snapshot.Nodes[0].Resources.CPU.Quantity.Allocatable.MilliValue())
+	require.Equal(t, int64(0), snapshot.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
+	require.Equal(t, int64(0), snapshot.Nodes[0].Resources.Memory.Quantity.Capacity.Value())
+	require.Equal(t, int64(0), snapshot.Nodes[0].Resources.GPU.Quantity.Allocatable.Value())
+	require.Equal(t, int64(0), snapshot.Nodes[0].Resources.EphemeralStorage.Allocated.Value())
+	require.Equal(t, int64(0), snapshot.Storage[0].Quantity.Allocatable.Value())
+
+	require.Equal(t, int64(-500), inv.Cluster.Nodes[0].Resources.CPU.Quantity.Allocatable.MilliValue())
+	require.Equal(t, int64(-250), inv.Cluster.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
+}
+
+func TestInventoryMetricsSanitizesNegativeQuantities(t *testing.T) {
+	cluster := makeBaseCluster()
+	cluster.Nodes[0].Resources.CPU.Quantity.Allocatable.SetMilli(-500)
+	cluster.Nodes[0].Resources.GPU.Quantity.Allocatable.Set(-1)
+	cluster.Storage[0].Quantity.Allocatable.Set(-1)
+
+	metrics := newInventory(cluster).Metrics()
+
+	require.Len(t, metrics.Nodes, 1)
+	require.Equal(t, uint64(0), metrics.Nodes[0].Allocatable.CPU)
+	require.Equal(t, uint64(0), metrics.Nodes[0].Allocatable.GPU)
+	require.Equal(t, uint64(0), metrics.TotalAllocatable.CPU)
+	require.Equal(t, uint64(0), metrics.TotalAllocatable.GPU)
+	require.Equal(t, uint64(0), metrics.TotalAllocatable.Storage["default"])
+}
+
+func TestInventoryAdjustSanitizesNegativeAllocatedBeforeBidding(t *testing.T) {
+	cluster := makeBaseCluster()
+	cluster.Nodes[0].Resources.CPU.Quantity.Allocated.SetMilli(-1000)
+
+	inv := newInventory(cluster)
+	reservation := &testReservation{
+		resources: dvbeta.GroupSpec{
+			Name: "group",
+			Resources: dvbeta.ResourceUnits{
+				{
+					Resources: rtypes.Resources{
+						ID:     1,
+						CPU:    &rtypes.CPU{Units: rtypes.NewResourceValue(1500)},
+						GPU:    &rtypes.GPU{Units: rtypes.NewResourceValue(0)},
+						Memory: &rtypes.Memory{Quantity: rtypes.NewResourceValue(1)},
+					},
+					Count: 1,
+				},
+			},
+		},
+	}
+
+	err := inv.Adjust(reservation)
+
+	require.ErrorIs(t, err, ctypes.ErrInsufficientCapacity)
+}
+
+func TestInventoryAdjustKeepsRawStateAndUpdatesSafeState(t *testing.T) {
+	cluster := makeBaseCluster()
+	cluster.Nodes[0].Resources.CPU.Quantity.Allocated.SetMilli(-1000)
+
+	inv := newInventory(cluster)
+	reservation := &testReservation{
+		resources: dvbeta.GroupSpec{
+			Name: "group",
+			Resources: dvbeta.ResourceUnits{
+				{
+					Resources: rtypes.Resources{
+						ID:     1,
+						CPU:    &rtypes.CPU{Units: rtypes.NewResourceValue(500)},
+						GPU:    &rtypes.GPU{Units: rtypes.NewResourceValue(0)},
+						Memory: &rtypes.Memory{Quantity: rtypes.NewResourceValue(1)},
+					},
+					Count: 1,
+				},
+			},
+		},
+	}
+
+	err := inv.Adjust(reservation)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(-1000), inv.Cluster.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
+	require.Equal(t, int64(500), inv.Snapshot().Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
+}
+
 func TestInventorySingleNodeNoPods(t *testing.T) {
 	const expectedCPU = 13
 	const expectedMemory = 14

--- a/cluster/kube/operators/clients/inventory/client_test.go
+++ b/cluster/kube/operators/clients/inventory/client_test.go
@@ -364,8 +364,8 @@ func TestInventorySnapshotSanitizesNegativeQuantities(t *testing.T) {
 	require.Equal(t, int64(0), snapshot.Nodes[0].Resources.EphemeralStorage.Allocated.Value())
 	require.Equal(t, int64(0), snapshot.Storage[0].Quantity.Allocatable.Value())
 
-	require.Equal(t, int64(-500), inv.Cluster.Nodes[0].Resources.CPU.Quantity.Allocatable.MilliValue())
-	require.Equal(t, int64(-250), inv.Cluster.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
+	require.Equal(t, int64(-500), inv.Nodes[0].Resources.CPU.Quantity.Allocatable.MilliValue())
+	require.Equal(t, int64(-250), inv.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
 }
 
 func TestInventoryMetricsSanitizesNegativeQuantities(t *testing.T) {
@@ -411,7 +411,7 @@ func TestInventoryAdjustSanitizesNegativeAllocatedBeforeBidding(t *testing.T) {
 	require.ErrorIs(t, err, ctypes.ErrInsufficientCapacity)
 }
 
-func TestInventoryAdjustKeepsRawStateAndUpdatesSafeState(t *testing.T) {
+func TestInventoryAdjustKeepsRawStateAndUpdatesSanitizedState(t *testing.T) {
 	cluster := makeBaseCluster()
 	cluster.Nodes[0].Resources.CPU.Quantity.Allocated.SetMilli(-1000)
 
@@ -436,7 +436,7 @@ func TestInventoryAdjustKeepsRawStateAndUpdatesSafeState(t *testing.T) {
 	err := inv.Adjust(reservation)
 
 	require.NoError(t, err)
-	require.Equal(t, int64(-1000), inv.Cluster.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
+	require.Equal(t, int64(-1000), inv.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
 	require.Equal(t, int64(500), inv.Snapshot().Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
 }
 

--- a/cluster/kube/operators/clients/inventory/inventory.go
+++ b/cluster/kube/operators/clients/inventory/inventory.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	inventoryV1 "pkg.akt.dev/go/inventory/v1"
 	dvbeta "pkg.akt.dev/go/node/deployment/v1beta4"
 	attrtypes "pkg.akt.dev/go/node/types/attributes/v1"
@@ -16,11 +17,20 @@ import (
 	crd "github.com/akash-network/provider/pkg/apis/akash.network/v2beta2"
 )
 
-var _ ctypes.Inventory = (*inventory)(nil)
+var (
+	_ ctypes.Inventory = (*inventory)(nil)
+
+	quantityZero = resource.NewQuantity(0, resource.DecimalSI)
+)
 
 func newInventory(clState inventoryV1.Cluster) *inventory {
+	raw := *clState.Dup()
+	safe := *clState.Dup()
+	sanitizeCluster(&safe)
+
 	inv := &inventory{
-		Cluster: clState,
+		Cluster: raw,
+		safe:    safe,
 	}
 
 	return inv
@@ -29,6 +39,16 @@ func newInventory(clState inventoryV1.Cluster) *inventory {
 func (inv *inventory) dup() inventory {
 	dup := inventory{
 		Cluster: *inv.Cluster.Dup(),
+		safe:    *inv.safe.Dup(),
+	}
+
+	return dup
+}
+
+func (inv *inventory) safeDup() inventory {
+	dup := inventory{
+		Cluster: *inv.safe.Dup(),
+		safe:    *inv.safe.Dup(),
 	}
 
 	return dup
@@ -38,6 +58,37 @@ func (inv *inventory) Dup() ctypes.Inventory {
 	dup := inv.dup()
 
 	return &dup
+}
+
+func sanitizeCluster(cluster *inventoryV1.Cluster) {
+	for idx := range cluster.Nodes {
+		sanitizeNodeResources(&cluster.Nodes[idx].Resources)
+	}
+
+	for idx := range cluster.Storage {
+		sanitizeResourcePair(&cluster.Storage[idx].Quantity)
+	}
+}
+
+func sanitizeNodeResources(resources *inventoryV1.NodeResources) {
+	sanitizeResourcePair(&resources.CPU.Quantity)
+	sanitizeResourcePair(&resources.Memory.Quantity)
+	sanitizeResourcePair(&resources.GPU.Quantity)
+	sanitizeResourcePair(&resources.EphemeralStorage)
+	sanitizeResourcePair(&resources.VolumesAttached)
+	sanitizeResourcePair(&resources.VolumesMounted)
+}
+
+func sanitizeResourcePair(pair *inventoryV1.ResourcePair) {
+	sanitizeQuantity(pair.Capacity)
+	sanitizeQuantity(pair.Allocatable)
+	sanitizeQuantity(pair.Allocated)
+}
+
+func sanitizeQuantity(quantity *resource.Quantity) {
+	if quantity.Cmp(*quantityZero) < 0 {
+		quantity.Set(0)
+	}
 }
 
 // tryAdjust cluster inventory
@@ -262,7 +313,7 @@ func (inv *inventory) Adjust(reservation ctypes.ReservationGroup, opts ...ctypes
 
 	cparams := make(crd.ReservationClusterSettings)
 
-	currInventory := inv.dup()
+	currInventory := inv.safeDup()
 
 	var err error
 
@@ -322,7 +373,7 @@ nodes:
 
 	if len(resources) == 0 {
 		if !cfg.DryRun {
-			*inv = currInventory
+			inv.safe = *currInventory.Cluster.Dup()
 		}
 
 		reservation.SetAllocatedResources(adjustedResources)
@@ -339,10 +390,12 @@ nodes:
 }
 
 func (inv *inventory) Snapshot() inventoryV1.Cluster {
-	return *inv.Cluster.Dup()
+	return *inv.safe.Dup()
 }
 
 func (inv *inventory) Metrics() inventoryV1.Metrics {
+	safe := inv.safeDup()
+
 	cpuTotal := uint64(0)
 	gpuTotal := uint64(0)
 	memoryTotal := uint64(0)
@@ -356,10 +409,10 @@ func (inv *inventory) Metrics() inventoryV1.Metrics {
 	storageAvailable := make(map[string]uint64)
 
 	ret := inventoryV1.Metrics{
-		Nodes: make([]inventoryV1.NodeMetrics, 0, len(inv.Nodes)),
+		Nodes: make([]inventoryV1.NodeMetrics, 0, len(safe.Nodes)),
 	}
 
-	for _, nd := range inv.Nodes {
+	for _, nd := range safe.Nodes {
 		invNode := inventoryV1.NodeMetrics{
 			Name: nd.Name,
 			Allocatable: inventoryV1.ResourcesMetric{
@@ -394,7 +447,7 @@ func (inv *inventory) Metrics() inventoryV1.Metrics {
 		ret.Nodes = append(ret.Nodes, invNode)
 	}
 
-	for _, class := range inv.Storage {
+	for _, class := range safe.Storage {
 		tmp := class.Quantity.Allocatable.DeepCopy()
 		storageTotal[class.Info.Class] = uint64(tmp.Value()) //nolint: gosec
 

--- a/cluster/kube/operators/clients/inventory/inventory.go
+++ b/cluster/kube/operators/clients/inventory/inventory.go
@@ -25,12 +25,12 @@ var (
 
 func newInventory(clState inventoryV1.Cluster) *inventory {
 	raw := *clState.Dup()
-	safe := *clState.Dup()
-	sanitizeCluster(&safe)
+	sanitized := *clState.Dup()
+	sanitizeCluster(&sanitized)
 
 	inv := &inventory{
-		Cluster: raw,
-		safe:    safe,
+		Cluster:   raw,
+		sanitized: sanitized,
 	}
 
 	return inv
@@ -38,17 +38,17 @@ func newInventory(clState inventoryV1.Cluster) *inventory {
 
 func (inv *inventory) dup() inventory {
 	dup := inventory{
-		Cluster: *inv.Cluster.Dup(),
-		safe:    *inv.safe.Dup(),
+		Cluster:   *inv.Cluster.Dup(),
+		sanitized: *inv.sanitized.Dup(),
 	}
 
 	return dup
 }
 
-func (inv *inventory) safeDup() inventory {
+func (inv *inventory) sanitizedDup() inventory {
 	dup := inventory{
-		Cluster: *inv.safe.Dup(),
-		safe:    *inv.safe.Dup(),
+		Cluster:   *inv.sanitized.Dup(),
+		sanitized: *inv.sanitized.Dup(),
 	}
 
 	return dup
@@ -313,7 +313,7 @@ func (inv *inventory) Adjust(reservation ctypes.ReservationGroup, opts ...ctypes
 
 	cparams := make(crd.ReservationClusterSettings)
 
-	currInventory := inv.safeDup()
+	currInventory := inv.sanitizedDup()
 
 	var err error
 
@@ -373,7 +373,7 @@ nodes:
 
 	if len(resources) == 0 {
 		if !cfg.DryRun {
-			inv.safe = *currInventory.Cluster.Dup()
+			inv.sanitized = *currInventory.Cluster.Dup()
 		}
 
 		reservation.SetAllocatedResources(adjustedResources)
@@ -390,11 +390,11 @@ nodes:
 }
 
 func (inv *inventory) Snapshot() inventoryV1.Cluster {
-	return *inv.safe.Dup()
+	return *inv.sanitized.Dup()
 }
 
 func (inv *inventory) Metrics() inventoryV1.Metrics {
-	safe := inv.safeDup()
+	sanitized := inv.sanitizedDup()
 
 	cpuTotal := uint64(0)
 	gpuTotal := uint64(0)
@@ -409,10 +409,10 @@ func (inv *inventory) Metrics() inventoryV1.Metrics {
 	storageAvailable := make(map[string]uint64)
 
 	ret := inventoryV1.Metrics{
-		Nodes: make([]inventoryV1.NodeMetrics, 0, len(safe.Nodes)),
+		Nodes: make([]inventoryV1.NodeMetrics, 0, len(sanitized.Nodes)),
 	}
 
-	for _, nd := range safe.Nodes {
+	for _, nd := range sanitized.Nodes {
 		invNode := inventoryV1.NodeMetrics{
 			Name: nd.Name,
 			Allocatable: inventoryV1.ResourcesMetric{
@@ -447,7 +447,7 @@ func (inv *inventory) Metrics() inventoryV1.Metrics {
 		ret.Nodes = append(ret.Nodes, invNode)
 	}
 
-	for _, class := range safe.Storage {
+	for _, class := range sanitized.Storage {
 		tmp := class.Quantity.Allocatable.DeepCopy()
 		storageTotal[class.Info.Class] = uint64(tmp.Value()) //nolint: gosec
 

--- a/operator/inventory/ceph.go
+++ b/operator/inventory/ceph.go
@@ -336,7 +336,13 @@ func (c *ceph) run(startch chan<- struct{}) error {
 
 						delete(pvMap, obj.Name)
 
-						scs[obj.Spec.StorageClassName].allocated.Sub(res)
+						sc, exists := scs[obj.Spec.StorageClassName]
+						if !exists {
+							log.Error(fmt.Errorf("storage class %q is not tracked", obj.Spec.StorageClassName), "persistent volume delete event references untracked storage class", "driver", "ceph", "storage_class", obj.Spec.StorageClassName, "persistent_volume", obj.Name, "persistent_volume_id", string(obj.UID))
+							break
+						}
+
+						subStorageAllocatedResource(log, "ceph", obj.Spec.StorageClassName, obj.Name, string(obj.UID), sc.allocated, res, cephStorageInventoryLogValue(scs))
 					}
 					signalScrape()
 				}

--- a/operator/inventory/diagnostics.go
+++ b/operator/inventory/diagnostics.go
@@ -1,0 +1,199 @@
+package inventory
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/resource"
+	inventoryV1 "pkg.akt.dev/go/inventory/v1"
+)
+
+var (
+	errNegativeAllocatedResource = errors.New("inventory allocated resource went negative")
+	errNegativeInventoryResource = errors.New("inventory resource went negative")
+	quantityZero                 = resource.NewQuantity(0, resource.DecimalSI)
+)
+
+type allocatedStorageChange struct {
+	Driver             string `json:"driver"`
+	StorageClass       string `json:"storage_class"`
+	PersistentVolume   string `json:"persistent_volume"`
+	PersistentVolumeID string `json:"persistent_volume_id"`
+	AllocatedBefore    string `json:"allocated_before"`
+	Subtracted         string `json:"subtracted"`
+	AllocatedAfter     string `json:"allocated_after"`
+}
+
+type negativeInventoryResource struct {
+	Scope        string `json:"scope"`
+	Node         string `json:"node,omitempty"`
+	StorageClass string `json:"storage_class,omitempty"`
+	Resource     string `json:"resource"`
+	Field        string `json:"field"`
+	Value        string `json:"value"`
+}
+
+type storageAccountingLogEntry struct {
+	Driver         string `json:"driver"`
+	Class          string `json:"class"`
+	Allocated      string `json:"allocated"`
+	IsCeph         bool   `json:"is_ceph,omitempty"`
+	IsRancher      bool   `json:"is_rancher,omitempty"`
+	IsAkashManaged bool   `json:"is_akash_managed"`
+	Pool           string `json:"pool,omitempty"`
+	ClusterID      string `json:"cluster_id,omitempty"`
+}
+
+func jsonLogValue(value interface{}) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("json marshal error %v", err)
+	}
+
+	return string(data)
+}
+
+func subStorageAllocatedResource(
+	log logr.Logger,
+	driver string,
+	class string,
+	persistentVolume string,
+	persistentVolumeID string,
+	allocated *resource.Quantity,
+	val resource.Quantity,
+	inventoryBefore interface{},
+) {
+	before := allocated.DeepCopy()
+	after := allocated.DeepCopy()
+	after.Sub(val)
+
+	if after.Cmp(*quantityZero) < 0 {
+		change := allocatedStorageChange{
+			Driver:             driver,
+			StorageClass:       class,
+			PersistentVolume:   persistentVolume,
+			PersistentVolumeID: persistentVolumeID,
+			AllocatedBefore:    before.String(),
+			Subtracted:         val.String(),
+			AllocatedAfter:     after.String(),
+		}
+
+		log.Error(errNegativeAllocatedResource, "inventory storage allocated resource went negative",
+			"driver", driver,
+			"storage_class", class,
+			"persistent_volume", persistentVolume,
+			"persistent_volume_id", persistentVolumeID,
+			"inventory_before", jsonLogValue(inventoryBefore),
+			"change", jsonLogValue(change))
+	}
+
+	*allocated = after
+}
+
+func logNegativeClusterInventory(log logr.Logger, cluster *inventoryV1.Cluster, source string) {
+	negatives := negativeInventoryResources(cluster)
+	if len(negatives) == 0 {
+		return
+	}
+
+	log.Error(errNegativeInventoryResource, "inventory contains negative resource quantity",
+		"source", source,
+		"inventory", jsonLogValue(cluster),
+		"negative_resources", jsonLogValue(negatives))
+}
+
+func negativeInventoryResources(cluster *inventoryV1.Cluster) []negativeInventoryResource {
+	var result []negativeInventoryResource
+
+	for _, node := range cluster.Nodes {
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "cpu", &node.Resources.CPU.Quantity)
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "memory", &node.Resources.Memory.Quantity)
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "gpu", &node.Resources.GPU.Quantity)
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "ephemeral_storage", &node.Resources.EphemeralStorage)
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "volumes_attached", &node.Resources.VolumesAttached)
+		result = appendNegativeResourcePair(result, "node", node.Name, "", "volumes_mounted", &node.Resources.VolumesMounted)
+	}
+
+	for _, storage := range cluster.Storage {
+		result = appendNegativeResourcePair(result, "storage", "", storage.Info.Class, "storage", &storage.Quantity)
+	}
+
+	return result
+}
+
+func appendNegativeResourcePair(result []negativeInventoryResource, scope, node, class, name string, pair *inventoryV1.ResourcePair) []negativeInventoryResource {
+	result = appendNegativeQuantity(result, scope, node, class, name, "capacity", pair.Capacity)
+	result = appendNegativeQuantity(result, scope, node, class, name, "allocatable", pair.Allocatable)
+	result = appendNegativeQuantity(result, scope, node, class, name, "allocated", pair.Allocated)
+
+	return result
+}
+
+func appendNegativeQuantity(result []negativeInventoryResource, scope, node, class, name, field string, quantity *resource.Quantity) []negativeInventoryResource {
+	if quantity == nil || quantity.Cmp(*quantityZero) >= 0 {
+		return result
+	}
+
+	return append(result, negativeInventoryResource{
+		Scope:        scope,
+		Node:         node,
+		StorageClass: class,
+		Resource:     name,
+		Field:        field,
+		Value:        quantity.String(),
+	})
+}
+
+func cephStorageInventoryLogValue(scs cephStorageClasses) []storageAccountingLogEntry {
+	classes := make([]string, 0, len(scs))
+	for class := range scs {
+		classes = append(classes, class)
+	}
+	sort.Strings(classes)
+
+	result := make([]storageAccountingLogEntry, 0, len(classes))
+	for _, class := range classes {
+		params := scs[class]
+		allocated := ""
+		if params.allocated != nil {
+			allocated = params.allocated.String()
+		}
+
+		result = append(result, storageAccountingLogEntry{
+			Driver:         "ceph",
+			Class:          class,
+			Allocated:      allocated,
+			IsCeph:         params.isCeph,
+			IsAkashManaged: params.isAkashManaged,
+			Pool:           params.pool,
+			ClusterID:      params.clusterID,
+		})
+	}
+
+	return result
+}
+
+func rancherStorageInventoryLogValue(scs rancherStorageClasses) []storageAccountingLogEntry {
+	classes := make([]string, 0, len(scs))
+	for class := range scs {
+		classes = append(classes, class)
+	}
+	sort.Strings(classes)
+
+	result := make([]storageAccountingLogEntry, 0, len(classes))
+	for _, class := range classes {
+		params := scs[class]
+		result = append(result, storageAccountingLogEntry{
+			Driver:         "rancher",
+			Class:          class,
+			Allocated:      params.allocated.String(),
+			IsRancher:      params.isRancher,
+			IsAkashManaged: params.isAkashManaged,
+		})
+	}
+
+	return result
+}

--- a/operator/inventory/diagnostics_test.go
+++ b/operator/inventory/diagnostics_test.go
@@ -1,0 +1,119 @@
+package inventory
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	inventoryV1 "pkg.akt.dev/go/inventory/v1"
+)
+
+func TestSubStorageAllocatedResourceLogsAndKeepsNegative(t *testing.T) {
+	allocated := resource.MustParse("1")
+	subtracted := resource.MustParse("2")
+	inventoryBefore := map[string]string{
+		"class":     "local-path",
+		"allocated": "1",
+	}
+
+	entries := make([]capturedLogEntry, 0, 1)
+	log := logr.New(&captureSink{entries: &entries})
+
+	subStorageAllocatedResource(log, "rancher", "local-path", "pv-1", "pv-uid", &allocated, subtracted, inventoryBefore)
+
+	require.Negative(t, allocated.Value())
+	require.Len(t, entries, 1)
+	require.ErrorIs(t, entries[0].err, errNegativeAllocatedResource)
+
+	values := logValues(entries[0].values)
+	require.Equal(t, "rancher", values["driver"])
+	require.Equal(t, "local-path", values["storage_class"])
+	require.Equal(t, "pv-1", values["persistent_volume"])
+	require.Equal(t, "pv-uid", values["persistent_volume_id"])
+
+	var before map[string]string
+	require.NoError(t, json.Unmarshal([]byte(values["inventory_before"].(string)), &before))
+	require.Equal(t, inventoryBefore, before)
+
+	var change allocatedStorageChange
+	require.NoError(t, json.Unmarshal([]byte(values["change"].(string)), &change))
+	require.Equal(t, "rancher", change.Driver)
+	require.Equal(t, "local-path", change.StorageClass)
+	require.Equal(t, "pv-1", change.PersistentVolume)
+	require.Equal(t, "pv-uid", change.PersistentVolumeID)
+	require.Equal(t, "1", change.AllocatedBefore)
+	require.Equal(t, "2", change.Subtracted)
+	require.Equal(t, "-1", change.AllocatedAfter)
+}
+
+func TestLogNegativeClusterInventory(t *testing.T) {
+	cluster := inventoryV1.Cluster{
+		Nodes: inventoryV1.Nodes{
+			{
+				Name: "node1",
+				Resources: inventoryV1.NodeResources{
+					CPU: inventoryV1.CPU{
+						Quantity: inventoryV1.NewResourcePairMilli(1000, 1000, -250, resource.DecimalSI),
+					},
+					Memory: inventoryV1.Memory{
+						Quantity: inventoryV1.NewResourcePair(1024, -1, 0, resource.DecimalSI),
+					},
+					GPU:              inventoryV1.GPU{Quantity: inventoryV1.NewResourcePair(1, 1, 0, resource.DecimalSI)},
+					EphemeralStorage: inventoryV1.NewResourcePair(10, 10, 0, resource.DecimalSI),
+					VolumesAttached:  inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+					VolumesMounted:   inventoryV1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+				},
+			},
+		},
+		Storage: inventoryV1.ClusterStorage{
+			{
+				Quantity: inventoryV1.NewResourcePair(10, -1, 0, resource.DecimalSI),
+				Info:     inventoryV1.StorageInfo{Class: "default"},
+			},
+		},
+	}
+
+	entries := make([]capturedLogEntry, 0, 1)
+	log := logr.New(&captureSink{entries: &entries})
+
+	logNegativeClusterInventory(log, &cluster, "unit-test")
+
+	require.Len(t, entries, 1)
+	require.ErrorIs(t, entries[0].err, errNegativeInventoryResource)
+
+	values := logValues(entries[0].values)
+	require.Equal(t, "unit-test", values["source"])
+
+	var loggedCluster inventoryV1.Cluster
+	require.NoError(t, json.Unmarshal([]byte(values["inventory"].(string)), &loggedCluster))
+	require.Equal(t, int64(-250), loggedCluster.Nodes[0].Resources.CPU.Quantity.Allocated.MilliValue())
+	require.Equal(t, int64(-1), loggedCluster.Storage[0].Quantity.Allocatable.Value())
+
+	var negatives []negativeInventoryResource
+	require.NoError(t, json.Unmarshal([]byte(values["negative_resources"].(string)), &negatives))
+	require.ElementsMatch(t, []negativeInventoryResource{
+		{
+			Scope:    "node",
+			Node:     "node1",
+			Resource: "cpu",
+			Field:    "allocated",
+			Value:    "-250m",
+		},
+		{
+			Scope:    "node",
+			Node:     "node1",
+			Resource: "memory",
+			Field:    "allocatable",
+			Value:    "-1",
+		},
+		{
+			Scope:        "storage",
+			StorageClass: "default",
+			Resource:     "storage",
+			Field:        "allocatable",
+			Value:        "-1",
+		},
+	}, negatives)
+}

--- a/operator/inventory/node-discovery.go
+++ b/operator/inventory/node-discovery.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/jaypipes/ghw/pkg/cpu"
 	"github.com/jaypipes/ghw/pkg/gpu"
 	"github.com/jaypipes/ghw/pkg/memory"
@@ -381,6 +382,13 @@ initloop:
 	}
 }
 
+func podKey(pod *corev1.Pod) string {
+	return k8stypes.NamespacedName{
+		Namespace: pod.Namespace,
+		Name:      pod.Name,
+	}.String()
+}
+
 func isPodAllocated(status corev1.PodStatus) bool {
 	for _, condition := range status.Conditions {
 		if condition.Type == corev1.PodScheduled {
@@ -495,7 +503,7 @@ func (dp *nodeDiscovery) monitor() error {
 
 			addPodAllocatedResources(&node, pod)
 
-			currPods[pod.Name] = *pod
+			currPods[podKey(pod)] = *pod
 		}
 
 		return nil
@@ -585,24 +593,25 @@ func (dp *nodeDiscovery) monitor() error {
 			}
 
 			obj := res.Object.(*corev1.Pod)
+			key := podKey(obj)
 			switch res.Type {
 			case watch.Added:
 				fallthrough
 			case watch.Modified:
-				if _, exists := currPods[obj.Name]; !exists && isPodAllocated(obj.Status) {
-					currPods[obj.Name] = *obj.DeepCopy()
+				if _, exists := currPods[key]; !exists && isPodAllocated(obj.Status) {
+					currPods[key] = *obj.DeepCopy()
 					addPodAllocatedResources(&node, obj)
 				}
 			case watch.Deleted:
-				pod, exists := currPods[obj.Name]
+				pod, exists := currPods[key]
 				if !exists {
 					log.Info("received pod delete event for item that does not exist. check node inventory logic, it's might have bug in it!")
 					break
 				}
 
-				subPodAllocatedResources(&node, &pod)
+				subPodAllocatedResources(log, &node, &pod)
 
-				delete(currPods, obj.Name)
+				delete(currPods, key)
 			}
 			signalState()
 		case <-statech:
@@ -779,31 +788,59 @@ func addPodAllocatedResources(node *v1.Node, pod *corev1.Pod) {
 	}
 }
 
-func subAllocatedNLZ(allocated *resource.Quantity, val resource.Quantity) {
-	newVal := allocated.Value() - val.Value()
-	if newVal < 0 {
-		newVal = 0
-	}
-
-	allocated.Set(newVal)
+type allocatedResourceChange struct {
+	Node            string `json:"node"`
+	Pod             string `json:"pod"`
+	PodID           string `json:"pod_id"`
+	Resource        string `json:"resource"`
+	AllocatedBefore string `json:"allocated_before"`
+	Subtracted      string `json:"subtracted"`
+	AllocatedAfter  string `json:"allocated_after"`
 }
 
-func subPodAllocatedResources(node *v1.Node, pod *corev1.Pod) {
+func subAllocatedResource(log logr.Logger, node *v1.Node, pod *corev1.Pod, resourceName string, allocated *resource.Quantity, val resource.Quantity) {
+	before := allocated.DeepCopy()
+	after := allocated.DeepCopy()
+	after.Sub(val)
+
+	if after.Cmp(*quantityZero) < 0 {
+		change := allocatedResourceChange{
+			Node:            node.Name,
+			Pod:             podKey(pod),
+			PodID:           string(pod.UID),
+			Resource:        resourceName,
+			AllocatedBefore: before.String(),
+			Subtracted:      val.String(),
+			AllocatedAfter:  after.String(),
+		}
+
+		log.Error(errNegativeAllocatedResource, "inventory allocated resource went negative",
+			"node", node.Name,
+			"pod", change.Pod,
+			"pod_id", change.PodID,
+			"inventory_before", jsonLogValue(node),
+			"change", jsonLogValue(change))
+	}
+
+	*allocated = after
+}
+
+func subPodAllocatedResources(log logr.Logger, node *v1.Node, pod *corev1.Pod) {
 	for _, container := range pod.Spec.Containers {
 		for name, quantity := range container.Resources.Requests {
 			switch name {
 			case corev1.ResourceCPU:
-				subAllocatedNLZ(node.Resources.CPU.Quantity.Allocated, quantity)
+				subAllocatedResource(log, node, pod, string(corev1.ResourceCPU), node.Resources.CPU.Quantity.Allocated, quantity)
 			case corev1.ResourceMemory:
-				subAllocatedNLZ(node.Resources.Memory.Quantity.Allocated, quantity)
+				subAllocatedResource(log, node, pod, string(corev1.ResourceMemory), node.Resources.Memory.Quantity.Allocated, quantity)
 			case corev1.ResourceEphemeralStorage:
-				subAllocatedNLZ(node.Resources.EphemeralStorage.Allocated, quantity)
+				subAllocatedResource(log, node, pod, string(corev1.ResourceEphemeralStorage), node.Resources.EphemeralStorage.Allocated, quantity)
 			case builder.ResourceGPUNvidia:
 				fallthrough
 			case builder.ResourceGPUNvidiaPGPU:
 				fallthrough
 			case builder.ResourceGPUAMD:
-				subAllocatedNLZ(node.Resources.GPU.Quantity.Allocated, quantity)
+				subAllocatedResource(log, node, pod, string(name), node.Resources.GPU.Quantity.Allocated, quantity)
 			}
 		}
 
@@ -812,7 +849,7 @@ func subPodAllocatedResources(node *v1.Node, pod *corev1.Pod) {
 				continue
 			}
 
-			subAllocatedNLZ(node.Resources.Memory.Quantity.Allocated, *vol.EmptyDir.SizeLimit)
+			subAllocatedResource(log, node, pod, "memory.emptydir", node.Resources.Memory.Quantity.Allocated, *vol.EmptyDir.SizeLimit)
 		}
 	}
 }

--- a/operator/inventory/node-discovery_test.go
+++ b/operator/inventory/node-discovery_test.go
@@ -1,0 +1,204 @@
+package inventory
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	v1 "pkg.akt.dev/go/inventory/v1"
+
+	"github.com/akash-network/provider/cluster/kube/builder"
+)
+
+type capturedLogEntry struct {
+	err    error
+	msg    string
+	values []interface{}
+}
+
+type captureSink struct {
+	entries *[]capturedLogEntry
+	values  []interface{}
+}
+
+func (s *captureSink) Init(logr.RuntimeInfo) {}
+
+func (s *captureSink) Enabled(int) bool {
+	return true
+}
+
+func (s *captureSink) Info(int, string, ...interface{}) {}
+
+func (s *captureSink) Error(err error, msg string, keysAndValues ...interface{}) {
+	values := append([]interface{}{}, s.values...)
+	values = append(values, keysAndValues...)
+	*s.entries = append(*s.entries, capturedLogEntry{
+		err:    err,
+		msg:    msg,
+		values: values,
+	})
+}
+
+func (s *captureSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	values := append([]interface{}{}, s.values...)
+	values = append(values, keysAndValues...)
+
+	return &captureSink{
+		entries: s.entries,
+		values:  values,
+	}
+}
+
+func (s *captureSink) WithName(string) logr.LogSink {
+	return &captureSink{
+		entries: s.entries,
+		values:  append([]interface{}{}, s.values...),
+	}
+}
+
+func logValues(values []interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for i := 0; i+1 < len(values); i += 2 {
+		key, ok := values[i].(string)
+		if !ok {
+			continue
+		}
+		result[key] = values[i+1]
+	}
+	return result
+}
+
+func TestSubPodAllocatedResourcesLogsAndKeepsNegative(t *testing.T) {
+	tests := []struct {
+		name            string
+		resourceName    corev1.ResourceName
+		requestQuantity string
+		changeResource  string
+		before          string
+		subtracted      string
+		after           string
+		setAllocated    func(*v1.Node)
+		allocated       func(*v1.Node) int64
+	}{
+		{
+			name:            "cpu",
+			resourceName:    corev1.ResourceCPU,
+			requestQuantity: "750m",
+			changeResource:  "cpu",
+			before:          "500m",
+			subtracted:      "750m",
+			after:           "-250m",
+			setAllocated: func(node *v1.Node) {
+				node.Resources.CPU.Quantity.Allocated.SetMilli(500)
+			},
+			allocated: func(node *v1.Node) int64 {
+				return node.Resources.CPU.Quantity.Allocated.MilliValue()
+			},
+		},
+		{
+			name:            "gpu",
+			resourceName:    builder.ResourceGPUNvidia,
+			requestQuantity: "2",
+			changeResource:  string(builder.ResourceGPUNvidia),
+			before:          "1",
+			subtracted:      "2",
+			after:           "-1",
+			setAllocated: func(node *v1.Node) {
+				node.Resources.GPU.Quantity.Allocated.Set(1)
+			},
+			allocated: func(node *v1.Node) int64 {
+				return node.Resources.GPU.Quantity.Allocated.Value()
+			},
+		},
+		{
+			name:            "memory",
+			resourceName:    corev1.ResourceMemory,
+			requestQuantity: "2",
+			changeResource:  "memory",
+			before:          "1",
+			subtracted:      "2",
+			after:           "-1",
+			setAllocated: func(node *v1.Node) {
+				node.Resources.Memory.Quantity.Allocated.Set(1)
+			},
+			allocated: func(node *v1.Node) int64 {
+				return node.Resources.Memory.Quantity.Allocated.Value()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &v1.Node{
+				Name: "node1",
+				Resources: v1.NodeResources{
+					CPU: v1.CPU{
+						Quantity: v1.NewResourcePairMilli(1000, 1000, 0, resource.DecimalSI),
+					},
+					Memory: v1.Memory{
+						Quantity: v1.NewResourcePair(1024, 1024, 0, resource.DecimalSI),
+					},
+					GPU: v1.GPU{
+						Quantity: v1.NewResourcePair(4, 4, 0, resource.DecimalSI),
+					},
+					EphemeralStorage: v1.NewResourcePair(100, 100, 0, resource.DecimalSI),
+					VolumesAttached:  v1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+					VolumesMounted:   v1.NewResourcePair(0, 0, 0, resource.DecimalSI),
+				},
+			}
+			tt.setAllocated(node)
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "lease-ns",
+					Name:      "web-0",
+					UID:       k8stypes.UID("pod-uid"),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "web",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									tt.resourceName: resource.MustParse(tt.requestQuantity),
+								},
+							},
+						},
+					},
+				},
+			}
+			entries := make([]capturedLogEntry, 0, 1)
+			log := logr.New(&captureSink{entries: &entries})
+
+			subPodAllocatedResources(log, node, pod)
+
+			require.Negative(t, tt.allocated(node))
+			require.Len(t, entries, 1)
+			require.ErrorIs(t, entries[0].err, errNegativeAllocatedResource)
+
+			values := logValues(entries[0].values)
+			require.Equal(t, "node1", values["node"])
+			require.Equal(t, "lease-ns/web-0", values["pod"])
+			require.Equal(t, "pod-uid", values["pod_id"])
+
+			var before v1.Node
+			require.NoError(t, json.Unmarshal([]byte(values["inventory_before"].(string)), &before))
+			require.Positive(t, tt.allocated(&before))
+
+			var change allocatedResourceChange
+			require.NoError(t, json.Unmarshal([]byte(values["change"].(string)), &change))
+			require.Equal(t, "node1", change.Node)
+			require.Equal(t, "lease-ns/web-0", change.Pod)
+			require.Equal(t, "pod-uid", change.PodID)
+			require.Equal(t, tt.changeResource, change.Resource)
+			require.Equal(t, tt.before, change.AllocatedBefore)
+			require.Equal(t, tt.subtracted, change.Subtracted)
+			require.Equal(t, tt.after, change.AllocatedAfter)
+		})
+	}
+}

--- a/operator/inventory/rancher.go
+++ b/operator/inventory/rancher.go
@@ -29,7 +29,7 @@ type rancher struct {
 type rancherStorage struct {
 	isRancher      bool
 	isAkashManaged bool
-	allocated      uint64
+	allocated      resource.Quantity
 }
 
 type rancherStorageClasses map[string]*rancherStorage
@@ -154,7 +154,7 @@ func (c *rancher) run(startch chan<- struct{}) error {
 
 					if _, exists = pvMap[obj.Name]; !exists {
 						pvMap[obj.Name] = *obj
-						params.allocated += uint64(res.Value()) // nolint: gosec
+						params.allocated.Add(res)
 					}
 				case watch.Deleted:
 					res, exists := obj.Spec.Capacity[corev1.ResourceStorage]
@@ -163,7 +163,14 @@ func (c *rancher) run(startch chan<- struct{}) error {
 					}
 
 					delete(pvMap, obj.Name)
-					scs[obj.Spec.StorageClassName].allocated -= uint64(res.Value()) // nolint: gosec
+
+					params, exists := scs[obj.Spec.StorageClassName]
+					if !exists {
+						log.Error(fmt.Errorf("storage class %q is not tracked", obj.Spec.StorageClassName), "persistent volume delete event references untracked storage class", "driver", "rancher", "storage_class", obj.Spec.StorageClassName, "persistent_volume", obj.Name, "persistent_volume_id", string(obj.UID))
+						break
+					}
+
+					subStorageAllocatedResource(log, "rancher", obj.Spec.StorageClassName, obj.Name, string(obj.UID), &params.allocated, res, rancherStorageInventoryLogValue(scs))
 				}
 
 				tryScrape()
@@ -229,7 +236,7 @@ func (c *rancher) run(startch chan<- struct{}) error {
 									continue
 								}
 
-								params.allocated += uint64(capacity.Value()) // nolint: gosec
+								params.allocated.Add(capacity)
 
 								pvMap[pv.Name] = pv
 							}
@@ -254,7 +261,7 @@ func (c *rancher) run(startch chan<- struct{}) error {
 			for class, params := range scs {
 				if params.isRancher && params.isAkashManaged {
 					res = append(res, inventory.Storage{
-						Quantity: inventory.NewResourcePair(allocatable, allocatable, int64(params.allocated), resource.DecimalSI), // nolint: gosec
+						Quantity: inventory.NewResourcePair(allocatable, allocatable, params.allocated.Value(), resource.DecimalSI),
 						Info: inventory.StorageInfo{
 							Class: class,
 						},

--- a/operator/inventory/state.go
+++ b/operator/inventory/state.go
@@ -30,6 +30,8 @@ func (s *clusterState) run() error {
 
 	defer bus.Unsub(datach)
 
+	log := fromctx.LogrFromCtx(s.ctx).WithName("cluster-state")
+
 	var cfg Config
 
 	trySignal := func() {
@@ -79,6 +81,7 @@ func (s *clusterState) run() error {
 				err: nil,
 			}
 		case <-signalch:
+			logNegativeClusterInventory(log, &state, "cluster-state")
 			bus.Pub(*state.Dup(), []string{topicInventoryCluster}, pubsub.WithRetain())
 		}
 	}


### PR DESCRIPTION
## Summary
Replaces https://github.com/akash-network/provider/pull/379 with a diagnostic fix for https://github.com/akash-network/support/issues/429. 

This keeps raw operator inventory intact so negative resource accounting remains visible, while bid, metrics, and provider status consume a sanitized non-negative view.

It also logs forensic data when accounting goes negative: pod/PV identity, `inventory_before`, and the applied change. Rancher storage accounting now uses signed resource quantities instead of `uint64` arithmetic so underflows stay visible instead of becoming huge positive values.

Fixes akash-network/support#429.

## Validation
- `GOWORK=off go test ./operator/inventory -count=1`
- `GOWORK=off go test ./cluster/... ./operator/inventory -count=1`
- `git diff --check`