### PR TITLE
fix(cluster): fail closed on unresolved TEE runtimes

### DIFF
--- a/cluster/client.go
+++ b/cluster/client.go
@@ -105,8 +105,9 @@ type Client interface {
 	// When service is empty, the first pod with a sidecar is used (legacy behavior).
 	AttestationQuote(ctx context.Context, lID mtypes.LeaseID, service string, podIndex uint, requestBody []byte) ([]byte, int, error)
 
-	// DetectTEEPlatform probes K8s node labels to determine the TEE platform
-	// available on the cluster (TDX or SNP). Returns TEEPlatformNone if no CC nodes found.
+	// DetectTEEPlatform probes managed K8s node labels to determine the TEE
+	// platform available to Akash workloads. It returns TEEPlatformNone when
+	// discovery cannot resolve one homogeneous platform.
 	DetectTEEPlatform(ctx context.Context) ctypes.TEEPlatform
 }
 

--- a/cluster/inventory.go
+++ b/cluster/inventory.go
@@ -147,16 +147,14 @@ func newInventoryService(
 	is.clients.inventory = cfromctx.ClientInventoryFromContext(ctx)
 	is.clients.ip = cfromctx.ClientIPFromContext(ctx)
 
-	is.teePlatform = client.DetectTEEPlatform(ctx)
-	if is.teePlatform != ctypes.TEEPlatformNone {
-		is.log.Info("detected TEE platform", "platform", is.teePlatform)
-	}
-
 	reservations := make([]*reservation, 0, len(deployments))
 	for _, d := range deployments {
 		res := newReservation(d.LeaseID().OrderID(), d.ManifestGroup())
 		res.SetClusterParams(d.ClusterParams())
-		res.teeType = teeTypeFromClusterParams(d.ClusterParams())
+		res.teeType, err = teeTypeFromClusterParams(d.ClusterParams())
+		if err != nil {
+			return nil, fmt.Errorf("restore reservation %s TEE type: %w", d.LeaseID(), err)
+		}
 
 		reservations = append(reservations, res)
 	}
@@ -479,7 +477,7 @@ func leasedIPStatus(state *inventoryServiceState) inventoryV1.ResourcePair {
 
 // teeTypeFromResourceGroup extracts the TEE type from the placement requirement
 // attributes of a resource group (e.g. tee/type=cpu-gpu).
-func teeTypeFromResourceGroup(rg dtypes.ResourceGroup) ctypes.TEEType {
+func teeTypeFromResourceGroup(rg dtypes.ResourceGroup) (ctypes.TEEType, error) {
 	var attrs atypes.Attributes
 	switch v := rg.(type) {
 	case dtypes.GroupSpec:
@@ -491,43 +489,58 @@ func teeTypeFromResourceGroup(rg dtypes.ResourceGroup) ctypes.TEEType {
 	case *dtypes.Group:
 		attrs = v.GroupSpec.Requirements.Attributes
 	default:
-		return ctypes.TEETypeNone
+		return ctypes.TEETypeNone, nil
 	}
+
+	var teeType ctypes.TEEType
+	found := false
 	for _, attr := range attrs {
-		if attr.Key == "tee/type" {
-			t, err := ctypes.ParseTEEType(attr.Value)
-			if err == nil {
-				return t
-			}
+		if attr.Key != "tee/type" {
+			continue
 		}
+		if found {
+			return ctypes.TEETypeNone, fmt.Errorf("duplicate tee/type placement attribute")
+		}
+		parsed, err := ctypes.ParseTEEType(attr.Value)
+		if err != nil {
+			return ctypes.TEETypeNone, fmt.Errorf("invalid tee/type placement attribute %q: %w", attr.Value, err)
+		}
+		teeType = parsed
+		found = true
 	}
-	return ctypes.TEETypeNone
+	return teeType, nil
 }
 
 // teeTypeFromClusterParams extracts the TEE type from stored cluster params
 // (used for existing reservations loaded at startup).
-func teeTypeFromClusterParams(cp interface{}) ctypes.TEEType {
+func teeTypeFromClusterParams(cp interface{}) (ctypes.TEEType, error) {
 	var sparams []*crd.SchedulerParams
 	switch v := cp.(type) {
 	case *crd.ClusterSettings:
 		if v == nil {
-			return ctypes.TEETypeNone
+			return ctypes.TEETypeNone, nil
 		}
 		sparams = v.SchedulerParams
 	case crd.ClusterSettings:
 		sparams = v.SchedulerParams
 	default:
-		return ctypes.TEETypeNone
+		return ctypes.TEETypeNone, nil
 	}
+
+	teeType := ctypes.TEETypeNone
 	for _, sp := range sparams {
 		if sp != nil && sp.TEEType != "" && !sp.AttestationDisabled {
-			t, err := ctypes.ParseTEEType(sp.TEEType)
-			if err == nil {
-				return t
+			parsed, err := ctypes.ParseTEEType(sp.TEEType)
+			if err != nil {
+				return ctypes.TEETypeNone, fmt.Errorf("invalid stored TEE type %q: %w", sp.TEEType, err)
 			}
+			if teeType != ctypes.TEETypeNone && teeType != parsed {
+				return ctypes.TEETypeNone, fmt.Errorf("conflicting stored TEE types %q and %q", teeType, parsed)
+			}
+			teeType = parsed
 		}
 	}
-	return ctypes.TEETypeNone
+	return teeType, nil
 }
 
 func (is *inventoryService) adjustOpts(teeType ctypes.TEEType) []ctypes.InventoryOption {
@@ -539,6 +552,13 @@ func (is *inventoryService) adjustOpts(teeType ctypes.TEEType) []ctypes.Inventor
 }
 
 func (is *inventoryService) handleRequest(req inventoryRequest, state *inventoryServiceState) {
+	teeType, err := teeTypeFromResourceGroup(req.resources)
+	if err != nil {
+		inventoryRequestsCounter.WithLabelValues("reserve", "invalid-tee-type").Inc()
+		req.ch <- inventoryResponse{err: err}
+		return
+	}
+
 	// convert the resources to the committed amount
 	resourcesToCommit := is.resourcesToCommit(req.resources)
 	// create new registration if capacity available
@@ -567,8 +587,8 @@ func (is *inventoryService) handleRequest(req inventoryRequest, state *inventory
 		reservation.ipsConfirmed = true // No IPs, just mark it as confirmed implicitly
 	}
 
-	reservation.teeType = teeTypeFromResourceGroup(req.resources)
-	err := state.inventory.Adjust(reservation, is.adjustOpts(reservation.teeType)...)
+	reservation.teeType = teeType
+	err = state.inventory.Adjust(reservation, is.adjustOpts(reservation.teeType)...)
 	if err != nil {
 		is.log.Info("insufficient capacity for reservation", "order", req.order)
 		inventoryRequestsCounter.WithLabelValues("reserve", "insufficient-capacity").Inc()
@@ -600,6 +620,14 @@ func (is *inventoryService) run(ctx context.Context, reservationsArg []*reservat
 	if err != nil {
 		is.lc.ShutdownInitiated(err)
 		return
+	}
+
+	// Inventory discovery applies the akash.network=true label only after it
+	// has excluded unschedulable nodes. Detect the TEE platform after the
+	// operators are ready so startup ordering cannot leave it unresolved.
+	is.teePlatform = is.client.DetectTEEPlatform(ctx)
+	if is.teePlatform != ctypes.TEEPlatformNone {
+		is.log.Info("detected TEE platform", "platform", is.teePlatform)
 	}
 
 	var runch <-chan runner.Result

--- a/cluster/inventory.go
+++ b/cluster/inventory.go
@@ -523,6 +523,11 @@ func teeTypeFromClusterParams(cp interface{}) (ctypes.TEEType, error) {
 		sparams = v.SchedulerParams
 	case crd.ClusterSettings:
 		sparams = v.SchedulerParams
+	case crd.ReservationClusterSettings:
+		sparams = make([]*crd.SchedulerParams, 0, len(v))
+		for _, sp := range v {
+			sparams = append(sparams, sp)
+		}
 	default:
 		return ctypes.TEETypeNone, nil
 	}

--- a/cluster/inventory_test.go
+++ b/cluster/inventory_test.go
@@ -881,3 +881,71 @@ func TestPlacementRequirementsPreserved(t *testing.T) {
 		require.Empty(t, placementRequirements(nil).Attributes)
 	})
 }
+
+func TestTEETypeFromResourceGroup(t *testing.T) {
+	group := func(attrs attrtypes.Attributes) dvbeta.ResourceGroup {
+		return dvbeta.GroupSpec{
+			Requirements: attrtypes.PlacementRequirements{Attributes: attrs},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		attrs   attrtypes.Attributes
+		want    ctypes.TEEType
+		wantErr string
+	}{
+		{name: "absent", want: ctypes.TEETypeNone},
+		{name: "CPU", attrs: attrtypes.Attributes{{Key: "tee/type", Value: "cpu"}}, want: ctypes.TEETypeCPU},
+		{name: "CPU and GPU", attrs: attrtypes.Attributes{{Key: "tee/type", Value: "cpu-gpu"}}, want: ctypes.TEETypeCPUGPU},
+		{name: "invalid", attrs: attrtypes.Attributes{{Key: "tee/type", Value: "future"}}, wantErr: "invalid tee/type"},
+		{name: "duplicate", attrs: attrtypes.Attributes{
+			{Key: "tee/type", Value: "cpu"},
+			{Key: "tee/type", Value: "cpu-gpu"},
+		}, wantErr: "duplicate tee/type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := teeTypeFromResourceGroup(group(tt.attrs))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Equal(t, ctypes.TEETypeNone, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTEETypeFromClusterParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  []*crd.SchedulerParams
+		want    ctypes.TEEType
+		wantErr string
+	}{
+		{name: "absent", want: ctypes.TEETypeNone},
+		{name: "CPU", params: []*crd.SchedulerParams{{TEEType: "cpu"}}, want: ctypes.TEETypeCPU},
+		{name: "disabled ignored", params: []*crd.SchedulerParams{{TEEType: "future", AttestationDisabled: true}}, want: ctypes.TEETypeNone},
+		{name: "invalid", params: []*crd.SchedulerParams{{TEEType: "future"}}, wantErr: "invalid stored TEE type"},
+		{name: "conflicting", params: []*crd.SchedulerParams{
+			{TEEType: "cpu"},
+			{TEEType: "cpu-gpu"},
+		}, wantErr: "conflicting stored TEE types"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := teeTypeFromClusterParams(crd.ClusterSettings{SchedulerParams: tt.params})
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Equal(t, ctypes.TEETypeNone, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cluster/inventory_test.go
+++ b/cluster/inventory_test.go
@@ -948,4 +948,29 @@ func TestTEETypeFromClusterParams(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+
+	t.Run("reservation settings", func(t *testing.T) {
+		got, err := teeTypeFromClusterParams(crd.ReservationClusterSettings{
+			1: {TEEType: "cpu-gpu"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ctypes.TEETypeCPUGPU, got)
+	})
+
+	t.Run("invalid reservation settings", func(t *testing.T) {
+		got, err := teeTypeFromClusterParams(crd.ReservationClusterSettings{
+			1: {TEEType: "future"},
+		})
+		require.ErrorContains(t, err, "invalid stored TEE type")
+		require.Equal(t, ctypes.TEETypeNone, got)
+	})
+
+	t.Run("conflicting reservation settings", func(t *testing.T) {
+		got, err := teeTypeFromClusterParams(crd.ReservationClusterSettings{
+			1: {TEEType: "cpu"},
+			2: {TEEType: "cpu-gpu"},
+		})
+		require.ErrorContains(t, err, "conflicting stored TEE types")
+		require.Equal(t, ctypes.TEETypeNone, got)
+	})
 }

--- a/cluster/kube/builder/runtime_class_test.go
+++ b/cluster/kube/builder/runtime_class_test.go
@@ -4,7 +4,41 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	ctypes "github.com/akash-network/provider/cluster/types/v1beta3"
 )
+
+func TestRuntimeClassForTEEType(t *testing.T) {
+	tests := []struct {
+		name     string
+		teeType  ctypes.TEEType
+		platform ctypes.TEEPlatform
+		want     RuntimeClass
+		wantErr  bool
+	}{
+		{name: "SNP CPU", teeType: ctypes.TEETypeCPU, platform: ctypes.TEEPlatformSNP, want: RuntimeClassKataQemuSNP},
+		{name: "SNP GPU", teeType: ctypes.TEETypeCPUGPU, platform: ctypes.TEEPlatformSNP, want: RuntimeClassKataQemuNvidiaGPUSNP},
+		{name: "TDX CPU", teeType: ctypes.TEETypeCPU, platform: ctypes.TEEPlatformTDX, want: RuntimeClassKataQemuTDX},
+		{name: "TDX GPU", teeType: ctypes.TEETypeCPUGPU, platform: ctypes.TEEPlatformTDX, want: RuntimeClassKataQemuNvidiaGPUTDX},
+		{name: "missing platform", teeType: ctypes.TEETypeCPU, platform: ctypes.TEEPlatformNone, wantErr: true},
+		{name: "unknown platform", teeType: ctypes.TEETypeCPU, platform: ctypes.TEEPlatform("future"), wantErr: true},
+		{name: "missing TEE type", teeType: ctypes.TEETypeNone, platform: ctypes.TEEPlatformSNP, wantErr: true},
+		{name: "unknown TEE type", teeType: ctypes.TEEType("future"), platform: ctypes.TEEPlatformSNP, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RuntimeClassForTEEType(tt.teeType, tt.platform)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func TestRuntimeClass_Is_NoOptions(t *testing.T) {
 	for _, rc := range []RuntimeClass{

--- a/cluster/kube/builder/workload.go
+++ b/cluster/kube/builder/workload.go
@@ -34,23 +34,32 @@ var (
 	WithTDX = ctypes.WithTDX
 )
 
-// RuntimeClassForTEEType maps a TEE type ("cpu", "cpu-gpu") to the corresponding
-// Kata runtime class using the detected TEE platform ("tdx" or "snp").
-func RuntimeClassForTEEType(teeType string, teePlatform string) RuntimeClass {
-	isGPU := teeType == "cpu-gpu"
-	switch teePlatform {
-	case "tdx":
-		if isGPU {
-			return RuntimeClassKataQemuNvidiaGPUTDX
-		}
-		return RuntimeClassKataQemuTDX
-	case "snp":
-		if isGPU {
-			return RuntimeClassKataQemuNvidiaGPUSNP
-		}
-		return RuntimeClassKataQemuSNP
+// RuntimeClassForTEEType maps a validated TEE request and detected platform to
+// its Kata runtime class. Missing and unknown values are errors so confidential
+// workloads can never fall through to the default OCI runtime.
+func RuntimeClassForTEEType(teeType ctypes.TEEType, teePlatform ctypes.TEEPlatform) (RuntimeClass, error) {
+	var isGPU bool
+	switch teeType {
+	case ctypes.TEETypeCPU:
+	case ctypes.TEETypeCPUGPU:
+		isGPU = true
 	default:
-		return ""
+		return "", fmt.Errorf("unsupported TEE type %q", teeType)
+	}
+
+	switch teePlatform {
+	case ctypes.TEEPlatformTDX:
+		if isGPU {
+			return RuntimeClassKataQemuNvidiaGPUTDX, nil
+		}
+		return RuntimeClassKataQemuTDX, nil
+	case ctypes.TEEPlatformSNP:
+		if isGPU {
+			return RuntimeClassKataQemuNvidiaGPUSNP, nil
+		}
+		return RuntimeClassKataQemuSNP, nil
+	default:
+		return "", fmt.Errorf("unsupported TEE platform %q for TEE type %q", teePlatform, teeType)
 	}
 }
 

--- a/cluster/kube/client_attestation.go
+++ b/cluster/kube/client_attestation.go
@@ -123,23 +123,37 @@ func (c *client) findAttestationSidecarPod(ctx context.Context, namespace string
 	return candidates[podIndex].Name, nil
 }
 
-// DetectTEEPlatform scans K8s nodes to determine the TEE platform available.
-// Returns TEEPlatformTDX if any node has the TDX label, TEEPlatformSNP for SNP,
-// or TEEPlatformNone if no CC-capable nodes are found.
+// DetectTEEPlatform scans schedulable nodes managed by the Akash inventory
+// operator. A mixed or unavailable result stays unresolved so TEE inventory
+// adjustment rejects the workload instead of falling back to the OCI runtime.
 func (c *client) DetectTEEPlatform(ctx context.Context) ctypes.TEEPlatform {
-	nodes, err := c.kc.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	nodes, err := c.kc.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", builder.AkashManagedLabelName, builder.ValTrue),
+	})
 	if err != nil {
+		c.log.Error("TEE platform detection failed; TEE workloads will be rejected", "error", err)
 		return ctypes.TEEPlatformNone
 	}
 
+	var hasTDX, hasSNP bool
 	for _, node := range nodes.Items {
 		if node.Labels[intelTDXLabelKey] == builder.ValTrue {
-			return ctypes.TEEPlatformTDX
+			hasTDX = true
 		}
 		if node.Labels[amdSNPLabelKey] == builder.ValTrue {
-			return ctypes.TEEPlatformSNP
+			hasSNP = true
 		}
 	}
 
+	if hasTDX && hasSNP {
+		c.log.Error("TEE platform detection found both TDX and SNP; TEE workloads will be rejected")
+		return ctypes.TEEPlatformNone
+	}
+	if hasTDX {
+		return ctypes.TEEPlatformTDX
+	}
+	if hasSNP {
+		return ctypes.TEEPlatformSNP
+	}
 	return ctypes.TEEPlatformNone
 }

--- a/cluster/kube/client_attestation_test.go
+++ b/cluster/kube/client_attestation_test.go
@@ -1,0 +1,73 @@
+package kube
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cosmossdk.io/log"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/akash-network/provider/cluster/kube/builder"
+	ctypes "github.com/akash-network/provider/cluster/types/v1beta3"
+)
+
+func TestDetectTEEPlatform(t *testing.T) {
+	node := func(name string, labels map[string]string) runtime.Object {
+		labels[builder.AkashManagedLabelName] = builder.ValTrue
+		return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+	}
+	unmanagedNode := func(name string, labels map[string]string) runtime.Object {
+		return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+	}
+
+	tests := []struct {
+		name  string
+		nodes []runtime.Object
+		want  ctypes.TEEPlatform
+	}{
+		{name: "none", want: ctypes.TEEPlatformNone},
+		{name: "SNP only", nodes: []runtime.Object{node("snp", map[string]string{amdSNPLabelKey: "true"})}, want: ctypes.TEEPlatformSNP},
+		{name: "TDX only", nodes: []runtime.Object{node("tdx", map[string]string{intelTDXLabelKey: "true"})}, want: ctypes.TEEPlatformTDX},
+		{name: "homogeneous across nodes", nodes: []runtime.Object{
+			node("snp-a", map[string]string{amdSNPLabelKey: "true"}),
+			node("snp-b", map[string]string{amdSNPLabelKey: "true"}),
+		}, want: ctypes.TEEPlatformSNP},
+		{name: "unmanaged opposite platform ignored", nodes: []runtime.Object{
+			node("snp", map[string]string{amdSNPLabelKey: "true"}),
+			unmanagedNode("tdx", map[string]string{intelTDXLabelKey: "true"}),
+		}, want: ctypes.TEEPlatformSNP},
+		{name: "mixed managed nodes unresolved", nodes: []runtime.Object{
+			node("snp", map[string]string{amdSNPLabelKey: "true"}),
+			node("tdx", map[string]string{intelTDXLabelKey: "true"}),
+		}, want: ctypes.TEEPlatformNone},
+		{name: "both labels on one node", nodes: []runtime.Object{
+			node("mixed", map[string]string{amdSNPLabelKey: "true", intelTDXLabelKey: "true"}),
+		}, want: ctypes.TEEPlatformNone},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &client{kc: fake.NewClientset(tt.nodes...), log: log.NewNopLogger()}
+			got := c.DetectTEEPlatform(context.Background())
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectTEEPlatformPropagatesListFailure(t *testing.T) {
+	kc := fake.NewClientset()
+	wantErr := errors.New("nodes unavailable")
+	kc.PrependReactor("list", "nodes", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, wantErr
+	})
+
+	c := &client{kc: kc, log: log.NewNopLogger()}
+	got := c.DetectTEEPlatform(context.Background())
+	require.Equal(t, ctypes.TEEPlatformNone, got)
+}

--- a/cluster/kube/operators/clients/inventory/inventory.go
+++ b/cluster/kube/operators/clients/inventory/inventory.go
@@ -102,8 +102,8 @@ func sanitizeQuantity(quantity *resource.Quantity) {
 // It returns two boolean values. First indicates if node-wide resources satisfy (true) requirements
 // Seconds indicates if cluster-wide resources satisfy (true) requirements
 //
-// teeType/teePlatform carry the confidential-compute selection through to
-// tryAdjustGPU.
+// teeType/ccRuntimeClass carry the validated confidential-compute selection
+// through to tryAdjustGPU.
 //
 // requiredFabric is the placement-level interconnect fabric pin extracted by the
 // caller from `Reservation.Resources()` via PlacementRequiredFabric. Empty
@@ -115,7 +115,7 @@ func (inv *inventory) tryAdjust(
 	node int,
 	res *rtypes.Resources,
 	teeType ctypes.TEEType,
-	teePlatform ctypes.TEEPlatform,
+	ccRuntimeClass builder.RuntimeClass,
 	requiredFabric string,
 	requiresInterconnect bool,
 	interconnectGroup string,
@@ -154,7 +154,7 @@ func (inv *inventory) tryAdjust(
 		return nil, false, true
 	}
 
-	if !tryAdjustGPU(&nd.Resources.GPU, res.GPU, sparams, teeType, teePlatform) {
+	if !tryAdjustGPU(&nd.Resources.GPU, res.GPU, sparams, teeType, ccRuntimeClass) {
 		return nil, false, true
 	}
 
@@ -213,7 +213,7 @@ func (inv *inventory) tryAdjust(
 	// sets it in tryAdjustGPU) and reserve sidecar resources.
 	if teeType.IsCC() {
 		if sparams.RuntimeClass == "" {
-			sparams.RuntimeClass = builder.RuntimeClassForTEEType(string(teeType), string(teePlatform))
+			sparams.RuntimeClass = ccRuntimeClass
 		}
 
 		sidecarCPU := rtypes.NewResourceValue(uint64(builder.SidecarCPULimitMillicores))
@@ -259,7 +259,7 @@ func tryAdjustCPU(rp *inventoryV1.ResourcePair, res *rtypes.CPU) bool {
 	return rp.SubMilliNLZ(res.Units)
 }
 
-func tryAdjustGPU(rp *inventoryV1.GPU, res *rtypes.GPU, sparams *crd.SchedulerParams, teeType ctypes.TEEType, teePlatform ctypes.TEEPlatform) bool {
+func tryAdjustGPU(rp *inventoryV1.GPU, res *rtypes.GPU, sparams *crd.SchedulerParams, teeType ctypes.TEEType, ccRuntimeClass builder.RuntimeClass) bool {
 	reqCnt := res.Units.Value()
 
 	if reqCnt == 0 {
@@ -310,7 +310,7 @@ func tryAdjustGPU(rp *inventoryV1.GPU, res *rtypes.GPU, sparams *crd.SchedulerPa
 			sparams.Resources.GPU.Model = info.Name
 
 			if teeType.IsCC() {
-				sparams.RuntimeClass = builder.RuntimeClassForTEEType(string(teeType), string(teePlatform))
+				sparams.RuntimeClass = ccRuntimeClass
 			} else {
 				switch vendor {
 				case builder.GPUVendorNvidia:
@@ -420,6 +420,15 @@ func (inv *inventory) Adjust(reservation ctypes.ReservationGroup, opts ...ctypes
 		cfg = opt(cfg)
 	}
 
+	ccRuntimeClass := builder.RuntimeClass("")
+	if cfg.TEEType.IsCC() {
+		var err error
+		ccRuntimeClass, err = builder.RuntimeClassForTEEType(cfg.TEEType, cfg.TEEPlatform)
+		if err != nil {
+			return err
+		}
+	}
+
 	origResources := reservation.Resources().GetResourceUnits()
 	resources := make(dvbeta.ResourceUnits, 0, len(origResources))
 	adjustedResources := make(dvbeta.ResourceUnits, 0, len(origResources))
@@ -493,7 +502,7 @@ nodes:
 			}
 
 			for ; resources[i].Count > 0; resources[i].Count-- {
-				sparams, nStatus, cStatus := currInventory.tryAdjust(nodeIdx, adjusted, cfg.TEEType, cfg.TEEPlatform, requiredFabric, requiresInterconnect[i], interconnectGroup[i], groupClaims)
+				sparams, nStatus, cStatus := currInventory.tryAdjust(nodeIdx, adjusted, cfg.TEEType, ccRuntimeClass, requiredFabric, requiresInterconnect[i], interconnectGroup[i], groupClaims)
 				if !cStatus {
 					// cannot satisfy cluster-wide resources, stop lookup
 					break nodes

--- a/cluster/kube/operators/clients/inventory/tee_runtime_test.go
+++ b/cluster/kube/operators/clients/inventory/tee_runtime_test.go
@@ -1,0 +1,32 @@
+package inventory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ctypes "github.com/akash-network/provider/cluster/types/v1beta3"
+)
+
+func TestAdjustRejectsUnresolvedTEEPlatformBeforeInventoryMutation(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform ctypes.TEEPlatform
+	}{
+		{name: "missing", platform: ctypes.TEEPlatformNone},
+		{name: "unknown", platform: ctypes.TEEPlatform("future")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv := &inventory{}
+			before := inv.Dup()
+			err := inv.Adjust(nil,
+				ctypes.WithTEEType(ctypes.TEETypeCPUGPU),
+				ctypes.WithTEEPlatform(tt.platform),
+			)
+			require.ErrorContains(t, err, "unsupported TEE platform")
+			require.Equal(t, before, inv.Dup())
+		})
+	}
+}

--- a/cluster/types/v1beta3/clients/inventory/inventory.go
+++ b/cluster/types/v1beta3/clients/inventory/inventory.go
@@ -283,7 +283,7 @@ func (inv *inventory) Dup() ctypes.Inventory {
 // tryAdjust cluster inventory
 // It returns two boolean values. First indicates if node-wide resources satisfy (true) requirements
 // Seconds indicates if cluster-wide resources satisfy (true) requirements
-func (inv *inventory) tryAdjust(node int, res *rtypes.Resources, teeType ctypes.TEEType, teePlatform ctypes.TEEPlatform) (*crd.SchedulerParams, bool, bool) {
+func (inv *inventory) tryAdjust(node int, res *rtypes.Resources, teeType ctypes.TEEType, ccRuntimeClass builder.RuntimeClass) (*crd.SchedulerParams, bool, bool) {
 	nd := inv.Nodes[node].Dup()
 	sparams := &crd.SchedulerParams{}
 
@@ -291,7 +291,7 @@ func (inv *inventory) tryAdjust(node int, res *rtypes.Resources, teeType ctypes.
 		return nil, false, true
 	}
 
-	if !tryAdjustGPU(&nd.Resources.GPU, res.GPU, sparams, teeType, teePlatform) {
+	if !tryAdjustGPU(&nd.Resources.GPU, res.GPU, sparams, teeType, ccRuntimeClass) {
 		return nil, false, true
 	}
 
@@ -350,7 +350,7 @@ func (inv *inventory) tryAdjust(node int, res *rtypes.Resources, teeType ctypes.
 	// sets it in tryAdjustGPU) and reserve sidecar resources.
 	if teeType.IsCC() {
 		if sparams.RuntimeClass == "" {
-			sparams.RuntimeClass = builder.RuntimeClassForTEEType(string(teeType), string(teePlatform))
+			sparams.RuntimeClass = ccRuntimeClass
 		}
 
 		sidecarCPU := rtypes.NewResourceValue(uint64(builder.SidecarCPULimitMillicores))
@@ -384,7 +384,7 @@ func tryAdjustCPU(rp *inventoryV1.ResourcePair, res *rtypes.CPU) bool {
 	return rp.SubMilliNLZ(res.Units)
 }
 
-func tryAdjustGPU(rp *inventoryV1.GPU, res *rtypes.GPU, sparams *crd.SchedulerParams, teeType ctypes.TEEType, teePlatform ctypes.TEEPlatform) bool {
+func tryAdjustGPU(rp *inventoryV1.GPU, res *rtypes.GPU, sparams *crd.SchedulerParams, teeType ctypes.TEEType, ccRuntimeClass builder.RuntimeClass) bool {
 	reqCnt := res.Units.Value()
 
 	if reqCnt == 0 {
@@ -434,7 +434,7 @@ func tryAdjustGPU(rp *inventoryV1.GPU, res *rtypes.GPU, sparams *crd.SchedulerPa
 			sparams.Resources.GPU.Model = info.Name
 
 			if teeType.IsCC() {
-				sparams.RuntimeClass = builder.RuntimeClassForTEEType(string(teeType), string(teePlatform))
+				sparams.RuntimeClass = ccRuntimeClass
 			}
 
 			key := fmt.Sprintf("vendor/%s/model/%s", vendor, info.Name)
@@ -477,6 +477,15 @@ func (inv *inventory) Adjust(reservation ctypes.ReservationGroup, opts ...ctypes
 		cfg = opt(cfg)
 	}
 
+	ccRuntimeClass := builder.RuntimeClass("")
+	if cfg.TEEType.IsCC() {
+		var err error
+		ccRuntimeClass, err = builder.RuntimeClassForTEEType(cfg.TEEType, cfg.TEEPlatform)
+		if err != nil {
+			return err
+		}
+	}
+
 	origResources := reservation.Resources().GetResourceUnits()
 	resources := make(dvbeta.ResourceUnits, 0, len(origResources))
 	adjustedResources := make(dvbeta.ResourceUnits, 0, len(origResources))
@@ -514,7 +523,7 @@ nodes:
 			}
 
 			for ; resources[i].Count > 0; resources[i].Count-- {
-				sparams, nStatus, cStatus := currInventory.tryAdjust(nodeIdx, adjusted, cfg.TEEType, cfg.TEEPlatform)
+				sparams, nStatus, cStatus := currInventory.tryAdjust(nodeIdx, adjusted, cfg.TEEType, ccRuntimeClass)
 				if !cStatus {
 					// cannot satisfy cluster-wide resources, stop lookup
 					break nodes

--- a/cluster/types/v1beta3/clients/inventory/tee_runtime_test.go
+++ b/cluster/types/v1beta3/clients/inventory/tee_runtime_test.go
@@ -1,0 +1,32 @@
+package inventory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ctypes "github.com/akash-network/provider/cluster/types/v1beta3"
+)
+
+func TestAdjustRejectsUnresolvedTEEPlatformBeforeInventoryMutation(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform ctypes.TEEPlatform
+	}{
+		{name: "missing", platform: ctypes.TEEPlatformNone},
+		{name: "unknown", platform: ctypes.TEEPlatform("future")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv := &inventory{}
+			before := inv.Dup()
+			err := inv.Adjust(nil,
+				ctypes.WithTEEType(ctypes.TEETypeCPUGPU),
+				ctypes.WithTEEPlatform(tt.platform),
+			)
+			require.ErrorContains(t, err, "unsupported TEE platform")
+			require.Equal(t, before, inv.Dup())
+		})
+	}
+}


### PR DESCRIPTION
## Why

A confidential workload whose TEE type or node platform cannot be resolved must not fall through to the ordinary OCI runtime. Startup label races, unmanaged nodes, mixed platforms, and unknown values must fail closed.

## What changed

- make TEE type-to-runtime selection typed and exhaustive
- resolve the runtime before mutating inventory state
- reject invalid or conflicting stored TEE state
- fail startup on an invalid restored reservation so occupied capacity cannot be omitted and overcommitted
- scope platform discovery to Akash-managed nodes
- delay discovery until managed nodes are ready
- cover supported combinations and every fail-closed case

## Validation

- focused runtime, inventory, and managed-node tests pass
- restored reservation regressions pass
- all Provider GitHub build, test, lint, coverage, release dry-run, shell, YAML, and CRD integration checks pass
- CodeRabbit's restore-path parsing finding is fixed; its suggestion to skip bad restored reservations was declined to preserve capacity accounting

This PR changes only runtime selection and inventory safety. It does not add a new GPU passthrough path.
