### PR TITLE
fix(rest): expose leased IP inventory in status REST response

### DIFF
--- a/gateway/rest/integration_test.go
+++ b/gateway/rest/integration_test.go
@@ -25,6 +25,7 @@ import (
 	mtypes "pkg.akt.dev/go/node/market/v1"
 	providertypes "pkg.akt.dev/go/node/provider/v1beta4"
 	apclient "pkg.akt.dev/go/provider/client"
+	providerV1 "pkg.akt.dev/go/provider/v1"
 	"pkg.akt.dev/go/testutil"
 	ajwt "pkg.akt.dev/go/util/jwt"
 
@@ -82,6 +83,7 @@ func Test_router_Status(t *testing.T) {
 
 		mocks := createMocks()
 		mocks.pclient.On("Status", mock.Anything).Return(expected, nil)
+		mocks.pclient.On("StatusV1", mock.Anything).Return(&providerV1.Status{}, nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/gateway/rest/router.go
+++ b/gateway/rest/router.go
@@ -21,6 +21,7 @@ import (
 	"cosmossdk.io/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	inventoryV1 "pkg.akt.dev/go/inventory/v1"
 	manifest "pkg.akt.dev/go/manifest/v2beta3"
 	mtypes "pkg.akt.dev/go/node/market/v1"
 	apclient "pkg.akt.dev/go/provider/client"
@@ -439,13 +440,25 @@ func createStatusHandler(log log.Logger, sclient provider.StatusClient, provider
 			http.Error(w, err.Error(), httperror.StatusCodeFrom(err))
 			return
 		}
+		leasedIP := inventoryV1.ResourcePair{}
+		statusV1, statusV1Err := sclient.StatusV1(req.Context())
+		if statusV1Err != nil {
+			log.Error("failed to fetch v1 status; leased_ip will be omitted", "err", statusV1Err)
+		}
+		if statusV1 != nil && statusV1.Cluster != nil {
+			inventory := statusV1.Cluster.GetInventory()
+			leasedIP = inventory.GetLeasedIP()
+		}
+
 		data := struct {
 			// provider.Status
 			apclient.ProviderStatus
-			Address string `json:"address"`
+			Address  string                   `json:"address"`
+			LeasedIP inventoryV1.ResourcePair `json:"leased_ip"`
 		}{
 			ProviderStatus: *status,
 			Address:        providerAddr.String(),
+			LeasedIP:       leasedIP,
 		}
 		writeJSON(log, w, data)
 	}

--- a/gateway/rest/router_test.go
+++ b/gateway/rest/router_test.go
@@ -15,17 +15,20 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeVersion "k8s.io/apimachinery/pkg/version"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	inventoryV1 "pkg.akt.dev/go/inventory/v1"
 	manifestValidation "pkg.akt.dev/go/manifest/v2beta3"
 	qmock "pkg.akt.dev/go/mocks/node/client"
 	dtypes "pkg.akt.dev/go/node/deployment/v1"
 	mtypes "pkg.akt.dev/go/node/market/v1"
 	apclient "pkg.akt.dev/go/provider/client"
+	providerV1 "pkg.akt.dev/go/provider/v1"
 	"pkg.akt.dev/go/sdl"
 	"pkg.akt.dev/go/testutil"
 	ajwt "pkg.akt.dev/go/util/jwt"
@@ -397,15 +400,22 @@ func TestRouteVersionOK(t *testing.T) {
 }
 
 func TestRouteStatusOK(t *testing.T) {
-	runRouterTest(t, []routerTestAuth{}, func(test *routerTest, hdr http.Header) {
+	runRouterTest(t, []routerTestAuth{routerTestAuthNone}, func(test *routerTest, hdr http.Header) {
 		status := &apclient.ProviderStatus{
-			Cluster:               nil,
+			Cluster:               &apclient.ClusterStatus{},
 			Bidengine:             nil,
 			Manifest:              nil,
 			ClusterPublicHostname: "foobar",
 		}
 
 		test.pclient.On("Status", mock.Anything).Return(status, nil)
+		test.pclient.On("StatusV1", mock.Anything).Return(&providerV1.Status{
+			Cluster: &providerV1.ClusterStatus{
+				Inventory: providerV1.Inventory{
+					LeasedIP: inventoryV1.NewResourcePair(10, 10, 6, resource.DecimalSI),
+				},
+			},
+		}, nil)
 
 		uri, err := apclient.MakeURI(test.host, apclient.StatusPath())
 		require.NoError(t, err)
@@ -427,6 +437,12 @@ func TestRouteStatusOK(t *testing.T) {
 		cph, ok := data["cluster_public_hostname"].(string)
 		require.True(t, ok)
 		require.Equal(t, cph, "foobar")
+
+		leasedIP, ok := data["leased_ip"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, "10", leasedIP["capacity"])
+		require.Equal(t, "10", leasedIP["allocatable"])
+		require.Equal(t, "6", leasedIP["allocated"])
 	})
 }
 


### PR DESCRIPTION
## Summary
- add the provider v1 leased IP ResourcePair to the legacy REST /status response
- preserve the existing REST response shape and expose leased_ip as an additive top-level field
- cover the REST route and existing status integration mock

## Validation
- GOWORK=off go test ./gateway/rest -count=1
- GOWORK=off go test ./cluster -run 'TestInventory_StatusV1ReportsLeasedIPResourcePair|TestInventory_StatusV1SaturatesLeasedIPResourcePairAvailable' -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The status endpoint now returns leased IP information, including resource capacity, allocatable, and allocated metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->