### PR TITLE
fix: 295: Shell access to a SHM mounted workload

### DIFF
--- a/cluster/kube/client.go
+++ b/cluster/kube/client.go
@@ -1092,13 +1092,15 @@ func (c *client) ServiceStatus(ctx context.Context, lid mtypes.LeaseID, name str
 		return nil, kubeclienterrors.ErrNoServiceForLease
 	}
 
+	// Check if this service uses persistent storage (should be StatefulSet)
+	// This logic must match the deployment creation logic in Deploy()
 	isDeployment := true
-	if params := svc.Params; params != nil {
-		for _, param := range params.Storage {
-			if param.Mount != "" {
-				isDeployment = false
-				break
-			}
+	persistent := false
+	for i := range svc.Resources.Storage {
+		attrVal := svc.Resources.Storage[i].Attributes.Find(sdl.StorageAttributePersistent)
+		if persistent, _ = attrVal.AsBool(); persistent {
+			isDeployment = false
+			break
 		}
 	}
 

--- a/cluster/kube/client_test.go
+++ b/cluster/kube/client_test.go
@@ -15,6 +15,8 @@ import (
 
 	manifest "pkg.akt.dev/go/manifest/v2beta3"
 	mtypes "pkg.akt.dev/go/node/market/v1"
+	attrtypes "pkg.akt.dev/go/node/types/attributes/v1"
+	"pkg.akt.dev/go/sdl"
 	"pkg.akt.dev/go/testutil"
 
 	"github.com/akash-network/provider/cluster/kube/builder"
@@ -687,4 +689,154 @@ func TestServiceStatusWithoutIngress(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, status)
 	require.Len(t, status.URIs, 0)
+}
+
+func TestServiceStatusStatefulSetDetection(t *testing.T) {
+	lid := testutil.LeaseID(t)
+	ns := builder.LidNS(lid)
+
+	lns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ns,
+		},
+	}
+
+	testCases := []struct {
+		name             string
+		serviceName      string
+		services         manifest.Services
+		expectedWorkload string
+	}{
+		{
+			name:        "PersistentStorage_UsesStatefulSet",
+			serviceName: "postgres",
+			services: manifest.Services{
+				{
+					Name:  "postgres",
+					Image: "postgres:latest",
+					Resources: rtypes.Resources{
+						Storage: []rtypes.Storage{
+							{
+								Name:     "data",
+								Quantity: rtypes.NewResourceValue(10737418240), // 10Gi
+								Attributes: attrtypes.Attributes{
+									{
+										Key:   sdl.StorageAttributePersistent,
+										Value: "true",
+									},
+								},
+							},
+						},
+					},
+					Count: 1,
+				},
+			},
+			expectedWorkload: "StatefulSet",
+		},
+		{
+			name:        "NonPersistentStorage_UsesDeployment",
+			serviceName: "web",
+			services: manifest.Services{
+				{
+					Name:  "web",
+					Image: "nginx:latest",
+					Resources: rtypes.Resources{
+						Storage: []rtypes.Storage{
+							{
+								Name:     "tmp",
+								Quantity: rtypes.NewResourceValue(1073741824), // 1Gi
+								Attributes: attrtypes.Attributes{
+									{
+										Key:   sdl.StorageAttributePersistent,
+										Value: "false",
+									},
+								},
+							},
+						},
+					},
+					Count: 2,
+				},
+			},
+			expectedWorkload: "Deployment",
+		},
+		{
+			name:        "NoStorage_UsesDeployment",
+			serviceName: "api",
+			services: manifest.Services{
+				{
+					Name:      "api",
+					Image:     "myapp:latest",
+					Resources: rtypes.Resources{},
+					Count:     3,
+				},
+			},
+			expectedWorkload: "Deployment",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create the manifest
+			mg := &manifest.Group{
+				Name:     "test-group",
+				Services: tc.services,
+			}
+
+			cparams := crd.ClusterSettings{
+				SchedulerParams: make([]*crd.SchedulerParams, len(mg.Services)),
+			}
+
+			m, err := crd.NewManifest(testKubeClientNs, lid, mg, cparams)
+			require.NoError(t, err)
+
+			// Create the deployment or statefulset
+			var kobjs []runtime.Object
+			kobjs = append(kobjs, lns)
+
+			if tc.expectedWorkload == "StatefulSet" {
+				ss := &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tc.serviceName,
+						Namespace: ns,
+					},
+					Spec: appsv1.StatefulSetSpec{},
+					Status: appsv1.StatefulSetStatus{
+						CurrentReplicas: 1,
+						Replicas:        1,
+					},
+				}
+				kobjs = append(kobjs, ss)
+			} else {
+				depl := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tc.serviceName,
+						Namespace: ns,
+					},
+					Spec: appsv1.DeploymentSpec{},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: int32(tc.services[0].Count),
+						Replicas:          int32(tc.services[0].Count),
+					},
+				}
+				kobjs = append(kobjs, depl)
+			}
+
+			clientInterface := clientForTest(t, kobjs, []runtime.Object{m})
+
+			// Test ServiceStatus
+			status, err := clientInterface.ServiceStatus(context.Background(), lid, tc.serviceName)
+			require.NoError(t, err)
+			require.NotNil(t, status)
+			require.Equal(t, tc.serviceName, status.Name)
+
+			// Verify we can find the correct workload type
+			if tc.expectedWorkload == "StatefulSet" {
+				require.Equal(t, int32(1), status.Available)
+				require.Equal(t, int32(1), status.Total)
+			} else {
+				require.Equal(t, int32(tc.services[0].Count), status.Available)
+				require.Equal(t, int32(tc.services[0].Count), status.Total)
+			}
+		})
+	}
 }

--- a/gateway/rest/router.go
+++ b/gateway/rest/router.go
@@ -342,6 +342,10 @@ func leaseShellHandler(log log.Logger, cclient cluster.Client) http.HandlerFunc 
 		if err != nil {
 			if cluster.ErrorIsOkToSendToClient(err) || errors.Is(err, kubeclienterrors.ErrNoServiceForLease) {
 				responseData.Message = err.Error()
+			} else {
+				resultWriter = wsutil.NewWsWriterWrapper(shellWs, LeaseShellCodeFailure, l)
+				encodeData = false
+				localLog.Error("service status check failed", "err", err)
 			}
 		}
 


### PR DESCRIPTION
Closes https://github.com/akash-network/support/issues/295

Rebased version of #310 onto current `main`. The original PR conflicted because `main` migrated its API imports from `github.com/akash-network/akash-api` / `github.com/akash-network/node` to `pkg.akt.dev/go`; the changes here are ported to the new packages (`rtypes`, `attrtypes`, `pkg.akt.dev/go/sdl`) and the tests were adjusted for the current `ServiceStatus` field types (`int32`) and the StatefulSet `CurrentReplicas` field.

This addresses an issue with the provider when attempting to SSH to a lease with a shared memory mount. It also corrects a websocket protocol violation on error (encountered while debugging the SHM issue). The core issue was that when the lease-shell command attempted to connect, it would try to do so on a StatefulSet due to detecting a volume on the deployment. Having it follow the convention of the `Deploy()` function lets it connect to the deployment properly.

## 1. StatefulSet Detection Fix
- Fixed incorrect logic in `ServiceStatus` that was checking for any mounted storage instead of persistent storage to determine workload type.
- The bug caused services with RAM volumes to incorrectly attempt StatefulSet operations, resulting in `statefulsets.apps not found` errors.
- Now correctly checks `storage.Attributes.Find(sdl.StorageAttributePersistent)` to match the deployment creation logic.

## 2. WebSocket Error Handling in lease-shell
- Fixed improper error handling when `ServiceStatus` fails during shell operations.
- Previously used `http.Error()` on WebSocket connections, causing protocol violations.
- Now properly uses the WebSocket writer with `LeaseShellCodeFailure` and logs errors.
- Prevents silent failures and improves debugging for shell access issues.

## Tests
Added unit tests for StatefulSet detection logic covering:
- Services with persistent storage (should use StatefulSet)
- Services with non-persistent storage (should use Deployment)
- Services with no storage (should use Deployment)
