### PR TITLE
fix: deployment not updating after provider restart

### DIFF
--- a/pkg/apis/akash.network/v2beta2/manifest.go
+++ b/pkg/apis/akash.network/v2beta2/manifest.go
@@ -185,12 +185,15 @@ func (m *Manifest) Deployment() (ctypes.IDeployment, error) {
 		return nil, err
 	}
 
+	cparams := make(ReservationClusterSettings, len(group.Services))
+	for i := range group.Services {
+		cparams[group.Services[i].Resources.ID] = schedulerParams[i]
+	}
+
 	return &deployment{
-		lid:   lid,
-		group: group,
-		cparams: ClusterSettings{
-			SchedulerParams: schedulerParams,
-		},
+		lid:             lid,
+		group:           group,
+		cparams:         cparams,
 		resourceVersion: m.ResourceVersion,
 	}, nil
 }

--- a/pkg/apis/akash.network/v2beta2/types_test.go
+++ b/pkg/apis/akash.network/v2beta2/types_test.go
@@ -29,3 +29,29 @@ func Test_Manifest_encoding(t *testing.T) {
 		assert.Equal(t, &mgroup, deployment.ManifestGroup(), spec.Name)
 	}
 }
+
+// Recovered deployments must carry ReservationClusterSettings (keyed by resource ID),
+// matching what inventory.Adjust() produces for live reservations. Returning
+// ClusterSettings instead leaves updateManifest false in the kube builder, which
+// silently drops deployment updates for leases recovered after a provider restart.
+func Test_Manifest_Deployment_recovers_reservation_cluster_params(t *testing.T) {
+	for _, spec := range mtestutil.Generators {
+		lid := atestutil.LeaseID(t)
+		mgroup := spec.Generator.Group(t)
+		sparams := make([]*SchedulerParams, len(mgroup.Services))
+
+		kmani, err := NewManifest("foo", lid, &mgroup, ClusterSettings{SchedulerParams: sparams})
+		require.NoError(t, err, spec.Name)
+
+		deployment, err := kmani.Deployment()
+		require.NoError(t, err, spec.Name)
+
+		cparams, ok := deployment.ClusterParams().(ReservationClusterSettings)
+		require.True(t, ok, "%s: expected ReservationClusterSettings, got %T", spec.Name, deployment.ClusterParams())
+
+		for i := range mgroup.Services {
+			_, exists := cparams[mgroup.Services[i].Resources.ID]
+			assert.True(t, exists, "%s: missing cluster params for resource %d", spec.Name, mgroup.Services[i].Resources.ID)
+		}
+	}
+}


### PR DESCRIPTION
Set the correct `ReservationClusterSettings` type rather than `ClusterSettings`.