### PR TITLE
feat(kube): attach rail networks to RoCE interconnect workloads

### DIFF
--- a/cluster/kube/builder/builder.go
+++ b/cluster/kube/builder/builder.go
@@ -96,10 +96,19 @@ const (
 	// NCCL tuning vars, injected only for services whose reservation
 	// pinned an interconnect HCA. Tenants may override any of these by
 	// setting the same key in service.env (addIfNotPresent honors that).
-	envVarNCCLIBDisable     = "NCCL_IB_DISABLE"
-	envVarNCCLIBHCA         = "NCCL_IB_HCA"
-	envVarNCCLIBGIDIndex    = "NCCL_IB_GID_INDEX"
-	nccLIBGIDIndexRoCEValue = "3"
+	envVarNCCLIBDisable  = "NCCL_IB_DISABLE"
+	envVarNCCLIBHCA      = "NCCL_IB_HCA"
+	envVarNCCLIBGIDIndex = "NCCL_IB_GID_INDEX"
+)
+
+const (
+	// InterconnectFabricRoCE matches SchedulerResourceInterconnect.Fabric as
+	// stamped by tryAdjustInterconnect from the node's discovered link layer.
+	InterconnectFabricRoCE = "roce"
+
+	// multusNetworksAnnotation is the standard CNCF annotation multus watches
+	// to attach secondary networks (NetworkAttachmentDefinitions) to a pod.
+	multusNetworksAnnotation = "k8s.v1.cni.cncf.io/networks"
 )
 
 var (

--- a/cluster/kube/builder/interconnect_test.go
+++ b/cluster/kube/builder/interconnect_test.go
@@ -105,9 +105,12 @@ func TestWorkloadJoinsMultipleHCAPrefixes(t *testing.T) {
 	require.Equal(t, "mlx5,bnxt_re", env[envVarNCCLIBHCA])
 }
 
-// AKT-494: NCCL on RoCE needs NCCL_IB_GID_INDEX=3 to pick the RoCEv2 +
-// VLAN GID. The builder auto-injects it for RoCE-pinned reservations.
-func TestWorkloadInjectsGIDIndexOnRoCE(t *testing.T) {
+// NCCL_IB_GID_INDEX is never injected — on RoCE the pod's rail netdevs
+// (multus-attached, see podAnnotations) register RoCEv2 GIDs at a
+// pod-specific index invisible to any fixed host-side value, and NCCL's
+// auto-selection picks the right one from the pod's own GID table. On IB
+// the default selection is correct too.
+func TestWorkloadOmitsGIDIndexOnRoCE(t *testing.T) {
 	lid := testutil.LeaseID(t)
 	_, workload := testSetup(t, "../../../testdata/deployment/deployment.yaml", 0, lid)
 
@@ -115,12 +118,10 @@ func TestWorkloadInjectsGIDIndexOnRoCE(t *testing.T) {
 
 	container := workload.container()
 	env := envMap(container.Env)
-	require.Equal(t, "3", env[envVarNCCLIBGIDIndex])
+	_, hasGID := env[envVarNCCLIBGIDIndex]
+	require.False(t, hasGID, "RoCE reservations must not carry an auto-injected NCCL_IB_GID_INDEX")
 }
 
-// AKT-494: IB fabrics do NOT get NCCL_IB_GID_INDEX injected — NCCL's
-// default GID selection is correct on IB, and overriding it can pick the
-// wrong index on multi-port hosts.
 func TestWorkloadOmitsGIDIndexOnInfiniBand(t *testing.T) {
 	lid := testutil.LeaseID(t)
 	_, workload := testSetup(t, "../../../testdata/deployment/deployment.yaml", 0, lid)
@@ -133,10 +134,9 @@ func TestWorkloadOmitsGIDIndexOnInfiniBand(t *testing.T) {
 	require.False(t, hasGID, "InfiniBand reservations must not carry an explicit NCCL_IB_GID_INDEX")
 }
 
-// AKT-494: a tenant who already set NCCL_IB_GID_INDEX in SDL env wins —
-// addIfNotPresent honors the override on RoCE just like every other
-// auto-injected NCCL knob.
-func TestWorkloadRespectsSDLGIDIndexOverrideOnRoCE(t *testing.T) {
+// A tenant who sets NCCL_IB_GID_INDEX in SDL env keeps it — the builder
+// passes service.env through untouched.
+func TestWorkloadRespectsSDLGIDIndexOnRoCE(t *testing.T) {
 	lid := testutil.LeaseID(t)
 	_, workload := testSetup(t, "../../../testdata/deployment/deployment.yaml", 0, lid)
 
@@ -148,6 +148,59 @@ func TestWorkloadRespectsSDLGIDIndexOverrideOnRoCE(t *testing.T) {
 	container := workload.container()
 	env := envMap(container.Env)
 	require.Equal(t, "5", env[envVarNCCLIBGIDIndex])
+}
+
+// RoCE-pinned services get the configured rail networks attached via the
+// multus annotation — RoCEv2 QP setup resolves the remote rail IP through
+// the pod netns, so the rail netdevs must be in the pod.
+func TestWorkloadAttachesRoCENetworks(t *testing.T) {
+	lid := testutil.LeaseID(t)
+	_, workload := testSetup(t, "../../../testdata/deployment/deployment.yaml", 0, lid)
+
+	workload.settings.InterconnectRoCENetworks = "default/rail0,default/rail1"
+	stampinterconnect(workload, "", interconnectParamsWith("roce", []string{"mlx5"}))
+
+	annotations := workload.podAnnotations()
+	require.Equal(t, "default/rail0,default/rail1", annotations[multusNetworksAnnotation])
+}
+
+// InfiniBand is LID-addressed — no rail attachment even when networks are
+// configured.
+func TestWorkloadNoNetworkAnnotationOnInfiniBand(t *testing.T) {
+	lid := testutil.LeaseID(t)
+	_, workload := testSetup(t, "../../../testdata/deployment/deployment.yaml", 0, lid)
+
+	workload.settings.InterconnectRoCENetworks = "default/rail0"
+	stampinterconnect(workload, "", interconnectParamsWith("infiniband", []string{"mlx5"}))
+
+	annotations := workload.podAnnotations()
+	_, has := annotations[multusNetworksAnnotation]
+	require.False(t, has, "InfiniBand workloads must not get the multus annotation")
+}
+
+// RoCE with no networks configured: no annotation (nothing to attach).
+func TestWorkloadNoNetworkAnnotationWhenUnconfigured(t *testing.T) {
+	lid := testutil.LeaseID(t)
+	_, workload := testSetup(t, "../../../testdata/deployment/deployment.yaml", 0, lid)
+
+	stampinterconnect(workload, "", interconnectParamsWith("roce", []string{"mlx5"}))
+
+	annotations := workload.podAnnotations()
+	_, has := annotations[multusNetworksAnnotation]
+	require.False(t, has)
+}
+
+// Non-interconnect services never get the annotation regardless of
+// provider config.
+func TestWorkloadNoNetworkAnnotationWithoutInterconnect(t *testing.T) {
+	lid := testutil.LeaseID(t)
+	_, workload := testSetup(t, "../../../testdata/deployment/deployment.yaml", 0, lid)
+
+	workload.settings.InterconnectRoCENetworks = "default/rail0"
+
+	annotations := workload.podAnnotations()
+	_, has := annotations[multusNetworksAnnotation]
+	require.False(t, has)
 }
 
 func TestWorkloadNointerconnectNoEnvNoResource(t *testing.T) {

--- a/cluster/kube/builder/settings.go
+++ b/cluster/kube/builder/settings.go
@@ -80,6 +80,26 @@ type Settings struct {
 
 	// Gateway provider when using gateway-api mode
 	GatewayProvider string
+
+	// InterconnectRoCENetworksNamespace is the namespace the kube client
+	// scans for multus NetworkAttachmentDefinitions to attach to
+	// interconnect workloads when the pinned fabric is RoCE. Operators
+	// create one NAD per rail there (and nothing else); the provider picks
+	// them all up at deploy time, so adding a rail needs no provider
+	// restart. Empty disables the attachment entirely.
+	InterconnectRoCENetworksNamespace string
+
+	// InterconnectRoCENetworks is the resolved comma-separated list of
+	// NAD references ("namespace/name") applied verbatim as the pod's
+	// `k8s.v1.cni.cncf.io/networks` annotation on RoCE-pinned interconnect
+	// workloads. Populated per-deploy by the kube client from the NADs
+	// found in InterconnectRoCENetworksNamespace — not set from provider
+	// flags. RoCEv2 is IP-addressed: building a QP resolves the remote
+	// rail IP through the pod's own network namespace, so the pod needs
+	// the rail netdevs (and the RoCEv2 GIDs they register) — the RDMA
+	// verbs device alone is not enough. InfiniBand is LID-addressed and
+	// needs no attachment.
+	InterconnectRoCENetworks string
 }
 
 var ErrSettingsValidation = errors.New("settings validation")

--- a/cluster/kube/builder/workload.go
+++ b/cluster/kube/builder/workload.go
@@ -357,12 +357,29 @@ func (b *Workload) persistentVolumeClaims() []corev1.PersistentVolumeClaim {
 
 func (b *Workload) podAnnotations() map[string]string {
 	params := b.sparams[b.serviceIdx]
+
+	var obj map[string]string
+
 	if params != nil && params.AttestationDisabled {
-		return map[string]string{
+		obj = map[string]string{
 			AkashAttestationDisabledAnnotation: "true",
 		}
 	}
-	return nil
+
+	// RoCEv2 resolves the remote rail IP through the pod's own network
+	// namespace, so interconnect pods on a RoCE fabric need the rail
+	// netdevs attached — the RDMA verbs device alone cannot complete
+	// QP setup. InfiniBand is LID-addressed and skips this entirely.
+	if ic := sparamsInterconnect(params); ic != nil && ic.Enabled && ic.Fabric == InterconnectFabricRoCE {
+		if networks := strings.TrimSpace(b.settings.InterconnectRoCENetworks); networks != "" {
+			if obj == nil {
+				obj = make(map[string]string, 1)
+			}
+			obj[multusNetworksAnnotation] = networks
+		}
+	}
+
+	return obj
 }
 
 func (b *Workload) runtimeClass() *string {
@@ -610,18 +627,17 @@ func (b *Workload) addEnvVarsForDeployment(envVarsAlreadyAdded map[string]int, e
 	// comma-separated list natively, so mixed-vendor hosts like
 	// ["mlx5","bnxt_re"] just emit `NCCL_IB_HCA=mlx5,bnxt_re`.
 	//
-	// AKT-494: NCCL on RoCE requires NCCL_IB_GID_INDEX=3 to select the
-	// RoCEv2 + VLAN GID — the common production GID. Without it NCCL
-	// falls back to auto-detect, which works on uniform single-GID hosts
-	// but picks the wrong GID on multi-GID nodes. IB stays untouched
-	// (NCCL's default behaviour is correct there).
+	// NCCL_IB_GID_INDEX is deliberately NOT injected, for RoCE included.
+	// RoCE pods reach the rail through multus-attached netdevs in their own
+	// network namespace (see podAnnotations); the RoCEv2 GIDs those netdevs
+	// register land at a pod-specific index (host GID entries are not
+	// visible from the pod netns), so any fixed value is wrong. NCCL
+	// auto-selects the RoCEv2 GID from the pod's table, which is correct on
+	// both fabrics. Tenants can still pin an index via service.env.
 	if ic := sparamsInterconnect(b.sparams[b.serviceIdx]); ic != nil && ic.Enabled {
 		env = addIfNotPresent(envVarsAlreadyAdded, env, envVarNCCLIBDisable, "0")
 		if hca := strings.Join(ic.NCCLHCAPrefixes, ","); hca != "" {
 			env = addIfNotPresent(envVarsAlreadyAdded, env, envVarNCCLIBHCA, hca)
-		}
-		if ic.Fabric == "roce" {
-			env = addIfNotPresent(envVarsAlreadyAdded, env, envVarNCCLIBGIDIndex, nccLIBGIDIndexRoCEValue)
 		}
 	}
 

--- a/cluster/kube/client.go
+++ b/cluster/kube/client.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"runtime/debug"
 	"slices"
+	"sort"
 	"strings"
 
 	"cosmossdk.io/log"
@@ -20,6 +21,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
@@ -47,6 +49,14 @@ var (
 	kubeCallsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "provider_kube_calls",
 	}, []string{"action", "result"})
+
+	// nadGVR addresses multus NetworkAttachmentDefinitions via the dynamic
+	// client — the typed clientset for k8s.cni.cncf.io is not vendored.
+	nadGVR = schema.GroupVersionResource{
+		Group:    "k8s.cni.cncf.io",
+		Version:  "v1",
+		Resource: "network-attachment-definitions",
+	}
 )
 
 // Client interface includes cluster client
@@ -409,6 +419,59 @@ type deployObjNames struct {
 	services     map[string]string
 }
 
+// deploymentNeedsRoCENetworks reports whether any service in the deployment
+// carries an interconnect pin on a RoCE fabric — the only case where rail
+// NetworkAttachmentDefinitions must be attached to the pods.
+func deploymentNeedsRoCENetworks(d builder.IClusterDeployment) bool {
+	for _, sp := range d.ClusterParams().SchedulerParams {
+		if sp == nil || sp.Resources == nil || sp.Resources.Interconnect == nil {
+			continue
+		}
+		if ic := sp.Resources.Interconnect; ic.Enabled && ic.Fabric == builder.InterconnectFabricRoCE {
+			return true
+		}
+	}
+	return false
+}
+
+// interconnectRoCENetworks resolves the multus annotation value for RoCE
+// interconnect workloads: every NetworkAttachmentDefinition in the rails
+// namespace, sorted by name, as "namespace/name" references. A RoCE pod
+// without the rail netdevs cannot establish RDMA connections at all, so a
+// configured namespace that resolves no NADs — missing namespace, empty
+// namespace, or a cluster without the multus CRD (NotFound) — fails the
+// deploy with ErrNoRoCERailNetworks rather than delivering a broken lease.
+// An empty namespace argument is the explicit operator opt-out and returns
+// no networks without an API call.
+func (c *client) interconnectRoCENetworks(ctx context.Context, namespace string) (string, error) {
+	if namespace == "" {
+		return "", nil
+	}
+
+	list, err := c.dc.Resource(nadGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	metricsutils.IncCounterVecWithLabelValuesFiltered(kubeCallsCounter, "nad-list", err, kerrors.IsNotFound)
+
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return "", fmt.Errorf("%w: namespace %q (multus CRD not installed)", kubeclienterrors.ErrNoRoCERailNetworks, namespace)
+		}
+		return "", err
+	}
+
+	if len(list.Items) == 0 {
+		return "", fmt.Errorf("%w: namespace %q", kubeclienterrors.ErrNoRoCERailNetworks, namespace)
+	}
+
+	refs := make([]string, 0, len(list.Items))
+	for idx := range list.Items {
+		refs = append(refs, namespace+"/"+list.Items[idx].GetName())
+	}
+
+	sort.Strings(refs)
+
+	return strings.Join(refs, ","), nil
+}
+
 func (c *client) Deploy(ctx context.Context, deployment ctypes.IDeployment) (err error) {
 	var settings builder.Settings
 	var valid bool
@@ -439,6 +502,25 @@ func (c *client) Deploy(ctx context.Context, deployment ctypes.IDeployment) (err
 
 	lid := cdeployment.LeaseID()
 	group := cdeployment.ManifestGroup()
+
+	// RoCE interconnect pods need the rail NADs in their netns (see
+	// builder.Workload.podAnnotations). Resolved per-deploy so rails added
+	// by the operator are picked up without a provider restart. No rails
+	// found fails the deploy — a RoCE pod without them cannot do RDMA, and
+	// a loud failure beats a broken lease the tenant pays for. An empty
+	// namespace is the explicit opt-out.
+	if deploymentNeedsRoCENetworks(cdeployment) {
+		if settings.InterconnectRoCENetworksNamespace == "" {
+			c.log.Info("RoCE rail network attachment disabled (empty namespace); interconnect pods will not reach the rail fabric", "lease", lid)
+		} else {
+			networks, nerr := c.interconnectRoCENetworks(ctx, settings.InterconnectRoCENetworksNamespace)
+			if nerr != nil {
+				return nerr
+			}
+
+			settings.InterconnectRoCENetworks = networks
+		}
+	}
 
 	po := &previousObj{}
 

--- a/cluster/kube/errors/errors.go
+++ b/cluster/kube/errors/errors.go
@@ -19,6 +19,7 @@ var (
 	ErrInvalidHostnameConnection = fmt.Errorf("%w: invalid hostname connection", errKubeClient)
 	ErrNotConfiguredWithSettings = fmt.Errorf("%w: not configured with settings in the context passed to function", errKubeClient)
 	ErrAlreadyExists             = fmt.Errorf("%w: resource already exists", errKubeClient)
+	ErrNoRoCERailNetworks        = fmt.Errorf("%w: no RoCE rail NetworkAttachmentDefinitions found", errKubeClient)
 )
 
 // IsKubeAPIUnreachable reports whether err indicates the kube API server is unreachable.

--- a/cluster/kube/roce_networks_test.go
+++ b/cluster/kube/roce_networks_test.go
@@ -1,0 +1,115 @@
+package kube
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"pkg.akt.dev/go/testutil"
+
+	"github.com/akash-network/provider/cluster/kube/builder"
+	kubeclienterrors "github.com/akash-network/provider/cluster/kube/errors"
+	crd "github.com/akash-network/provider/pkg/apis/akash.network/v2beta2"
+)
+
+func interconnectSparams(fabric string) crd.ClusterSettings {
+	return crd.ClusterSettings{
+		SchedulerParams: []*crd.SchedulerParams{
+			nil, // non-interconnect service
+			{
+				Resources: &crd.SchedulerResources{
+					Interconnect: &crd.SchedulerResourceInterconnect{
+						Enabled:      true,
+						Units:        1,
+						ResourceName: "rdma/rdma_shared_device_ib",
+						Fabric:       fabric,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestDeploymentNeedsRoCENetworks(t *testing.T) {
+	require.True(t, deploymentNeedsRoCENetworks(&builder.ClusterDeployment{
+		Sparams: interconnectSparams(builder.InterconnectFabricRoCE),
+	}))
+
+	require.False(t, deploymentNeedsRoCENetworks(&builder.ClusterDeployment{
+		Sparams: interconnectSparams("infiniband"),
+	}), "InfiniBand pins must not trigger NAD attachment")
+
+	require.False(t, deploymentNeedsRoCENetworks(&builder.ClusterDeployment{
+		Sparams: crd.ClusterSettings{SchedulerParams: []*crd.SchedulerParams{nil, nil}},
+	}), "deployments without interconnect pins must not trigger NAD attachment")
+}
+
+func nad(namespace, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("k8s.cni.cncf.io/v1")
+	obj.SetKind("NetworkAttachmentDefinition")
+	obj.SetNamespace(namespace)
+	obj.SetName(name)
+	return obj
+}
+
+// nadFakeClient builds a client over a fake dynamic clientset holding the
+// given NADs. Objects are created through the fake (not seeded via the
+// tracker) because the tracker derives resource names by naive
+// pluralization, which mangles multus's dashed
+// "network-attachment-definitions".
+func nadFakeClient(t *testing.T, objects ...*unstructured.Unstructured) *client {
+	t.Helper()
+
+	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{nadGVR: "NetworkAttachmentDefinitionList"},
+	)
+
+	for _, obj := range objects {
+		_, err := dc.Resource(nadGVR).Namespace(obj.GetNamespace()).Create(context.Background(), obj, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	return &client{
+		dc:  dc,
+		log: testutil.Logger(t),
+	}
+}
+
+func TestInterconnectRoCENetworksSortedJoin(t *testing.T) {
+	c := nadFakeClient(t,
+		nad("akash-rails", "rail1"),
+		nad("akash-rails", "rail0"),
+		nad("akash-rails", "rail2"),
+		nad("elsewhere", "rail9"), // other namespaces are ignored
+	)
+
+	networks, err := c.interconnectRoCENetworks(context.Background(), "akash-rails")
+	require.NoError(t, err)
+	require.Equal(t, "akash-rails/rail0,akash-rails/rail1,akash-rails/rail2", networks)
+}
+
+func TestInterconnectRoCENetworksEmptyNamespace(t *testing.T) {
+	c := nadFakeClient(t, nad("akash-rails", "rail0"))
+
+	networks, err := c.interconnectRoCENetworks(context.Background(), "")
+	require.NoError(t, err)
+	require.Empty(t, networks, "empty namespace disables attachment without an API call")
+}
+
+func TestInterconnectRoCENetworksNoNADsFailsDeploy(t *testing.T) {
+	c := nadFakeClient(t)
+
+	networks, err := c.interconnectRoCENetworks(context.Background(), "akash-rails")
+	require.ErrorIs(t, err, kubeclienterrors.ErrNoRoCERailNetworks,
+		"a configured rails namespace with no NADs must fail the deploy — the pods could not do RDMA")
+	require.ErrorContains(t, err, "akash-rails")
+	require.Empty(t, networks)
+}

--- a/cmd/provider-services/cmd/flags.go
+++ b/cmd/provider-services/cmd/flags.go
@@ -100,6 +100,11 @@ func addRunFlags(cmd *cobra.Command) error {
 		return err
 	}
 
+	cmd.Flags().String(FlagInterconnectRoCENetworksNS, "akash-rails", "Namespace scanned for multus NetworkAttachmentDefinitions to attach to GPU interconnect workloads on RoCE fabrics; every NAD found there is attached. Empty disables attachment")
+	if err := viper.BindPFlag(FlagInterconnectRoCENetworksNS, cmd.Flags().Lookup(FlagInterconnectRoCENetworksNS)); err != nil {
+		return err
+	}
+
 	cmd.Flags().Uint(FlagClusterNodePortQuantity, 1, "The number of node ports available on the Kubernetes cluster")
 	if err := viper.BindPFlag(FlagClusterNodePortQuantity, cmd.Flags().Lookup(FlagClusterNodePortQuantity)); err != nil {
 		return err

--- a/cmd/provider-services/cmd/run.go
+++ b/cmd/provider-services/cmd/run.go
@@ -95,6 +95,7 @@ const (
 	FlagDeploymentIngressExposeLBHosts   = "deployment-ingress-expose-lb-hosts"
 	FlagDeploymentNetworkPoliciesEnabled = "deployment-network-policies-enabled"
 	FlagDockerImagePullSecretsName       = "docker-image-pull-secrets-name" // nolint: gosec
+	FlagInterconnectRoCENetworksNS       = "interconnect-roce-networks-namespace"
 	FlagOvercommitPercentMemory          = "overcommit-pct-mem"
 	FlagOvercommitPercentCPU             = "overcommit-pct-cpu"
 	FlagOvercommitPercentStorage         = "overcommit-pct-storage"
@@ -557,6 +558,7 @@ func doRunCmd(ctx context.Context, cmd *cobra.Command, _ []string) error {
 	kubeSettings.StorageCommitLevel = overcommitPercentStorage
 	kubeSettings.DeploymentRuntimeClass = deploymentRuntimeClass
 	kubeSettings.DockerImagePullSecretsName = strings.TrimSpace(dockerImagePullSecretsName)
+	kubeSettings.InterconnectRoCENetworksNamespace = strings.TrimSpace(viper.GetString(FlagInterconnectRoCENetworksNS))
 
 	// Discover all API server endpoint addresses for network policies.
 	// HA control planes expose multiple backends in the "kubernetes" Endpoints


### PR DESCRIPTION
## Problem

GPU interconnect (#400) validated end-to-end on InfiniBand but not on RoCE. On a RoCE cluster, interconnect pods received the RDMA device, correct scheduling, and NCCL env — but `ib_write_bw` between pods failed at `Failed to modify QP to RTR`.

Root cause: **RoCEv2 is IP-addressed.** QP setup resolves the remote rail IP through the pod's own network namespace, so the RDMA verbs device alone is not enough — the pod needs the rail netdevs (and the RoCEv2 GIDs they register) in its netns. InfiniBand is LID-addressed and needs none of this, which is exactly why IB passed while RoCE failed.

## Fix

**Attach the rail networks to RoCE interconnect pods.**

- At deploy time, when a deployment carries a RoCE-pinned interconnect reservation, the kube client lists multus `NetworkAttachmentDefinitions` in a dedicated rails namespace (`--interconnect-roce-networks-namespace`, default `akash-rails`) and applies them all — sorted, as `namespace/name` refs — via the `k8s.v1.cni.cncf.io/networks` pod annotation.
- Operators create one NAD per rail in that namespace (MacvlanNetwork + nv-ipam IPPool via the NVIDIA Network Operator); adding a rail later requires no provider restart or config change. With the default namespace there is nothing to configure on the provider.
- **Drops the hardcoded `NCCL_IB_GID_INDEX=3` injection for RoCE.** With rail netdevs attached, the pod's RoCEv2 GID registers at a pod-specific index and host GID entries are not visible from the pod netns — any fixed value is wrong. NCCL auto-selects the correct GID from the pod's own table. SDL-supplied overrides still pass through.

IB providers are unaffected: the NAD listing only runs for `fabric == roce` deployments, the annotation is gated on the same check, and IB never received the GID env var.

## Validation

4-node Dell 8× H200 SXM cluster, 8× ConnectX-7 rails per node (400G each, Ethernet mode / RoCEv2), NVIDIA Network Operator 26.1.1, nv-ipam auto-assigned pod IPs. Real marketplace lease (not a hand-built pod):

- Provider auto-attached all 8 rails: pods came up with `net1`–`net8` + rail IPs, annotation `akash-rails/rail0,…,rail7` stamped with zero operator config
- NCCL env: `NCCL_IB_DISABLE=0`, `NCCL_IB_HCA=mlx5`, no GID index
- Services on distinct nodes (interconnect anti-affinity)
- Pod-to-pod `ib_write_bw` over a rail: **391.37 Gb/s** — line rate, identical to the raw host-to-host baseline
- 8-rail concurrent aggregate (pre-provider harness, same pod shape): **2.09+ Tb/s**

Before the fix, the same lease shape failed QP RTR with only the cluster CNI interface in the pod.

## Notes

- Provider RBAC needs `list` on `network-attachment-definitions.k8s.cni.cncf.io` (helm-charts follow-up; broad SAs already have it)
- New tests: NAD listing (sorted join, namespace scoping, empty/missing cases), RoCE/IB/no-interconnect annotation gating, GID-index omission on both fabrics