### PR TITLE
feat(bidengine): support wildcard gpu multi-bids

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -6,7 +6,7 @@ COPY provider-services /usr/bin/
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
-    go install github.com/go-delve/delve/cmd/dlv@latest \
+    go install github.com/go-delve/delve/cmd/dlv@v1.26.3 \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
     tini \

--- a/bidengine/order.go
+++ b/bidengine/order.go
@@ -3,7 +3,8 @@ package bidengine
 import (
 	"context"
 	"fmt"
-	"regexp"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/boz/go-lifecycle"
@@ -142,8 +143,6 @@ func newOrderInternal(svc *service, oid mtypes.OrderID, cfg Config, pass Provide
 	return order, nil
 }
 
-var matchBidNotFound = regexp.MustCompile("^.+bid not found.+$")
-
 func (o *order) bidTimeoutEnabled() bool {
 	return o.cfg.BidTimeout > time.Duration(0)
 }
@@ -171,95 +170,249 @@ func (o *order) isStaleBid(bid mvbeta.Bid) bool {
 	return atLeastThisOld > o.cfg.BidTimeout
 }
 
+type bidAttempt struct {
+	id          mtypes.BidID
+	reservation ctypes.Reservation
+	msg         *mvbeta.MsgCreateBid
+	placed      bool
+	existing    bool
+}
+
+type reservationResult struct {
+	bidID       mtypes.BidID
+	existing    bool
+	reservation ctypes.Reservation
+}
+
+type priceResult struct {
+	bidID mtypes.BidID
+	price sdk.DecCoin
+}
+
+func bidIDWithSequence(orderID mtypes.OrderID, provider sdk.AccAddress, bseq uint32) mtypes.BidID {
+	id := mtypes.MakeBidID(orderID, provider)
+	id.BSeq = bseq
+
+	return id
+}
+
+func groupHasGPUModelWildcard(group *dtypes.Group) bool {
+	for _, resource := range group.GroupSpec.GetResourceUnits() {
+		gpu := resource.Resources.GetGPU()
+		if gpu == nil || gpu.GetUnits().Value() == 0 {
+			continue
+		}
+
+		for _, attr := range gpu.GetAttributes() {
+			tokens := strings.Split(attr.Key, "/")
+			for idx := 0; idx+1 < len(tokens); idx += 2 {
+				if tokens[idx] == "model" && tokens[idx+1] == "*" {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func findBidAttempt(attempts []bidAttempt, id mtypes.BidID) int {
+	for idx := range attempts {
+		if attempts[idx].id == id {
+			return idx
+		}
+	}
+
+	return -1
+}
+
+func placedBidCount(attempts []bidAttempt) int {
+	count := 0
+	for _, attempt := range attempts {
+		if attempt.placed {
+			count++
+		}
+	}
+
+	return count
+}
+
 func (o *order) run(checkForExistingBid bool) {
 	defer o.lc.ShutdownCompleted()
 	ctx, cancel := context.WithCancel(context.Background())
+	providerAddr := o.session.Provider().Address()
 
 	var (
-		// Channel for receiving group details query result.
-		groupch <-chan runner.Result
-		// Channel for storing group details result while checking existing bid.
+		groupch       <-chan runner.Result
 		storedGroupCh <-chan runner.Result
-		// Channel for receiving cluster reservation result.
-		clusterch <-chan runner.Result
-		// Channel for receiving bid creation transaction result.
-		bidch <-chan runner.Result
-		// Channel for receiving bid price calculation result.
-		pricech <-chan runner.Result
-		// Channel for receiving existing bid query result.
-		queryBidCh <-chan runner.Result
-		// Channel for receiving result of bid eligibility check.
-		shouldBidCh <-chan runner.Result
-		// Channel that triggers when bid timeout is reached.
-		bidTimeout <-chan time.Time
+		clusterch     <-chan runner.Result
+		bidch         <-chan runner.Result
+		pricech       <-chan runner.Result
+		queryBidsCh   <-chan runner.Result
+		shouldBidCh   <-chan runner.Result
+		bidTimeout    <-chan time.Time
 
-		group       *dtypes.Group
-		reservation ctypes.Reservation
+		group *dtypes.Group
 
-		won bool
-		msg *mvbeta.MsgCreateBid
+		attempts            []bidAttempt
+		pendingExistingBids []mtypes.BidID
+		nextBSeq            uint32
+		maxBidAttempts      uint32 = 1
+		reserveStarted      uint32
+		broadcastingBid     *mtypes.BidID
+		wonBid              *mtypes.BidID
+		stopCreatingBids    bool
 	)
 
-	// Begin fetching group details immediately.
 	groupch = runner.Do(func() runner.Result {
 		res, err := o.session.Client().Query().Deployment().Group(ctx, &dtypes.QueryGroupRequest{ID: o.orderID.GroupID()})
 		return runner.NewResult(res.GetGroup(), err)
 	})
 
-	// Load existing bid if needed
 	if checkForExistingBid {
-		queryBidCh = runner.Do(func() runner.Result {
-			return runner.NewResult(o.session.Client().Query().Market().Bid(
+		queryBidsCh = runner.Do(func() runner.Result {
+			return runner.NewResult(o.session.Client().Query().Market().Bids(
 				ctx,
-				&mvbeta.QueryBidRequest{
-					ID: mtypes.MakeBidID(o.orderID, o.session.Provider().Address()),
+				&mvbeta.QueryBidsRequest{
+					Filters: mvbeta.BidFilters{
+						Owner:    o.orderID.Owner,
+						DSeq:     o.orderID.DSeq,
+						GSeq:     o.orderID.GSeq,
+						OSeq:     o.orderID.OSeq,
+						Provider: providerAddr.String(),
+						State:    mvbeta.BidOpen.String(),
+					},
 				},
 			))
 		})
-		// Hide the group details result for later
 		storedGroupCh = groupch
 		groupch = nil
 	}
 
-	bidPlaced := false
+	startReservation := func(bidID mtypes.BidID, existing bool) {
+		o.log.Info("requesting reservation", "bid", bidID, "bseq", bidID.BSeq)
+		clusterch = runner.Do(metricsutils.ObserveRunner(func() runner.Result {
+			reservation, err := o.cluster.ReserveBid(bidID, group)
+			return runner.NewResult(reservationResult{
+				bidID:       bidID,
+				existing:    existing,
+				reservation: reservation,
+			}, err)
+		}, reservationDuration))
+	}
+
+	startNextReservation := func() bool {
+		if clusterch != nil || stopCreatingBids {
+			return false
+		}
+
+		if len(pendingExistingBids) != 0 {
+			bidID := pendingExistingBids[0]
+			pendingExistingBids = pendingExistingBids[1:]
+			startReservation(bidID, true)
+			return true
+		}
+
+		if reserveStarted >= maxBidAttempts {
+			return false
+		}
+
+		if nextBSeq == ^uint32(0) {
+			o.log.Error("bid sequence exhausted")
+			stopCreatingBids = true
+			return false
+		}
+
+		bidID := bidIDWithSequence(o.orderID, providerAddr, nextBSeq)
+		nextBSeq++
+		reserveStarted++
+		startReservation(bidID, false)
+		return true
+	}
+
+	finishBidding := func() {
+		if placedBidCount(attempts) != 0 {
+			bidTimeout = o.getBidTimeout()
+		}
+	}
+
+	unreserveAttempt := func(idx int) {
+		if idx < 0 || idx >= len(attempts) || attempts[idx].reservation == nil {
+			return
+		}
+
+		bidID := attempts[idx].id
+		o.log.Debug("unreserving reservation", "bid", bidID, "bseq", bidID.BSeq)
+		if err := o.cluster.UnreserveBid(bidID); err != nil {
+			o.log.Error("error unreserving reservation", "err", err, "bid", bidID, "bseq", bidID.BSeq)
+			reservationCounter.WithLabelValues("close", metricsutils.FailLabel).Inc()
+		} else {
+			reservationCounter.WithLabelValues("close", metricsutils.SuccessLabel).Inc()
+		}
+		attempts[idx].reservation = nil
+	}
+
+	removeAttempt := func(idx int) {
+		if idx < 0 || idx >= len(attempts) {
+			return
+		}
+
+		attempts = append(attempts[:idx], attempts[idx+1:]...)
+	}
+
 loop:
 	for {
 		select {
 		case <-o.lc.ShutdownRequest():
 			break loop
 
-		case queryBid := <-queryBidCh:
-			err := queryBid.Error()
-			bidFound := true
-			if err != nil {
-				// Use super-advanced technique for detecting if bid is not on blockchain
-				if matchBidNotFound.MatchString(err.Error()) {
-					bidFound = false
-				} else {
-					o.session.Log().Error("could not get existing bid", "err", err, "errtype", fmt.Sprintf("%T", err))
-					break loop
-				}
+		case queryBids := <-queryBidsCh:
+			queryBidsCh = nil
+			if err := queryBids.Error(); err != nil {
+				o.session.Log().Error("could not get existing bids", "err", err, "errtype", fmt.Sprintf("%T", err))
+				break loop
 			}
 
-			if bidFound {
-				o.session.Log().Info("found existing bid")
-				bidResponse := queryBid.Value().(*mvbeta.QueryBidResponse)
+			bids := queryBids.Value().(*mvbeta.QueryBidsResponse).GetBids()
+			sort.Slice(bids, func(i, j int) bool {
+				return bids[i].GetBid().ID.BSeq < bids[j].GetBid().ID.BSeq
+			})
+
+			staleExistingBid := false
+			for _, bidResponse := range bids {
 				bid := bidResponse.GetBid()
-				bidState := bid.GetState()
-				if bidState != mvbeta.BidOpen {
-					o.session.Log().Error("bid in unexpected state", "bid-state", bidState)
+				if bid.GetState() != mvbeta.BidOpen {
+					o.session.Log().Error("bid in unexpected state", "bid-state", bid.GetState())
 					break loop
 				}
-				bidPlaced = true
-
+				if bid.ID.BSeq == ^uint32(0) {
+					o.session.Log().Error("bid sequence exhausted", "bid", bid.ID)
+					break loop
+				}
+				if bid.ID.BSeq >= nextBSeq {
+					nextBSeq = bid.ID.BSeq + 1
+				}
+				attempts = append(attempts, bidAttempt{
+					id:       bid.ID,
+					placed:   true,
+					existing: true,
+				})
+				pendingExistingBids = append(pendingExistingBids, bid.ID)
 				if o.isStaleBid(bid) {
 					o.session.Log().Info("found expired bid", "block-height", bid.GetCreatedAt())
-					break loop
+					staleExistingBid = true
 				}
-
-				bidTimeout = o.getBidTimeout()
 			}
-			groupch = storedGroupCh // Allow getting the group details result now
+
+			if staleExistingBid {
+				break loop
+			}
+
+			if len(bids) != 0 {
+				o.session.Log().Info("found existing bids", "count", len(bids))
+			}
+
+			groupch = storedGroupCh
 			storedGroupCh = nil
 
 		case ev := <-o.sub.Events():
@@ -275,10 +428,11 @@ loop:
 				if ev.ID.Provider != o.session.Provider().Address().String() {
 					orderCompleteCounter.WithLabelValues("lease-lost").Inc()
 					o.log.Info("lease lost", "lease", ev.ID)
-					// Ensure cleanup runs MsgCloseBid: we may have already set bidPlaced, or have a
-					// bid tx in flight (bidch != nil) that could land on chain; network does not auto-close
-					if bidch != nil {
-						bidPlaced = true
+					if broadcastingBid != nil {
+						idx := findBidAttempt(attempts, *broadcastingBid)
+						if idx != -1 {
+							attempts[idx].placed = true
+						}
 					}
 					break loop
 				}
@@ -294,7 +448,8 @@ loop:
 				}); err != nil {
 					o.log.Error("failed to publish to event queue", err)
 				}
-				won = true
+				winner := ev.ID.BidID()
+				wonBid = &winner
 
 				break loop
 			case *mtypes.EventOrderClosed:
@@ -307,7 +462,7 @@ loop:
 				orderCompleteCounter.WithLabelValues("order-closed").Inc()
 				break loop
 			case *mtypes.EventBidClosed:
-				if won {
+				if wonBid != nil {
 					// Ignore any event after LeaseCreated
 					continue
 				}
@@ -318,18 +473,24 @@ loop:
 				}
 
 				// Ignore bid closed not for this provider
-				if ev.ID.GetProvider() != o.session.Provider().String() {
+				if ev.ID.GetProvider() != providerAddr.String() {
 					break
 				}
 
-				// Bid has been closed (possibly by someone manually closing it on the CLI)
-				bidPlaced = false // bid already not on the blockchain
+				idx := findBidAttempt(attempts, ev.ID)
+				if idx == -1 {
+					break
+				}
+
+				attempts[idx].placed = false
+				unreserveAttempt(idx)
+				removeAttempt(idx)
 				orderCompleteCounter.WithLabelValues("bid-closed-external").Inc()
-				break loop
+				if placedBidCount(attempts) == 0 && clusterch == nil && pricech == nil && bidch == nil {
+					break loop
+				}
 			}
 		case result := <-groupch:
-			// Group details fetched.
-
 			groupch = nil
 			o.log.Info("group fetched")
 
@@ -362,22 +523,35 @@ loop:
 			}
 
 			shouldBidCounter.WithLabelValues("accept").Inc()
-			o.log.Info("requesting reservation")
-			// Begin reserving resources from cluster.
-			clusterch = runner.Do(metricsutils.ObserveRunner(func() runner.Result {
-				return runner.NewResult(o.cluster.Reserve(o.orderID, group))
-			}, reservationDuration))
+			if groupHasGPUModelWildcard(group) {
+				maxBidAttempts = mvbeta.DefaultParams().OrderMaxBids
+			}
+			reserveStarted = uint32(len(attempts))
+			if !startNextReservation() {
+				finishBidding()
+			}
 
 		case result := <-clusterch:
 			clusterch = nil
 
 			if result.Error() != nil {
-				reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.FailLabel)
+				reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.FailLabel).Inc()
 				o.log.Error("reserving resources", "err", result.Error())
-				break loop
+				reservationResult := result.Value().(reservationResult)
+				if reservationResult.existing {
+					break loop
+				}
+
+				if placedBidCount(attempts) == 0 {
+					break loop
+				}
+
+				stopCreatingBids = true
+				finishBidding()
+				continue
 			}
 
-			reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.SuccessLabel)
+			reservationCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.SuccessLabel).Inc()
 
 			o.log.Info("Reservation fulfilled")
 
@@ -389,55 +563,109 @@ loop:
 				}
 			}
 
-			// Resources reserved
-			reservation = result.Value().(ctypes.Reservation)
-			if bidPlaced {
-				o.log.Info("Fulfillment already exists")
-				// fulfillment already created (state recovered via queryExistingOrders)
-				break
+			reservationResult := result.Value().(reservationResult)
+			attempt := bidAttempt{
+				id:          reservationResult.bidID,
+				reservation: reservationResult.reservation,
+				existing:    reservationResult.existing,
+				placed:      reservationResult.existing,
 			}
+
+			if idx := findBidAttempt(attempts, attempt.id); idx == -1 {
+				attempts = append(attempts, attempt)
+			} else {
+				attempts[idx].reservation = attempt.reservation
+			}
+
+			if reservationResult.existing {
+				o.log.Info("Fulfillment already exists")
+				if !startNextReservation() {
+					finishBidding()
+				}
+				continue
+			}
+
 			pricech = runner.Do(metricsutils.ObserveRunner(func() runner.Result {
-				// Calculate price & bid
 				priceReq := Request{
 					Owner:              group.ID.Owner,
 					GSpec:              &group.GroupSpec,
 					PricePrecision:     DefaultPricePrecision,
-					AllocatedResources: reservation.GetAllocatedResources(),
+					AllocatedResources: reservationResult.reservation.GetAllocatedResources(),
 				}
-				return runner.NewResult(o.cfg.PricingStrategy.CalculatePrice(ctx, priceReq))
+				price, err := o.cfg.PricingStrategy.CalculatePrice(ctx, priceReq)
+				return runner.NewResult(priceResult{
+					bidID: reservationResult.bidID,
+					price: price,
+				}, err)
 			}, pricingDuration))
+
 		case result := <-pricech:
 			pricech = nil
 			if result.Error() != nil {
 				o.log.Error("error calculating price", "err", result.Error())
-				break loop
+				priceResult := result.Value().(priceResult)
+				idx := findBidAttempt(attempts, priceResult.bidID)
+				unreserveAttempt(idx)
+				removeAttempt(idx)
+				if placedBidCount(attempts) == 0 {
+					break loop
+				}
+				stopCreatingBids = true
+				finishBidding()
+				continue
 			}
 
-			price := result.Value().(sdk.DecCoin)
+			priceResult := result.Value().(priceResult)
+			price := priceResult.price
 			maxPrice := group.GroupSpec.Price()
 
 			if maxPrice.GetDenom() != price.GetDenom() {
 				o.log.Error("Unsupported Denomination", "calculated", price.String(), "max-price", maxPrice.String())
-				break loop
+				idx := findBidAttempt(attempts, priceResult.bidID)
+				unreserveAttempt(idx)
+				removeAttempt(idx)
+				if placedBidCount(attempts) == 0 {
+					break loop
+				}
+				stopCreatingBids = true
+				finishBidding()
+				continue
 			}
 
 			if maxPrice.IsLT(price) {
 				o.log.Info("Price too high, not bidding", "price", price.String(), "max-price", maxPrice.String())
-				break loop
+				idx := findBidAttempt(attempts, priceResult.bidID)
+				unreserveAttempt(idx)
+				removeAttempt(idx)
+				if placedBidCount(attempts) == 0 {
+					break loop
+				}
+				stopCreatingBids = true
+				finishBidding()
+				continue
 			}
 
 			o.log.Debug("submitting fulfillment", "price", price)
 
-			offer := mvbeta.ResourceOfferFromRU(reservation.GetAllocatedResources())
+			idx := findBidAttempt(attempts, priceResult.bidID)
+			if idx == -1 || attempts[idx].reservation == nil {
+				o.log.Error("priced bid without reservation", "bid", priceResult.bidID)
+				break loop
+			}
 
-			// Begin submitting fulfillment
-			msg = mvbeta.NewMsgCreateBid(mtypes.MakeBidID(o.orderID, o.session.Provider().Address()), price, deposit.Deposit{
+			offer := mvbeta.ResourceOfferFromRU(attempts[idx].reservation.GetAllocatedResources())
+
+			msg := mvbeta.NewMsgCreateBid(priceResult.bidID, price, deposit.Deposit{
 				Amount:  o.cfg.Deposit,
 				Sources: deposit.Sources{deposit.SourceBalance},
 			}, offer)
 			msg.ReclamationWindow = o.cfg.ReclamationWindow
+			attempts[idx].msg = msg
+			bidID := priceResult.bidID
+			broadcastingBid = &bidID
 			bidch = runner.Do(func() runner.Result {
-				return runner.NewResult(o.session.Client().Tx().BroadcastMsgs(ctx, []sdk.Msg{msg}, aclient.WithResultCodeAsError()))
+				_, err := o.session.Client().Tx().BroadcastMsgs(ctx, []sdk.Msg{msg}, aclient.WithResultCodeAsError())
+				return runner.NewResult(bidID, err)
 			})
 
 		case result := <-bidch:
@@ -445,18 +673,33 @@ loop:
 			if result.Error() != nil {
 				bidCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.FailLabel).Inc()
 				o.log.Error("bid failed", "err", result.Error())
-				break loop
+				if broadcastingBid != nil {
+					idx := findBidAttempt(attempts, *broadcastingBid)
+					unreserveAttempt(idx)
+					removeAttempt(idx)
+				}
+				broadcastingBid = nil
+				if placedBidCount(attempts) == 0 {
+					break loop
+				}
+				stopCreatingBids = true
+				finishBidding()
+				continue
+			}
+
+			bidID := result.Value().(mtypes.BidID)
+			broadcastingBid = nil
+			if idx := findBidAttempt(attempts, bidID); idx != -1 {
+				attempts[idx].placed = true
 			}
 
 			o.log.Info("bid complete")
 			bidCounter.WithLabelValues(metricsutils.OpenLabel, metricsutils.SuccessLabel).Inc()
 
-			// Fulfillment placed.
-			bidPlaced = true
-
-			bidTimeout = o.getBidTimeout()
+			if !startNextReservation() {
+				finishBidding()
+			}
 		case <-bidTimeout:
-			// The bid was not acted upon (e.g. lease created or deployment closed) so close it now
 			o.log.Info("bid timeout, closing bid")
 			orderCompleteCounter.WithLabelValues("bid-timeout").Inc()
 			break loop
@@ -467,39 +710,63 @@ loop:
 	o.lc.ShutdownInitiated(nil)
 	o.sub.Close()
 
-	// cancel reservation
-	if !won {
-		if clusterch != nil {
-			result := <-clusterch
-			clusterch = nil
-			if result.Error() == nil {
-				reservation = result.Value().(ctypes.Reservation)
+	if clusterch != nil {
+		result := <-clusterch
+		clusterch = nil
+		if result.Error() == nil {
+			reservationResult := result.Value().(reservationResult)
+			attempt := bidAttempt{
+				id:          reservationResult.bidID,
+				reservation: reservationResult.reservation,
+				existing:    reservationResult.existing,
+				placed:      reservationResult.existing,
 			}
-		}
-		if reservation != nil {
-			o.log.Debug("unreserving reservation")
-			if err := o.cluster.Unreserve(reservation.OrderID()); err != nil {
-				o.log.Error("error unreserving reservation", "err", err)
-				reservationCounter.WithLabelValues("close", metricsutils.FailLabel)
+			if idx := findBidAttempt(attempts, attempt.id); idx == -1 {
+				attempts = append(attempts, attempt)
 			} else {
-				reservationCounter.WithLabelValues("close", metricsutils.SuccessLabel)
+				attempts[idx].reservation = attempt.reservation
 			}
 		}
+	}
 
-		if bidPlaced {
-			o.log.Debug("closing bid", "order-id", o.orderID)
+	if bidch != nil {
+		result := <-bidch
+		bidch = nil
+		if result.Error() == nil {
+			bidID := result.Value().(mtypes.BidID)
+			if idx := findBidAttempt(attempts, bidID); idx != -1 {
+				attempts[idx].placed = true
+			}
+		}
+	}
 
+	for idx := range attempts {
+		if attempts[idx].reservation == nil {
+			continue
+		}
+		if wonBid != nil && attempts[idx].id == *wonBid {
+			continue
+		}
+		unreserveAttempt(idx)
+	}
+
+	if wonBid == nil {
+		for _, attempt := range attempts {
+			if !attempt.placed {
+				continue
+			}
+
+			o.log.Debug("closing bid", "bid", attempt.id, "bseq", attempt.id.BSeq)
 			msg := &mvbeta.MsgCloseBid{
-				ID:     mtypes.MakeBidID(o.orderID, o.session.Provider().Address()),
+				ID:     attempt.id,
 				Reason: mtypes.LeaseClosedReasonUnspecified,
 			}
-
 			_, err := o.session.Client().Tx().BroadcastMsgs(ctx, []sdk.Msg{msg}, aclient.WithResultCodeAsError())
 			if err != nil {
 				o.log.Error("closing bid", "err", err)
 				bidCounter.WithLabelValues("close", metricsutils.FailLabel).Inc()
 			} else {
-				o.log.Info("bid closed", "order-id", o.orderID)
+				o.log.Info("bid closed", "bid", attempt.id, "bseq", attempt.id.BSeq)
 				bidCounter.WithLabelValues("close", metricsutils.SuccessLabel).Inc()
 			}
 		}
@@ -518,6 +785,12 @@ loop:
 	}
 	if pricech != nil {
 		<-pricech
+	}
+	if queryBidsCh != nil {
+		<-queryBidsCh
+	}
+	if shouldBidCh != nil {
+		<-shouldBidCh
 	}
 }
 

--- a/bidengine/order.go
+++ b/bidengine/order.go
@@ -198,7 +198,7 @@ func bidIDWithSequence(orderID mtypes.OrderID, provider sdk.AccAddress, bseq uin
 
 func groupHasGPUModelWildcard(group *dtypes.Group) bool {
 	for _, resource := range group.GroupSpec.GetResourceUnits() {
-		gpu := resource.Resources.GetGPU()
+		gpu := resource.GetGPU()
 		if gpu == nil || gpu.GetUnits().Value() == 0 {
 			continue
 		}
@@ -262,6 +262,7 @@ func (o *order) run(checkForExistingBid bool) {
 		broadcastingBid     *mtypes.BidID
 		wonBid              *mtypes.BidID
 		stopCreatingBids    bool
+		cancelledBids       = make(map[mtypes.BidID]struct{})
 	)
 
 	groupch = runner.Do(func() runner.Result {
@@ -342,13 +343,7 @@ func (o *order) run(checkForExistingBid bool) {
 		}
 
 		bidID := attempts[idx].id
-		o.log.Debug("unreserving reservation", "bid", bidID, "bseq", bidID.BSeq)
-		if err := o.cluster.UnreserveBid(bidID); err != nil {
-			o.log.Error("error unreserving reservation", "err", err, "bid", bidID, "bseq", bidID.BSeq)
-			reservationCounter.WithLabelValues("close", metricsutils.FailLabel).Inc()
-		} else {
-			reservationCounter.WithLabelValues("close", metricsutils.SuccessLabel).Inc()
-		}
+		o.unreserveBid(bidID)
 		attempts[idx].reservation = nil
 	}
 
@@ -358,6 +353,23 @@ func (o *order) run(checkForExistingBid bool) {
 		}
 
 		attempts = append(attempts[:idx], attempts[idx+1:]...)
+	}
+
+	isCancelledBid := func(bidID mtypes.BidID) bool {
+		_, exists := cancelledBids[bidID]
+
+		return exists
+	}
+
+	handleCancelledReservation := func(result reservationResult) bool {
+		if !isCancelledBid(result.bidID) {
+			return false
+		}
+		if result.reservation != nil {
+			o.unreserveBid(result.bidID)
+		}
+
+		return true
 	}
 
 loop:
@@ -428,12 +440,6 @@ loop:
 				if ev.ID.Provider != o.session.Provider().Address().String() {
 					orderCompleteCounter.WithLabelValues("lease-lost").Inc()
 					o.log.Info("lease lost", "lease", ev.ID)
-					if broadcastingBid != nil {
-						idx := findBidAttempt(attempts, *broadcastingBid)
-						if idx != -1 {
-							attempts[idx].placed = true
-						}
-					}
 					break loop
 				}
 				orderCompleteCounter.WithLabelValues("lease-won").Inc()
@@ -477,6 +483,7 @@ loop:
 					break
 				}
 
+				cancelledBids[ev.ID] = struct{}{}
 				idx := findBidAttempt(attempts, ev.ID)
 				if idx == -1 {
 					break
@@ -564,6 +571,16 @@ loop:
 			}
 
 			reservationResult := result.Value().(reservationResult)
+			if handleCancelledReservation(reservationResult) {
+				if !startNextReservation() {
+					if placedBidCount(attempts) == 0 && pricech == nil && bidch == nil {
+						break loop
+					}
+					finishBidding()
+				}
+				continue
+			}
+
 			attempt := bidAttempt{
 				id:          reservationResult.bidID,
 				reservation: reservationResult.reservation,
@@ -715,16 +732,18 @@ loop:
 		clusterch = nil
 		if result.Error() == nil {
 			reservationResult := result.Value().(reservationResult)
-			attempt := bidAttempt{
-				id:          reservationResult.bidID,
-				reservation: reservationResult.reservation,
-				existing:    reservationResult.existing,
-				placed:      reservationResult.existing,
-			}
-			if idx := findBidAttempt(attempts, attempt.id); idx == -1 {
-				attempts = append(attempts, attempt)
-			} else {
-				attempts[idx].reservation = attempt.reservation
+			if !handleCancelledReservation(reservationResult) {
+				attempt := bidAttempt{
+					id:          reservationResult.bidID,
+					reservation: reservationResult.reservation,
+					existing:    reservationResult.existing,
+					placed:      reservationResult.existing,
+				}
+				if idx := findBidAttempt(attempts, attempt.id); idx == -1 {
+					attempts = append(attempts, attempt)
+				} else {
+					attempts[idx].reservation = attempt.reservation
+				}
 			}
 		}
 	}
@@ -777,6 +796,9 @@ loop:
 	if groupch != nil {
 		<-groupch
 	}
+	if storedGroupCh != nil {
+		<-storedGroupCh
+	}
 	if clusterch != nil {
 		<-clusterch
 	}
@@ -791,6 +813,16 @@ loop:
 	}
 	if shouldBidCh != nil {
 		<-shouldBidCh
+	}
+}
+
+func (o *order) unreserveBid(bidID mtypes.BidID) {
+	o.log.Debug("unreserving reservation", "bid", bidID, "bseq", bidID.BSeq)
+	if err := o.cluster.UnreserveBid(bidID); err != nil {
+		o.log.Error("error unreserving reservation", "err", err, "bid", bidID, "bseq", bidID.BSeq)
+		reservationCounter.WithLabelValues("close", metricsutils.FailLabel).Inc()
+	} else {
+		reservationCounter.WithLabelValues("close", metricsutils.SuccessLabel).Inc()
 	}
 }
 

--- a/bidengine/order_test.go
+++ b/bidengine/order_test.go
@@ -32,6 +32,7 @@ import (
 	"pkg.akt.dev/go/testutil"
 	"pkg.akt.dev/go/util/pubsub"
 
+	ctypes "github.com/akash-network/provider/cluster/types/v1beta3"
 	cmocks "github.com/akash-network/provider/mocks/cluster"
 	clmocks "github.com/akash-network/provider/mocks/cluster/types"
 	"github.com/akash-network/provider/operator/waiter"
@@ -55,6 +56,9 @@ type orderTestScaffold struct {
 	cluster           *cmocks.Cluster
 	broadcasts        chan []sdk.Msg
 	reserveCallNotify chan int
+	modifyGroup       func(*dvbeta.Group)
+	reserveBid        func(mtypes.BidID, dvbeta.ResourceGroup) (ctypes.Reservation, error)
+	pass              ProviderAttrSignatureService
 }
 
 type testBidPricingStrategy int64
@@ -101,6 +105,9 @@ func makeMocks(s *orderTestScaffold) {
 	}
 
 	groupResult.Group.GroupSpec.Resources[0] = resource
+	if s.modifyGroup != nil {
+		s.modifyGroup(&groupResult.Group)
+	}
 
 	homeDir, _ := os.MkdirTemp("", "akash-network-test-*")
 
@@ -119,7 +126,7 @@ func makeMocks(s *orderTestScaffold) {
 	queryMocks.On("Provider").Return(providerMocks, nil)
 
 	txMocks := &clientmocks.TxClient{}
-	s.broadcasts = make(chan []sdk.Msg, 1)
+	s.broadcasts = make(chan []sdk.Msg, 10)
 
 	txMocks.On("BroadcastMsgs", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		s.broadcasts <- args.Get(1).([]sdk.Msg)
@@ -143,13 +150,21 @@ func makeMocks(s *orderTestScaffold) {
 	mockReservation.On("GetAllocatedResources").Return(groupResult.Group.GroupSpec.Resources)
 
 	s.cluster = &cmocks.Cluster{}
-	s.reserveCallNotify = make(chan int, 1)
-	s.cluster.On("Reserve", s.orderID, &(groupResult.Group)).Run(func(_ mock.Arguments) {
+	s.reserveCallNotify = make(chan int, 20)
+	reserveBid := s.reserveBid
+	if reserveBid == nil {
+		reserveBid = func(mtypes.BidID, dvbeta.ResourceGroup) (ctypes.Reservation, error) {
+			return mockReservation, nil
+		}
+	}
+	s.cluster.On("ReserveBid", mock.Anything, &(groupResult.Group)).Run(func(_ mock.Arguments) {
 		s.reserveCallNotify <- 0
 		time.Sleep(time.Second) // add a delay before returning response, to test race conditions
-	}).Return(mockReservation, nil)
+	}).Return(reserveBid)
 
-	s.cluster.On("Unreserve", s.orderID, mock.Anything).Return(nil)
+	s.cluster.On("Reserve", s.orderID, &(groupResult.Group)).Return(mockReservation, nil)
+	s.cluster.On("Unreserve", s.orderID).Return(nil)
+	s.cluster.On("UnreserveBid", mock.Anything).Return(nil)
 }
 
 type nullProviderAttrSignatureService struct{}
@@ -162,6 +177,18 @@ func (nullProviderAttrSignatureService) GetAttributes() (attrtypes.Attributes, e
 	return nil, nil // Return no attributes & no error
 }
 
+type staticProviderAttrSignatureService struct {
+	attrs attrtypes.Attributes
+}
+
+func (s staticProviderAttrSignatureService) GetAuditorAttributeSignatures(_ string) (audittypes.AuditedProviders, error) {
+	return nil, nil
+}
+
+func (s staticProviderAttrSignatureService) GetAttributes() (attrtypes.Attributes, error) {
+	return s.attrs, nil
+}
+
 const testBidCreatedAt = 1234556789
 
 func makeOrderForTest(
@@ -171,6 +198,7 @@ func makeOrderForTest(
 	pricing BidPricingStrategy,
 	callerConfig *Config,
 	sessionHeight int64,
+	opts ...func(*orderTestScaffold),
 ) (*order, orderTestScaffold, <-chan int) {
 	if pricing == nil {
 		pricing = testBidPricingStrategy(1)
@@ -181,12 +209,14 @@ func makeOrderForTest(
 	scaffold.deploymentID = testutil.DeploymentID(t)
 	scaffold.groupID = dtypes.MakeGroupID(scaffold.deploymentID, 2)
 	scaffold.orderID = mtypes.MakeOrderID(scaffold.groupID, 1356326)
+	scaffold.testAddr = testutil.AccAddress(t)
+	for _, opt := range opts {
+		opt(&scaffold)
+	}
 
 	myLog := testutil.Logger(t)
 
 	makeMocks(&scaffold)
-
-	scaffold.testAddr = testutil.AccAddress(t)
 
 	myProvider := &ptypes.Provider{
 		Owner:      scaffold.testAddr.String(),
@@ -216,22 +246,37 @@ func makeOrderForTest(
 	if checkForExistingBid {
 		bidID := mtypes.MakeBidID(scaffold.orderID, mySession.Provider().Address())
 		scaffold.bidID = &bidID
-		queryBidRequest := &mvbeta.QueryBidRequest{
-			ID: bidID,
-		}
-		response := &mvbeta.QueryBidResponse{
-			Bid: mvbeta.Bid{
-				ID:        bidID,
-				State:     bidState,
-				Price:     sdk.NewInt64DecCoin(sdkutil.DenomUact, int64(testutil.RandRangeInt(100, 1000))),
-				CreatedAt: testBidCreatedAt,
+		queryBidsRequest := &mvbeta.QueryBidsRequest{
+			Filters: mvbeta.BidFilters{
+				Owner:    scaffold.orderID.Owner,
+				DSeq:     scaffold.orderID.DSeq,
+				GSeq:     scaffold.orderID.GSeq,
+				OSeq:     scaffold.orderID.OSeq,
+				Provider: mySession.Provider().Address().String(),
+				State:    mvbeta.BidOpen.String(),
 			},
 		}
-		scaffold.marketMocks.On("Bid", mock.Anything, queryBidRequest).Return(response, nil)
+		response := &mvbeta.QueryBidsResponse{
+			Bids: []mvbeta.QueryBidResponse{
+				{
+					Bid: mvbeta.Bid{
+						ID:        bidID,
+						State:     bidState,
+						Price:     sdk.NewInt64DecCoin(sdkutil.DenomUact, int64(testutil.RandRangeInt(100, 1000))),
+						CreatedAt: testBidCreatedAt,
+					},
+				},
+			},
+		}
+		scaffold.marketMocks.On("Bids", mock.Anything, queryBidsRequest).Return(response, nil)
 	}
 
 	reservationFulfilledNotify := make(chan int, 1)
-	order, err := newOrderInternal(serviceCast, scaffold.orderID, cfg, nullProviderAttrSignatureService{}, checkForExistingBid, reservationFulfilledNotify)
+	pass := scaffold.pass
+	if pass == nil {
+		pass = nullProviderAttrSignatureService{}
+	}
+	order, err := newOrderInternal(serviceCast, scaffold.orderID, cfg, pass, checkForExistingBid, reservationFulfilledNotify)
 
 	require.NoError(t, err)
 	require.NotNil(t, order)
@@ -251,12 +296,31 @@ func requireMsgType[T any](t *testing.T, res interface{}) T {
 	return msgs[0].(T)
 }
 
+func (s orderTestScaffold) bidIDForTest(bseq uint32) mtypes.BidID {
+	bidID := mtypes.MakeBidID(s.orderID, s.testAddr)
+	bidID.BSeq = bseq
+
+	return bidID
+}
+
+func resourceUnitsWithGPUModel(resources dvbeta.ResourceUnits, model string) dvbeta.ResourceUnits {
+	resources = resources.Dup()
+	resources[0].Resources.GPU.Attributes = attrtypes.Attributes{
+		{
+			Key:   "vendor/nvidia/model/" + model,
+			Value: "true",
+		},
+	}
+
+	return resources
+}
+
 func Test_BidOrderAndUnreserve(t *testing.T) {
 	order, scaffold, _ := makeOrderForTest(t, false, mvbeta.BidStateInvalid, nil, nil, testBidCreatedAt)
 
 	broadcast := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
 	// Should have called reserve once
-	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	createBidMsg := requireMsgType[*mvbeta.MsgCreateBid](t, broadcast)
 
@@ -274,7 +338,68 @@ func Test_BidOrderAndUnreserve(t *testing.T) {
 	order.lc.Shutdown(nil)
 
 	// Should have called unreserve once, nothing happened after the bid
-	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
+}
+
+func Test_BidOrderCreatesMultipleWildcardGPUBids(t *testing.T) {
+	models := []string{"rtx4090", "rtx5090"}
+	reserveCalls := 0
+	order, scaffold, _ := makeOrderForTest(t, false, mvbeta.BidStateInvalid, nil, nil, testBidCreatedAt, func(s *orderTestScaffold) {
+		s.modifyGroup = func(group *dvbeta.Group) {
+			group.GroupSpec.Resources[0].Resources.GPU.Units = rtypes.NewResourceValue(1)
+			group.GroupSpec.Resources[0].Resources.GPU.Attributes = attrtypes.Attributes{
+				{
+					Key:   "vendor/nvidia/model/*",
+					Value: "true",
+				},
+			}
+		}
+		s.pass = staticProviderAttrSignatureService{attrs: attrtypes.Attributes{
+			{
+				Key:   "capabilities/gpu/vendor/nvidia/model/rtx4090",
+				Value: "true",
+			},
+			{
+				Key:   "capabilities/gpu/vendor/nvidia/model/rtx5090",
+				Value: "true",
+			},
+		}}
+		s.reserveBid = func(bidID mtypes.BidID, group dvbeta.ResourceGroup) (ctypes.Reservation, error) {
+			if reserveCalls >= len(models) {
+				return nil, ctypes.ErrInsufficientCapacity
+			}
+
+			reservation := &clmocks.Reservation{}
+			reservation.On("OrderID").Return(s.orderID)
+			reservation.On("Resources").Return(group)
+			reservation.On("GetAllocatedResources").Return(resourceUnitsWithGPUModel(group.GetResourceUnits(), models[reserveCalls]))
+			reserveCalls++
+
+			return reservation, nil
+		}
+	})
+
+	firstBroadcast := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
+	firstBid := requireMsgType[*mvbeta.MsgCreateBid](t, firstBroadcast)
+	require.Equal(t, uint32(0), firstBid.ID.BSeq)
+	require.Equal(t, "vendor/nvidia/model/rtx4090", firstBid.ResourcesOffer[0].Resources.GPU.Attributes[0].Key)
+
+	secondBroadcast := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
+	secondBid := requireMsgType[*mvbeta.MsgCreateBid](t, secondBroadcast)
+	require.Equal(t, uint32(1), secondBid.ID.BSeq)
+	require.Equal(t, "vendor/nvidia/model/rtx5090", secondBid.ResourcesOffer[0].Resources.GPU.Attributes[0].Key)
+
+	leaseID := mtypes.MakeLeaseID(firstBid.ID)
+	err := scaffold.testBus.Publish(&mtypes.EventLeaseCreated{
+		ID:    leaseID,
+		Price: testutil.AkashDecCoin(t, 1),
+	})
+	require.NoError(t, err)
+
+	<-order.lc.Done()
+
+	scaffold.cluster.AssertNotCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(1))
 }
 
 func Test_BidOrderAndUnreserveOnTimeout(t *testing.T) {
@@ -284,7 +409,7 @@ func Test_BidOrderAndUnreserveOnTimeout(t *testing.T) {
 
 	broadcast := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
 	// Should have called reserve once
-	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	createBidMsg := requireMsgType[*mvbeta.MsgCreateBid](t, broadcast)
 
@@ -313,7 +438,7 @@ func Test_BidOrderAndUnreserveOnTimeout(t *testing.T) {
 	}
 
 	// Should have called unreserve once
-	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
 }
 
 func Test_BidOrderPriceTooHigh(t *testing.T) {
@@ -327,7 +452,7 @@ func Test_BidOrderPriceTooHigh(t *testing.T) {
 		t.Fatal("timed out waiting in test")
 	}
 	// Should have called reserve once
-	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	select {
 	case <-scaffold.broadcasts:
@@ -336,7 +461,7 @@ func Test_BidOrderPriceTooHigh(t *testing.T) {
 	}
 
 	// Should have called unreserve once, nothing happened after the bid
-	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
 
 }
 
@@ -345,7 +470,7 @@ func Test_BidOrderAndThenClosedUnreserve(t *testing.T) {
 
 	testutil.ChannelWaitForValue(t, scaffold.broadcasts)
 	// Should have called reserve once at this point
-	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	ev := &mtypes.EventOrderClosed{
 		ID: scaffold.orderID,
@@ -358,7 +483,7 @@ func Test_BidOrderAndThenClosedUnreserve(t *testing.T) {
 	<-order.lc.Done()
 
 	// Should have called unreserve once
-	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
 }
 
 func Test_OrderCloseBeforeReserveReturn(t *testing.T) {
@@ -366,7 +491,7 @@ func Test_OrderCloseBeforeReserveReturn(t *testing.T) {
 
 	testutil.ChannelWaitForValue(t, scaffold.reserveCallNotify)
 	// Should have called reserve once at this point
-	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	// reservationFulfilledNotify channel shouldn't have got any value yet because the Reserve call
 	// returns after a delay of one second
@@ -396,7 +521,7 @@ func Test_OrderCloseBeforeReserveReturn(t *testing.T) {
 	<-order.lc.Done()
 
 	// Should have called unreserve once
-	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
 }
 
 func Test_BidOrderAndThenLeaseCreated(t *testing.T) {
@@ -431,10 +556,10 @@ func Test_BidOrderAndThenLeaseCreated(t *testing.T) {
 	<-order.lc.Done()
 
 	// Should have called reserve once
-	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	// Should not have called unreserve
-	scaffold.cluster.AssertNotCalled(t, "Unreserve", mock.Anything, mock.Anything)
+	scaffold.cluster.AssertNotCalled(t, "UnreserveBid", mock.Anything)
 }
 
 func Test_BidOrderAndThenLeaseCreatedForDifferentDeployment(t *testing.T) {
@@ -446,7 +571,7 @@ func Test_BidOrderAndThenLeaseCreatedForDifferentDeployment(t *testing.T) {
 	broadcast := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
 
 	// Should have called reserve once
-	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	createBidMsg := requireMsgType[*mvbeta.MsgCreateBid](t, broadcast)
 
@@ -470,13 +595,13 @@ func Test_BidOrderAndThenLeaseCreatedForDifferentDeployment(t *testing.T) {
 	testutil.ChannelWaitForValue(t, subscriber.Events())
 
 	// Should not have called unreserve yet
-	scaffold.cluster.AssertNotCalled(t, "Unreserve", mock.Anything, mock.Anything)
+	scaffold.cluster.AssertNotCalled(t, "UnreserveBid", mock.Anything)
 
 	// Shutdown after the message has been published
 	order.lc.Shutdown(nil)
 
 	// Should have called unreserve
-	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
 
 	// The last call should be a broadcast to close the bid
 	txCalls := scaffold.txClient.Calls
@@ -497,10 +622,19 @@ func Test_ShouldNotBidWhenAlreadySet(t *testing.T) {
 	testutil.ChannelWaitForValue(t, scaffold.reserveCallNotify)
 
 	// Should have queried for the bid
-	scaffold.marketMocks.AssertCalled(t, "Bid", mock.Anything, &mvbeta.QueryBidRequest{ID: *scaffold.bidID})
+	scaffold.marketMocks.AssertCalled(t, "Bids", mock.Anything, &mvbeta.QueryBidsRequest{
+		Filters: mvbeta.BidFilters{
+			Owner:    scaffold.orderID.Owner,
+			DSeq:     scaffold.orderID.DSeq,
+			GSeq:     scaffold.orderID.GSeq,
+			OSeq:     scaffold.orderID.OSeq,
+			Provider: scaffold.testAddr.String(),
+			State:    mvbeta.BidOpen.String(),
+		},
+	})
 
 	// Should have called reserve once
-	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	// Wait for the reservation to be processed
 	testutil.ChannelWaitForValue(t, reservationFulfilledNotify)
@@ -517,7 +651,7 @@ func Test_ShouldNotBidWhenAlreadySet(t *testing.T) {
 	<-order.lc.Done()
 
 	// Should have called unreserve during shutdown
-	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
 
 	var broadcast []sdk.Msg
 	select {
@@ -545,7 +679,7 @@ func Test_ShouldCloseBidWhenAlreadySetAndOld(t *testing.T) {
 	testutil.ChannelWaitForClose(t, order.lc.Done())
 
 	// Should not have called reserve
-	scaffold.cluster.AssertNotCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertNotCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	// Should have closed the bid
 	expMsgs := []sdk.Msg{&mvbeta.MsgCloseBid{
@@ -571,7 +705,7 @@ func Test_ShouldExitWhenAlreadySetAndLost(t *testing.T) {
 	testutil.ChannelWaitForClose(t, order.lc.Done())
 
 	// Should not have called reserve
-	scaffold.cluster.AssertNotCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertNotCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	// Should not have closed the bid
 	expMsgs := &mvbeta.MsgCloseBid{
@@ -596,7 +730,7 @@ func Test_ShouldCloseBidWhenAlreadySetAndThenTimeout(t *testing.T) {
 	testutil.ChannelWaitForClose(t, order.lc.Done())
 
 	// Should have called reserve
-	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	// Should have closed the bid
 	expMsgs := []sdk.Msg{
@@ -608,7 +742,7 @@ func Test_ShouldCloseBidWhenAlreadySetAndThenTimeout(t *testing.T) {
 	scaffold.txClient.AssertCalled(t, "BroadcastMsgs", mock.Anything, expMsgs, mock.Anything)
 
 	// Should have called unreserve
-	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID)
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
 }
 
 func Test_ShouldRecognizeLeaseCreatedIfBiddingIsSkipped(t *testing.T) {
@@ -618,10 +752,10 @@ func Test_ShouldRecognizeLeaseCreatedIfBiddingIsSkipped(t *testing.T) {
 	testutil.ChannelWaitForValue(t, scaffold.reserveCallNotify)
 
 	// Should have called reserve once
-	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	// Should not have called unreserve
-	scaffold.cluster.AssertNotCalled(t, "Unreserve", mock.Anything, mock.Anything)
+	scaffold.cluster.AssertNotCalled(t, "UnreserveBid", mock.Anything)
 
 	leaseID := mtypes.MakeLeaseID(mtypes.MakeBidID(scaffold.orderID, scaffold.testAddr))
 
@@ -637,7 +771,7 @@ func Test_ShouldRecognizeLeaseCreatedIfBiddingIsSkipped(t *testing.T) {
 	<-order.lc.Done()
 
 	// Should not have called unreserve during shutdown
-	scaffold.cluster.AssertNotCalled(t, "Unreserve", mock.Anything, mock.Anything)
+	scaffold.cluster.AssertNotCalled(t, "UnreserveBid", mock.Anything)
 
 	var broadcast []sdk.Msg
 
@@ -675,7 +809,7 @@ func Test_BidOrderUsesBidPricingStrategy(t *testing.T) {
 	order.lc.Shutdown(nil)
 
 	// Should have called unreserve once, nothing happened after the bid
-	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
 }
 
 func (afbps alwaysFailsBidPricingStrategy) CalculatePrice(_ context.Context, _ Request) (sdk.DecCoin, error) {
@@ -692,7 +826,7 @@ func Test_BidOrderFailsAndAborts(t *testing.T) {
 	<-order.lc.Done() // Stops whenever the bid pricing is called and returns an errro
 
 	// Should have called reserve once
-	scaffold.cluster.AssertCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	var broadcast []sdk.Msg
 
@@ -704,7 +838,7 @@ func Test_BidOrderFailsAndAborts(t *testing.T) {
 	require.Nil(t, broadcast)
 
 	// Should have called unreserve once, nothing happened after the bid
-	scaffold.cluster.AssertCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
 }
 
 func Test_ShouldntBidIfOrderAttrsDontMatch(t *testing.T) {
@@ -720,7 +854,7 @@ func Test_ShouldntBidIfOrderAttrsDontMatch(t *testing.T) {
 	<-order.lc.Done() // Stops whenever it figures it shouldn't bid
 
 	// Should not have called reserve ever
-	scaffold.cluster.AssertNotCalled(t, "Reserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertNotCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
 	var broadcast []sdk.Msg
 
@@ -732,7 +866,7 @@ func Test_ShouldntBidIfOrderAttrsDontMatch(t *testing.T) {
 	require.Nil(t, broadcast)
 
 	// Should not have called unreserve ever, as nothing was ever reserved
-	scaffold.cluster.AssertNotCalled(t, "Unreserve", scaffold.orderID, mock.Anything)
+	scaffold.cluster.AssertNotCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
 }
 
 // TODO - add test failing the call to Broadcast on TxClient and

--- a/bidengine/order_test.go
+++ b/bidengine/order_test.go
@@ -256,17 +256,18 @@ func makeOrderForTest(
 				State:    mvbeta.BidOpen.String(),
 			},
 		}
-		response := &mvbeta.QueryBidsResponse{
-			Bids: []mvbeta.QueryBidResponse{
+		response := &mvbeta.QueryBidsResponse{}
+		if bidState == mvbeta.BidOpen {
+			response.Bids = []mvbeta.QueryBidResponse{
 				{
 					Bid: mvbeta.Bid{
 						ID:        bidID,
-						State:     bidState,
+						State:     mvbeta.BidOpen,
 						Price:     sdk.NewInt64DecCoin(sdkutil.DenomUact, int64(testutil.RandRangeInt(100, 1000))),
 						CreatedAt: testBidCreatedAt,
 					},
 				},
-			},
+			}
 		}
 		scaffold.marketMocks.On("Bids", mock.Anything, queryBidsRequest).Return(response, nil)
 	}
@@ -690,7 +691,7 @@ func Test_ShouldCloseBidWhenAlreadySetAndOld(t *testing.T) {
 	scaffold.txClient.AssertCalled(t, "BroadcastMsgs", mock.Anything, expMsgs, mock.Anything)
 }
 
-func Test_ShouldExitWhenAlreadySetAndLost(t *testing.T) {
+func Test_ShouldBidWhenExistingBidIsLost(t *testing.T) {
 	pricing, err := MakeRandomRangePricing()
 	require.NoError(t, err)
 	cfg := Config{
@@ -702,17 +703,15 @@ func Test_ShouldExitWhenAlreadySetAndLost(t *testing.T) {
 
 	order, scaffold, _ := makeOrderForTest(t, true, mvbeta.BidLost, nil, &cfg, testBidCreatedAt)
 
-	testutil.ChannelWaitForClose(t, order.lc.Done())
+	broadcast := testutil.ChannelWaitForValue(t, scaffold.broadcasts)
+	createBidMsg := requireMsgType[*mvbeta.MsgCreateBid](t, broadcast)
 
-	// Should not have called reserve
-	scaffold.cluster.AssertNotCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
+	require.Equal(t, scaffold.bidIDForTest(0), createBidMsg.ID)
+	scaffold.cluster.AssertCalled(t, "ReserveBid", scaffold.bidIDForTest(0), mock.Anything)
 
-	// Should not have closed the bid
-	expMsgs := &mvbeta.MsgCloseBid{
-		ID: mtypes.MakeBidID(order.orderID, scaffold.testAddr),
-	}
+	order.lc.Shutdown(nil)
 
-	scaffold.txClient.AssertNotCalled(t, "BroadcastMsgs", mock.Anything, expMsgs, mock.Anything)
+	scaffold.cluster.AssertCalled(t, "UnreserveBid", scaffold.bidIDForTest(0))
 }
 
 func Test_ShouldCloseBidWhenAlreadySetAndThenTimeout(t *testing.T) {

--- a/cluster/inventory.go
+++ b/cluster/inventory.go
@@ -791,16 +791,7 @@ loop:
 				res := run.Value().(runCheckResult)
 				state.ipAddrUsage = res.ipResult
 
-				// Process confirmed IP addresses usage
-				for _, confirmedOrderID := range res.confirmedResult {
-					for i, entry := range state.reservations {
-						if entry.OrderID().Equals(confirmedOrderID) {
-							state.reservations[i].ipsConfirmed = true
-							is.log.Info("confirmed IP allocation", "orderID", confirmedOrderID)
-							break
-						}
-					}
-				}
+				is.confirmReservedIPs(state, res.confirmedResult)
 			} else {
 				is.log.Error("checking IP addresses", "error", err)
 			}
@@ -832,14 +823,27 @@ loop:
 	is.log.Debug("shutdown complete")
 }
 
+func (is *inventoryService) confirmReservedIPs(state *inventoryServiceState, confirmed []mtypes.BidID) {
+	for _, confirmedBidID := range confirmed {
+		for i, entry := range state.reservations {
+			if entry.bid == confirmedBidID {
+				state.reservations[i].ipsConfirmed = true
+				is.log.Info("confirmed IP allocation", "orderID", confirmedBidID.OrderID(), "bid", confirmedBidID)
+				break
+			}
+		}
+	}
+}
+
 type confirmationItem struct {
+	bidID            mtypes.BidID
 	orderID          mtypes.OrderID
 	expectedQuantity uint
 }
 
 type runCheckResult struct {
 	ipResult        cip.AddressUsage
-	confirmedResult []mtypes.OrderID
+	confirmedResult []mtypes.BidID
 }
 
 func (is *inventoryService) runCheck(ctx context.Context, state *inventoryServiceState) <-chan runner.Result {
@@ -857,6 +861,7 @@ func (is *inventoryService) runCheck(ctx context.Context, state *inventoryServic
 		}
 
 		confirm = append(confirm, confirmationItem{
+			bidID:            entry.bid,
 			orderID:          entry.OrderID(),
 			expectedQuantity: entry.endpointQuantity,
 		})
@@ -882,7 +887,7 @@ func (is *inventoryService) runCheck(ctx context.Context, state *inventoryServic
 
 			numConfirmed := uint(len(status))
 			if numConfirmed == confirmItem.expectedQuantity {
-				retval.confirmedResult = append(retval.confirmedResult, confirmItem.orderID)
+				retval.confirmedResult = append(retval.confirmedResult, confirmItem.bidID)
 			}
 		}
 

--- a/cluster/inventory.go
+++ b/cluster/inventory.go
@@ -78,14 +78,17 @@ type invSnapshotResp struct {
 }
 
 type inventoryRequest struct {
+	bid       mtypes.BidID
+	exactBid  bool
 	order     mtypes.OrderID
 	resources dtypes.ResourceGroup
 	ch        chan<- inventoryResponse
 }
 
 type inventoryResponse struct {
-	value ctypes.Reservation
-	err   error
+	value   ctypes.Reservation
+	removed int64
+	err     error
 }
 
 type inventoryService struct {
@@ -145,7 +148,7 @@ func newInventoryService(
 
 	reservations := make([]*reservation, 0, len(deployments))
 	for _, d := range deployments {
-		res := newReservation(d.LeaseID().OrderID(), d.ManifestGroup())
+		res := newReservation(d.LeaseID().BidID(), d.ManifestGroup())
 		res.SetClusterParams(d.ClusterParams())
 
 		reservations = append(reservations, res)
@@ -182,7 +185,30 @@ func (is *inventoryService) lookup(order mtypes.OrderID, resources dtypes.Resour
 	}
 }
 
+func (is *inventoryService) lookupBid(bid mtypes.BidID, resources dtypes.ResourceGroup) (ctypes.Reservation, error) {
+	ch := make(chan inventoryResponse, 1)
+	req := inventoryRequest{
+		bid:       bid,
+		exactBid:  true,
+		order:     bid.OrderID(),
+		resources: resources,
+		ch:        ch,
+	}
+
+	select {
+	case is.lookupch <- req:
+		response := <-ch
+		return response.value, response.err
+	case <-is.lc.ShuttingDown():
+		return nil, ErrNotRunning
+	}
+}
+
 func (is *inventoryService) reserve(order mtypes.OrderID, resources dtypes.ResourceGroup) (ctypes.Reservation, error) {
+	return is.reserveBid(bidIDFromOrder(order), resources)
+}
+
+func (is *inventoryService) reserveBid(bid mtypes.BidID, resources dtypes.ResourceGroup) (ctypes.Reservation, error) {
 	for idx, res := range resources.GetResourceUnits() {
 		if res.CPU == nil {
 			return nil, fmt.Errorf("%w: CPU resource at idx %d is nil", ErrInvalidResource, idx)
@@ -197,7 +223,8 @@ func (is *inventoryService) reserve(order mtypes.OrderID, resources dtypes.Resou
 
 	ch := make(chan inventoryResponse, 1)
 	req := inventoryRequest{
-		order:     order,
+		bid:       bid,
+		order:     bid.OrderID(),
 		resources: resources,
 		ch:        ch,
 	}
@@ -226,13 +253,52 @@ func (is *inventoryService) unreserve(order mtypes.OrderID) error { // nolint: u
 	case is.unreservech <- req:
 		response := <-ch
 		if response.err == nil {
-			cnt := atomic.AddInt64(&is.reservationCount, -1)
+			cnt := atomic.AddInt64(&is.reservationCount, -response.removed)
 			is.log.Debug("reservation count", "cnt", cnt)
 		}
 		return response.err
 	case <-is.lc.ShuttingDown():
 		return ErrNotRunning
 	}
+}
+
+func (is *inventoryService) unreserveBid(bid mtypes.BidID) error {
+	ch := make(chan inventoryResponse, 1)
+	req := inventoryRequest{
+		bid:      bid,
+		exactBid: true,
+		order:    bid.OrderID(),
+		ch:       ch,
+	}
+
+	select {
+	case is.unreservech <- req:
+		response := <-ch
+		if response.err == nil {
+			cnt := atomic.AddInt64(&is.reservationCount, -response.removed)
+			is.log.Debug("reservation count", "cnt", cnt)
+		}
+		return response.err
+	case <-is.lc.ShuttingDown():
+		return ErrNotRunning
+	}
+}
+
+func bidIDFromOrder(order mtypes.OrderID) mtypes.BidID {
+	return mtypes.BidID{
+		Owner: order.Owner,
+		DSeq:  order.DSeq,
+		GSeq:  order.GSeq,
+		OSeq:  order.OSeq,
+	}
+}
+
+func reservationMatchesLease(res *reservation, leaseID mtypes.LeaseID) bool {
+	if res.bid.Provider == "" {
+		return res.OrderID().Equals(leaseID.OrderID())
+	}
+
+	return res.bid == leaseID.BidID()
 }
 
 func (is *inventoryService) status(ctx context.Context) (inventoryV1.InventoryMetrics, error) {
@@ -447,7 +513,7 @@ func (is *inventoryService) handleRequest(req inventoryRequest, state *inventory
 	// convert the resources to the committed amount
 	resourcesToCommit := is.resourcesToCommit(req.resources)
 	// create new registration if capacity available
-	reservation := newReservation(req.order, resourcesToCommit)
+	reservation := newReservation(req.bid, resourcesToCommit)
 
 	{
 		jReservation, _ := json.Marshal(req.resources.GetResourceUnits())
@@ -554,7 +620,7 @@ loop:
 			case event.ClusterDeployment:
 				// mark reservation allocated if deployment successful
 				for _, res := range state.reservations {
-					if !res.OrderID().Equals(ev.LeaseID.OrderID()) {
+					if !reservationMatchesLease(res, ev.LeaseID) {
 						continue
 					}
 					if res.Resources().GetName() != ev.Group.Name {
@@ -597,7 +663,11 @@ loop:
 		case req := <-is.lookupch:
 			// lookup registration
 			for _, res := range state.reservations {
-				if !res.OrderID().Equals(req.order) {
+				if req.exactBid {
+					if res.bid != req.bid {
+						continue
+					}
+				} else if !res.OrderID().Equals(req.order) {
 					continue
 				}
 				if res.Resources().GetName() != req.resources.GetName() {
@@ -611,26 +681,44 @@ loop:
 			inventoryRequestsCounter.WithLabelValues("lookup", "not-found").Inc()
 			req.ch <- inventoryResponse{err: errReservationNotFound}
 		case req := <-is.unreservech:
-			is.log.Debug("unreserving capacity", "order", req.order)
+			is.log.Debug("unreserving capacity", "order", req.order, "bid", req.bid)
 			// remove reservation
 
-			is.log.Info("attempting to removing reservation", "order", req.order)
+			is.log.Info("attempting to removing reservation", "order", req.order, "bid", req.bid)
 
-			for idx, res := range state.reservations {
-				if !res.OrderID().Equals(req.order) {
+			removed := int64(0)
+			for idx := 0; idx < len(state.reservations); {
+				res := state.reservations[idx]
+				if req.exactBid {
+					if res.bid != req.bid {
+						idx++
+						continue
+					}
+				} else if !res.OrderID().Equals(req.order) {
+					idx++
 					continue
 				}
 
-				is.log.Info("removing reservation", "order", res.OrderID())
+				is.log.Info("removing reservation", "order", res.OrderID(), "bid", res.bid)
 
 				state.reservations = append(state.reservations[:idx], state.reservations[idx+1:]...)
 				// reclaim availableExternalPorts if unreserving allocated resources
 				if res.allocated {
 					is.availableExternalPorts += reservationCountEndpoints(res)
 				}
+				removed++
 
-				req.ch <- inventoryResponse{value: res}
-				is.log.Info("unreserve capacity complete", "order", req.order)
+				if req.exactBid {
+					req.ch <- inventoryResponse{value: res, removed: removed}
+					is.log.Info("unreserve capacity complete", "order", req.order, "bid", req.bid)
+					inventoryRequestsCounter.WithLabelValues("unreserve", "destroyed").Inc()
+					continue loop
+				}
+			}
+
+			if removed != 0 {
+				req.ch <- inventoryResponse{removed: removed}
+				is.log.Info("unreserve capacity complete", "order", req.order, "removed", removed)
 				inventoryRequestsCounter.WithLabelValues("unreserve", "destroyed").Inc()
 				continue loop
 			}
@@ -706,7 +794,7 @@ loop:
 				// Process confirmed IP addresses usage
 				for _, confirmedOrderID := range res.confirmedResult {
 					for i, entry := range state.reservations {
-						if entry.order.Equals(confirmedOrderID) {
+						if entry.OrderID().Equals(confirmedOrderID) {
 							state.reservations[i].ipsConfirmed = true
 							is.log.Info("confirmed IP allocation", "orderID", confirmedOrderID)
 							break

--- a/cluster/inventory_test.go
+++ b/cluster/inventory_test.go
@@ -339,6 +339,29 @@ func makeInventoryScaffold(t *testing.T, leaseQty uint) *inventoryScaffold {
 	return scaffold
 }
 
+func TestInventory_ConfirmReservedIPsMatchesExactBid(t *testing.T) {
+	orderID := testutil.OrderID(t)
+	bid0 := mtypes.MakeBidID(orderID, testutil.AccAddress(t))
+	bid1 := bid0
+	bid1.BSeq = 1
+
+	group := makeGroupForInventoryTest(false, false, true)
+	reservation0 := newReservation(bid0, group)
+	reservation1 := newReservation(bid1, group)
+
+	state := &inventoryServiceState{
+		reservations: []*reservation{reservation0, reservation1},
+	}
+	inventory := &inventoryService{
+		log: testutil.Logger(t),
+	}
+
+	inventory.confirmReservedIPs(state, []mtypes.BidID{bid1})
+
+	require.False(t, state.reservations[0].ipsConfirmed)
+	require.True(t, state.reservations[1].ipsConfirmed)
+}
+
 func makeGroupForInventoryTest(sharedHTTP, nodePort, leasedIP bool) manifest.Group {
 	groupServices := make([]manifest.Service, 1)
 

--- a/cluster/reservation.go
+++ b/cluster/reservation.go
@@ -9,15 +9,15 @@ import (
 	"github.com/akash-network/provider/cluster/util"
 )
 
-func newReservation(order mtypes.OrderID, resources dtypes.ResourceGroup) *reservation {
+func newReservation(bid mtypes.BidID, resources dtypes.ResourceGroup) *reservation {
 	return &reservation{
-		order:            order,
+		bid:              bid,
 		resources:        resources,
 		endpointQuantity: util.GetEndpointQuantityOfResourceGroup(resources, rtypes.Endpoint_LEASED_IP)}
 }
 
 type reservation struct {
-	order             mtypes.OrderID
+	bid               mtypes.BidID
 	resources         dtypes.ResourceGroup
 	adjustedResources dtypes.ResourceUnits
 	clusterParams     interface{}
@@ -29,7 +29,7 @@ type reservation struct {
 var _ ctypes.Reservation = (*reservation)(nil)
 
 func (r *reservation) OrderID() mtypes.OrderID {
-	return r.order
+	return r.bid.OrderID()
 }
 
 func (r *reservation) Resources() dtypes.ResourceGroup {

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -77,7 +77,9 @@ type checkDeploymentExistsRequest struct {
 // Cluster is the interface that wraps Reserve and Unreserve methods
 type Cluster interface {
 	Reserve(mtypes.OrderID, dtypes.ResourceGroup) (ctypes.Reservation, error)
+	ReserveBid(mtypes.BidID, dtypes.ResourceGroup) (ctypes.Reservation, error)
 	Unreserve(mtypes.OrderID) error
+	UnreserveBid(mtypes.BidID) error
 }
 
 // StatusClient is the interface which includes status of service
@@ -225,8 +227,16 @@ func (s *service) Reserve(order mtypes.OrderID, resources dtypes.ResourceGroup) 
 	return s.inventory.reserve(order, resources)
 }
 
+func (s *service) ReserveBid(bid mtypes.BidID, resources dtypes.ResourceGroup) (ctypes.Reservation, error) {
+	return s.inventory.reserveBid(bid, resources)
+}
+
 func (s *service) Unreserve(order mtypes.OrderID) error {
 	return s.inventory.unreserve(order)
+}
+
+func (s *service) UnreserveBid(bid mtypes.BidID) error {
+	return s.inventory.unreserveBid(bid)
 }
 
 func (s *service) HostnameService() ctypes.HostnameServiceClient {
@@ -353,7 +363,7 @@ loop:
 					break
 				}
 
-				reservation, err := s.inventory.lookup(ev.LeaseID.OrderID(), mgroup)
+				reservation, err := s.inventory.lookupBid(ev.LeaseID.BidID(), mgroup)
 				if err != nil {
 					s.log.Error("error looking up manifest", "err", err, "lease", ev.LeaseID, "group-name", mgroup.Name)
 					break

--- a/mocks/cluster/Cluster_mock.go
+++ b/mocks/cluster/Cluster_mock.go
@@ -106,6 +106,74 @@ func (_c *Cluster_Reserve_Call) RunAndReturn(run func(orderID v1.OrderID, resour
 	return _c
 }
 
+// ReserveBid provides a mock function for the type Cluster
+func (_mock *Cluster) ReserveBid(bidID v1.BidID, resourceGroup v1beta4.ResourceGroup) (v1beta3.Reservation, error) {
+	ret := _mock.Called(bidID, resourceGroup)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReserveBid")
+	}
+
+	var r0 v1beta3.Reservation
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(v1.BidID, v1beta4.ResourceGroup) (v1beta3.Reservation, error)); ok {
+		return returnFunc(bidID, resourceGroup)
+	}
+	if returnFunc, ok := ret.Get(0).(func(v1.BidID, v1beta4.ResourceGroup) v1beta3.Reservation); ok {
+		r0 = returnFunc(bidID, resourceGroup)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(v1beta3.Reservation)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(v1.BidID, v1beta4.ResourceGroup) error); ok {
+		r1 = returnFunc(bidID, resourceGroup)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Cluster_ReserveBid_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReserveBid'
+type Cluster_ReserveBid_Call struct {
+	*mock.Call
+}
+
+// ReserveBid is a helper method to define mock.On call
+//   - bidID v1.BidID
+//   - resourceGroup v1beta4.ResourceGroup
+func (_e *Cluster_Expecter) ReserveBid(bidID interface{}, resourceGroup interface{}) *Cluster_ReserveBid_Call {
+	return &Cluster_ReserveBid_Call{Call: _e.mock.On("ReserveBid", bidID, resourceGroup)}
+}
+
+func (_c *Cluster_ReserveBid_Call) Run(run func(bidID v1.BidID, resourceGroup v1beta4.ResourceGroup)) *Cluster_ReserveBid_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 v1.BidID
+		if args[0] != nil {
+			arg0 = args[0].(v1.BidID)
+		}
+		var arg1 v1beta4.ResourceGroup
+		if args[1] != nil {
+			arg1 = args[1].(v1beta4.ResourceGroup)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Cluster_ReserveBid_Call) Return(reservation v1beta3.Reservation, err error) *Cluster_ReserveBid_Call {
+	_c.Call.Return(reservation, err)
+	return _c
+}
+
+func (_c *Cluster_ReserveBid_Call) RunAndReturn(run func(bidID v1.BidID, resourceGroup v1beta4.ResourceGroup) (v1beta3.Reservation, error)) *Cluster_ReserveBid_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Unreserve provides a mock function for the type Cluster
 func (_mock *Cluster) Unreserve(orderID v1.OrderID) error {
 	ret := _mock.Called(orderID)
@@ -153,6 +221,57 @@ func (_c *Cluster_Unreserve_Call) Return(err error) *Cluster_Unreserve_Call {
 }
 
 func (_c *Cluster_Unreserve_Call) RunAndReturn(run func(orderID v1.OrderID) error) *Cluster_Unreserve_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UnreserveBid provides a mock function for the type Cluster
+func (_mock *Cluster) UnreserveBid(bidID v1.BidID) error {
+	ret := _mock.Called(bidID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UnreserveBid")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(v1.BidID) error); ok {
+		r0 = returnFunc(bidID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Cluster_UnreserveBid_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UnreserveBid'
+type Cluster_UnreserveBid_Call struct {
+	*mock.Call
+}
+
+// UnreserveBid is a helper method to define mock.On call
+//   - bidID v1.BidID
+func (_e *Cluster_Expecter) UnreserveBid(bidID interface{}) *Cluster_UnreserveBid_Call {
+	return &Cluster_UnreserveBid_Call{Call: _e.mock.On("UnreserveBid", bidID)}
+}
+
+func (_c *Cluster_UnreserveBid_Call) Run(run func(bidID v1.BidID)) *Cluster_UnreserveBid_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 v1.BidID
+		if args[0] != nil {
+			arg0 = args[0].(v1.BidID)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Cluster_UnreserveBid_Call) Return(err error) *Cluster_UnreserveBid_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Cluster_UnreserveBid_Call) RunAndReturn(run func(bidID v1.BidID) error) *Cluster_UnreserveBid_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/cluster/Service_mock.go
+++ b/mocks/cluster/Service_mock.go
@@ -384,6 +384,74 @@ func (_c *Service_Reserve_Call) RunAndReturn(run func(orderID v1.OrderID, resour
 	return _c
 }
 
+// ReserveBid provides a mock function for the type Service
+func (_mock *Service) ReserveBid(bidID v1.BidID, resourceGroup v1beta4.ResourceGroup) (v1beta3.Reservation, error) {
+	ret := _mock.Called(bidID, resourceGroup)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReserveBid")
+	}
+
+	var r0 v1beta3.Reservation
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(v1.BidID, v1beta4.ResourceGroup) (v1beta3.Reservation, error)); ok {
+		return returnFunc(bidID, resourceGroup)
+	}
+	if returnFunc, ok := ret.Get(0).(func(v1.BidID, v1beta4.ResourceGroup) v1beta3.Reservation); ok {
+		r0 = returnFunc(bidID, resourceGroup)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(v1beta3.Reservation)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(v1.BidID, v1beta4.ResourceGroup) error); ok {
+		r1 = returnFunc(bidID, resourceGroup)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Service_ReserveBid_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReserveBid'
+type Service_ReserveBid_Call struct {
+	*mock.Call
+}
+
+// ReserveBid is a helper method to define mock.On call
+//   - bidID v1.BidID
+//   - resourceGroup v1beta4.ResourceGroup
+func (_e *Service_Expecter) ReserveBid(bidID interface{}, resourceGroup interface{}) *Service_ReserveBid_Call {
+	return &Service_ReserveBid_Call{Call: _e.mock.On("ReserveBid", bidID, resourceGroup)}
+}
+
+func (_c *Service_ReserveBid_Call) Run(run func(bidID v1.BidID, resourceGroup v1beta4.ResourceGroup)) *Service_ReserveBid_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 v1.BidID
+		if args[0] != nil {
+			arg0 = args[0].(v1.BidID)
+		}
+		var arg1 v1beta4.ResourceGroup
+		if args[1] != nil {
+			arg1 = args[1].(v1beta4.ResourceGroup)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Service_ReserveBid_Call) Return(reservation v1beta3.Reservation, err error) *Service_ReserveBid_Call {
+	_c.Call.Return(reservation, err)
+	return _c
+}
+
+func (_c *Service_ReserveBid_Call) RunAndReturn(run func(bidID v1.BidID, resourceGroup v1beta4.ResourceGroup) (v1beta3.Reservation, error)) *Service_ReserveBid_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Status provides a mock function for the type Service
 func (_mock *Service) Status(context1 context.Context) (*rest.ClusterStatus, error) {
 	ret := _mock.Called(context1)
@@ -630,6 +698,57 @@ func (_c *Service_Unreserve_Call) Return(err error) *Service_Unreserve_Call {
 }
 
 func (_c *Service_Unreserve_Call) RunAndReturn(run func(orderID v1.OrderID) error) *Service_Unreserve_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UnreserveBid provides a mock function for the type Service
+func (_mock *Service) UnreserveBid(bidID v1.BidID) error {
+	ret := _mock.Called(bidID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UnreserveBid")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(v1.BidID) error); ok {
+		r0 = returnFunc(bidID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Service_UnreserveBid_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UnreserveBid'
+type Service_UnreserveBid_Call struct {
+	*mock.Call
+}
+
+// UnreserveBid is a helper method to define mock.On call
+//   - bidID v1.BidID
+func (_e *Service_Expecter) UnreserveBid(bidID interface{}) *Service_UnreserveBid_Call {
+	return &Service_UnreserveBid_Call{Call: _e.mock.On("UnreserveBid", bidID)}
+}
+
+func (_c *Service_UnreserveBid_Call) Run(run func(bidID v1.BidID)) *Service_UnreserveBid_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 v1.BidID
+		if args[0] != nil {
+			arg0 = args[0].(v1.BidID)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Service_UnreserveBid_Call) Return(err error) *Service_UnreserveBid_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Service_UnreserveBid_Call) RunAndReturn(run func(bidID v1.BidID) error) *Service_UnreserveBid_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary
Adds provider multi-bid support for wildcard GPU model orders.

The bid engine now increments `BSeq`, reserves per bid, submits per-bid resource offers, and frees losing reservations when one local bid wins.

## Tests
- `GOWORK=off go test ./...`