### PR TITLE
fix(provider): disable workload healthcheck lease ejection

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -36,8 +36,6 @@ func NewDefaultConfig() Config {
 		MonitorMaxRetries:               40,
 		MonitorRetryPeriod:              time.Second * 4, // nolint revive
 		MonitorRetryPeriodJitter:        time.Second * 15,
-		MonitorHealthcheckPeriod:        time.Second * 10, // nolint revive
-		MonitorHealthcheckPeriodJitter:  time.Second * 5,
 		IngressMode:                     builder.IngressModeIngress,
 		GatewayName:                     "akash-gateway",
 		GatewayNamespace:                "akash-gateway",

--- a/cluster/monitor.go
+++ b/cluster/monitor.go
@@ -224,10 +224,18 @@ func (m *deploymentMonitor) scheduleRetry() <-chan time.Time {
 }
 
 func (m *deploymentMonitor) scheduleHealthcheck() <-chan time.Time {
+	if m.config.MonitorHealthcheckPeriod <= 0 {
+		return nil
+	}
+
 	return m.schedule(m.config.MonitorHealthcheckPeriod, m.config.MonitorHealthcheckPeriodJitter)
 }
 
 func (m *deploymentMonitor) schedule(minTime, jitter time.Duration) <-chan time.Time {
-	period := minTime + time.Duration(rand.Int63n(int64(jitter))) // nolint: gosec
+	period := minTime
+	if jitter > 0 {
+		period += time.Duration(rand.Int63n(int64(jitter))) // nolint: gosec
+	}
+
 	return time.After(period)
 }

--- a/cluster/monitor_test.go
+++ b/cluster/monitor_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"testing"
+	"time"
 
 	"github.com/boz/go-lifecycle"
 	"github.com/stretchr/testify/mock"
@@ -47,6 +48,22 @@ func TestMonitorInstantiate(t *testing.T) {
 	require.NotNil(t, monitor)
 
 	monitor.lc.Shutdown(nil)
+}
+
+func TestMonitorHealthcheckDisabledWhenPeriodZero(t *testing.T) {
+	config := NewDefaultConfig()
+	require.Zero(t, config.MonitorHealthcheckPeriod)
+	require.Zero(t, config.MonitorHealthcheckPeriodJitter)
+
+	monitor := &deploymentMonitor{
+		config: config,
+	}
+
+	var tickch <-chan time.Time
+	require.NotPanics(t, func() {
+		tickch = monitor.scheduleHealthcheck()
+	})
+	require.Nil(t, tickch)
 }
 
 func TestMonitorSendsClusterDeploymentPending(t *testing.T) {

--- a/cmd/provider-services/cmd/flags.go
+++ b/cmd/provider-services/cmd/flags.go
@@ -251,16 +251,6 @@ func addRunFlags(cmd *cobra.Command) error {
 		return err
 	}
 
-	cmd.Flags().Duration(FlagMonitorHealthcheckPeriod, 10*time.Second, "monitor healthcheck period. defaults to 10s")
-	if err := viper.BindPFlag(FlagMonitorHealthcheckPeriod, cmd.Flags().Lookup(FlagMonitorHealthcheckPeriod)); err != nil {
-		return err
-	}
-
-	cmd.Flags().Duration(FlagMonitorHealthcheckPeriodJitter, 5*time.Second, "monitor healthcheck window. defaults to 5s")
-	if err := viper.BindPFlag(FlagMonitorHealthcheckPeriodJitter, cmd.Flags().Lookup(FlagMonitorHealthcheckPeriodJitter)); err != nil {
-		return err
-	}
-
 	cmd.Flags().String(FlagPersistentConfigBackend, "bbolt", "backend storage for persistent config. defaults to bbolt. available options: bbolt")
 	if err := viper.BindPFlag(FlagPersistentConfigBackend, cmd.Flags().Lookup(FlagPersistentConfigBackend)); err != nil {
 		return err

--- a/cmd/provider-services/cmd/helpers_test.go
+++ b/cmd/provider-services/cmd/helpers_test.go
@@ -41,3 +41,9 @@ func TestUnwrappingURLError(t *testing.T) {
 	require.Error(t, err)
 	require.Regexp(t, expectedErrMsgForRPC, err)
 }
+
+func TestRunCmdDoesNotExposeMonitorHealthcheckFlags(t *testing.T) {
+	cmd := RunCmd()
+	require.Nil(t, cmd.Flags().Lookup("monitor-healthcheck-period"))
+	require.Nil(t, cmd.Flags().Lookup("monitor-healthcheck-period-jitter"))
+}

--- a/cmd/provider-services/cmd/run.go
+++ b/cmd/provider-services/cmd/run.go
@@ -108,8 +108,6 @@ const (
 	FlagMonitorMaxRetries                = "monitor-max-retries"
 	FlagMonitorRetryPeriod               = "monitor-retry-period"
 	FlagMonitorRetryPeriodJitter         = "monitor-retry-period-jitter"
-	FlagMonitorHealthcheckPeriod         = "monitor-healthcheck-period"
-	FlagMonitorHealthcheckPeriodJitter   = "monitor-healthcheck-period-jitter"
 	FlagPersistentConfigBackend          = "persistent-config-backend"
 	FlagPersistentConfigPath             = "persistent-config-path"
 	FlagGatewayTLSCert                   = "gateway-tls-cert"
@@ -213,10 +211,6 @@ func RunCmd() *cobra.Command {
 
 			if viper.GetDuration(FlagMonitorRetryPeriod) < 4*time.Second {
 				return fmt.Errorf(`flag "%s" value must be > "%s"`, FlagMonitorRetryPeriod, 4*time.Second) // nolint: err113
-			}
-
-			if viper.GetDuration(FlagMonitorHealthcheckPeriod) < 4*time.Second {
-				return fmt.Errorf(`flag "%s" value must be > "%s"`, FlagMonitorHealthcheckPeriod, 4*time.Second) // nolint: err113
 			}
 
 			pconfigBackend := viper.GetString(FlagPersistentConfigBackend)
@@ -496,8 +490,6 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	monitorMaxRetries := viper.GetUint(FlagMonitorMaxRetries)
 	monitorRetryPeriod := viper.GetDuration(FlagMonitorRetryPeriod)
 	monitorRetryPeriodJitter := viper.GetDuration(FlagMonitorRetryPeriodJitter)
-	monitorHealthcheckPeriod := viper.GetDuration(FlagMonitorHealthcheckPeriod)
-	monitorHealthcheckPeriodJitter := viper.GetDuration(FlagMonitorHealthcheckPeriodJitter)
 
 	pricing, err := createBidPricingStrategy(strategy)
 	if err != nil {
@@ -669,8 +661,6 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	config.MonitorMaxRetries = monitorMaxRetries
 	config.MonitorRetryPeriod = monitorRetryPeriod
 	config.MonitorRetryPeriodJitter = monitorRetryPeriodJitter
-	config.MonitorHealthcheckPeriod = monitorHealthcheckPeriod
-	config.MonitorHealthcheckPeriodJitter = monitorHealthcheckPeriodJitter
 
 	if len(providerConfig) != 0 {
 		pConf, err := xpconfig.ReadConfigPath(providerConfig)


### PR DESCRIPTION
## Summary

- Default provider monitor health checks to disabled after a deployment becomes healthy.
- Stop exposing the monitor healthcheck period and jitter provider-service flags.
- Treat a zero healthcheck period as no schedule instead of panicking.

## Root cause

The deployment monitor kept scheduling periodic health checks after a workload
had already become healthy. If later status checks failed enough times, the
provider broadcast MsgCloseBid with LeaseClosedReasonUnstable. The healthcheck
period was exposed as operator configuration, so providers could keep this lease
ejection behavior enabled unintentionally.

## Verification

Failing-before output from the regression test:

```text
=== RUN   TestMonitorHealthcheckDisabledWhenPeriodZero
    monitor_test.go:62:
        Error:       func (assert.PanicTestFunc)(...) should not panic
        Panic value: invalid argument to Int63n
--- FAIL: TestMonitorHealthcheckDisabledWhenPeriodZero
```

Passing checks:

```text
GOWORK=off go test ./cluster -run TestMonitorHealthcheckDisabledWhenPeriodZero -count=1 -v
GOWORK=off go test ./cmd/provider-services/cmd -run TestRunCmdDoesNotExposeMonitorHealthcheckFlags -count=1 -v
GOWORK=off go test ./cluster -count=1
GOWORK=off go test ./cmd/provider-services/cmd -count=1
git diff --check
```
