### PR TITLE
fix(attestation): preserve framed multi-GPU evidence

### DIFF
--- a/sidecar/attestation/nvml-helper/nvml_attestation.c
+++ b/sidecar/attestation/nvml-helper/nvml_attestation.c
@@ -88,31 +88,37 @@ static int hex2bytes(const char *hex, uint8_t *out, int maxlen) {
     return len/2;
 }
 
-static void write_le32(uint32_t val) {
+static int write_le32(uint32_t val) {
     uint8_t buf[4];
     buf[0] = val & 0xFF;
     buf[1] = (val >> 8) & 0xFF;
     buf[2] = (val >> 16) & 0xFF;
     buf[3] = (val >> 24) & 0xFF;
-    fwrite(buf, 1, 4, stdout);
+    return fwrite(buf, 1, 4, stdout) == 4 ? 0 : 1;
 }
 
-/* Attest a single device and write its report to stdout.
- * Returns 0 on success, non-zero on failure. */
-static int attest_device(
+typedef struct {
+    uint32_t devIdx;
+    nvmlConfComputeGpuAttestationReport_t report;
+    nvmlConfComputeGpuCertificate_t cert;
+} collectedAttestation_t;
+
+/* Collect and validate one complete device frame without writing output. */
+static int collect_attestation(
     fn_deviceGetAttReport nvmlDeviceGetAttReport,
     fn_deviceGetCert nvmlDeviceGetCert,
     nvmlDevice_t device,
     uint32_t devIdx,
     const uint8_t *nonce,
-    int nonceLen
+    int nonceLen,
+    collectedAttestation_t *evidence
 ) {
-    nvmlConfComputeGpuAttestationReport_t report;
-    memset(&report, 0, sizeof(report));
-    memcpy(report.nonce, nonce,
+    memset(evidence, 0, sizeof(*evidence));
+    evidence->devIdx = devIdx;
+    memcpy(evidence->report.nonce, nonce,
            nonceLen < NVML_CC_GPU_CEC_NONCE_SIZE ? nonceLen : NVML_CC_GPU_CEC_NONCE_SIZE);
 
-    nvmlReturn_t ret = nvmlDeviceGetAttReport(device, &report);
+    nvmlReturn_t ret = nvmlDeviceGetAttReport(device, &evidence->report);
     if (ret != NVML_SUCCESS) {
         fprintf(stderr, "GPU %u: nvmlDeviceGetConfComputeGpuAttestationReport: %d\n", devIdx, ret);
         return ret;
@@ -120,30 +126,17 @@ static int attest_device(
 
     /* Driver-reported sizes are untrusted. Truncation would produce evidence
      * that no longer matches the signed report, so reject it instead. */
-    if (report.attestationReportSize > sizeof(report.attestationReport)) {
+    if (evidence->report.attestationReportSize > sizeof(evidence->report.attestationReport)) {
         fprintf(stderr, "GPU %u: attestation report size %u exceeds buffer size %zu\n",
-                devIdx, report.attestationReportSize, sizeof(report.attestationReport));
+                devIdx, evidence->report.attestationReportSize,
+                sizeof(evidence->report.attestationReport));
         return 1;
     }
-    if (report.cecAttestationReportSize > sizeof(report.cecAttestationReport)) {
+    if (evidence->report.cecAttestationReportSize > sizeof(evidence->report.cecAttestationReport)) {
         fprintf(stderr, "GPU %u: CEC report size %u exceeds buffer size %zu\n",
-                devIdx, report.cecAttestationReportSize, sizeof(report.cecAttestationReport));
+                devIdx, evidence->report.cecAttestationReportSize,
+                sizeof(evidence->report.cecAttestationReport));
         return 1;
-    }
-
-    /* Write device index */
-    write_le32(devIdx);
-
-    /* Write attestation report */
-    write_le32(report.attestationReportSize);
-    fwrite(report.attestationReport, 1, report.attestationReportSize, stdout);
-
-    /* Write CEC report (size=0 if not present) */
-    if (report.isCecAttestationReportPresent && report.cecAttestationReportSize > 0) {
-        write_le32(report.cecAttestationReportSize);
-        fwrite(report.cecAttestationReport, 1, report.cecAttestationReportSize, stdout);
-    } else {
-        write_le32(0);
     }
 
     /* Local verification requires the attestation certificate chain. A report
@@ -154,21 +147,41 @@ static int attest_device(
         return 1;
     }
 
-    nvmlConfComputeGpuCertificate_t cert;
-    memset(&cert, 0, sizeof(cert));
-    ret = nvmlDeviceGetCert(device, &cert);
-    if (ret != NVML_SUCCESS || cert.attestationCertChainSize == 0) {
+    ret = nvmlDeviceGetCert(device, &evidence->cert);
+    if (ret != NVML_SUCCESS || evidence->cert.attestationCertChainSize == 0) {
         fprintf(stderr, "GPU %u: nvmlDeviceGetConfComputeGpuCertificate: %d (size=%u)\n",
-                devIdx, ret, cert.attestationCertChainSize);
+                devIdx, ret, evidence->cert.attestationCertChainSize);
         return 1;
     }
-    if (cert.attestationCertChainSize > sizeof(cert.attestationCertChain)) {
+    if (evidence->cert.attestationCertChainSize > sizeof(evidence->cert.attestationCertChain)) {
         fprintf(stderr, "GPU %u: certificate chain size %u exceeds buffer size %zu\n",
-                devIdx, cert.attestationCertChainSize, sizeof(cert.attestationCertChain));
+                devIdx, evidence->cert.attestationCertChainSize,
+                sizeof(evidence->cert.attestationCertChain));
         return 1;
     }
-    write_le32(cert.attestationCertChainSize);
-    fwrite(cert.attestationCertChain, 1, cert.attestationCertChainSize, stdout);
+
+    return 0;
+}
+
+static int write_attestation(const collectedAttestation_t *evidence) {
+    const nvmlConfComputeGpuAttestationReport_t *report = &evidence->report;
+    const nvmlConfComputeGpuCertificate_t *cert = &evidence->cert;
+    uint32_t cecSize = report->isCecAttestationReportPresent
+        ? report->cecAttestationReportSize
+        : 0;
+
+    if (write_le32(evidence->devIdx) != 0 ||
+        write_le32(report->attestationReportSize) != 0 ||
+        fwrite(report->attestationReport, 1, report->attestationReportSize, stdout)
+            != report->attestationReportSize ||
+        write_le32(cecSize) != 0 ||
+        fwrite(report->cecAttestationReport, 1, cecSize, stdout) != cecSize ||
+        write_le32(cert->attestationCertChainSize) != 0 ||
+        fwrite(cert->attestationCertChain, 1, cert->attestationCertChainSize, stdout)
+            != cert->attestationCertChainSize) {
+        fprintf(stderr, "GPU %u: failed to write attestation output\n", evidence->devIdx);
+        return 1;
+    }
 
     return 0;
 }
@@ -300,7 +313,19 @@ int main(int argc, char **argv) {
             return 3;
         }
 
-        int rc = attest_device(nvmlDeviceGetAttReport, nvmlDeviceGetCert, dev, idx, nonce, nonceLen);
+        collectedAttestation_t evidence;
+        int rc = collect_attestation(
+            nvmlDeviceGetAttReport,
+            nvmlDeviceGetCert,
+            dev,
+            idx,
+            nonce,
+            nonceLen,
+            &evidence
+        );
+        if (rc == 0) {
+            rc = write_attestation(&evidence);
+        }
         nvmlShutdown();
         return rc ? 4 : 0;
     }
@@ -331,18 +356,37 @@ int main(int argc, char **argv) {
             return 1;
         }
 
-        /* Write device count header */
-        write_le32(ccCount);
+        collectedAttestation_t *evidence = calloc(ccCount, sizeof(*evidence));
+        if (!evidence) {
+            fprintf(stderr, "failed to allocate multi-GPU attestation buffer\n");
+            nvmlShutdown();
+            return 4;
+        }
 
-        int failures = 0;
         for (uint32_t i = 0; i < ccCount; i++) {
-            if (attest_device(nvmlDeviceGetAttReport, nvmlDeviceGetCert, devices[i], deviceIdxs[i], nonce, nonceLen) != 0) {
-                failures++;
+            if (collect_attestation(
+                    nvmlDeviceGetAttReport,
+                    nvmlDeviceGetCert,
+                    devices[i],
+                    deviceIdxs[i],
+                    nonce,
+                    nonceLen,
+                    &evidence[i]
+                ) != 0) {
+                free(evidence);
+                nvmlShutdown();
+                return 4;
             }
         }
 
+        int writeFailed = write_le32(ccCount);
+        for (uint32_t i = 0; i < ccCount && writeFailed == 0; i++) {
+            writeFailed = write_attestation(&evidence[i]);
+        }
+
+        free(evidence);
         nvmlShutdown();
-        return failures > 0 ? 4 : 0;
+        return writeFailed ? 4 : 0;
     }
 
     if (strcmp(cmd, "cert") == 0) {

--- a/sidecar/attestation/nvml-helper/nvml_attestation.c
+++ b/sidecar/attestation/nvml-helper/nvml_attestation.c
@@ -19,6 +19,9 @@
  * Binary output format for attest / attest-all:
  *   For each device:
  *     4 bytes LE: device index
+ *     4 bytes LE: NVML device architecture
+ *     4 bytes LE: device UUID size
+ *     N bytes:    device UUID reported by NVML
  *     4 bytes LE: attestation report size
  *     N bytes:    attestation report
  *     4 bytes LE: CEC report size (0 if not present)
@@ -52,6 +55,7 @@ typedef void* nvmlDevice_t;
 #define NVML_CC_GPU_ATTESTATION_REPORT_SIZE 0x2000
 #define NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE 0x1000
 #define NVML_CC_GPU_CEC_NONCE_SIZE 0x20
+#define NVML_DEVICE_UUID_BUFFER_SIZE 80
 
 typedef struct {
     uint32_t certChainSize;
@@ -76,6 +80,8 @@ typedef nvmlReturn_t (*fn_deviceGetCount)(uint32_t*);
 typedef nvmlReturn_t (*fn_deviceGetHandleByIndex)(uint32_t, nvmlDevice_t*);
 typedef nvmlReturn_t (*fn_deviceGetCert)(nvmlDevice_t, nvmlConfComputeGpuCertificate_t*);
 typedef nvmlReturn_t (*fn_deviceGetAttReport)(nvmlDevice_t, nvmlConfComputeGpuAttestationReport_t*);
+typedef nvmlReturn_t (*fn_deviceGetArchitecture)(nvmlDevice_t, uint32_t*);
+typedef nvmlReturn_t (*fn_deviceGetUUID)(nvmlDevice_t, char*, uint32_t);
 
 static int hex2bytes(const char *hex, uint8_t *out, int maxlen) {
     int len = strlen(hex);
@@ -99,6 +105,8 @@ static int write_le32(uint32_t val) {
 
 typedef struct {
     uint32_t devIdx;
+    uint32_t architecture;
+    char uuid[NVML_DEVICE_UUID_BUFFER_SIZE];
     nvmlConfComputeGpuAttestationReport_t report;
     nvmlConfComputeGpuCertificate_t cert;
 } collectedAttestation_t;
@@ -107,6 +115,8 @@ typedef struct {
 static int collect_attestation(
     fn_deviceGetAttReport nvmlDeviceGetAttReport,
     fn_deviceGetCert nvmlDeviceGetCert,
+    fn_deviceGetArchitecture nvmlDeviceGetArchitecture,
+    fn_deviceGetUUID nvmlDeviceGetUUID,
     nvmlDevice_t device,
     uint32_t devIdx,
     const uint8_t *nonce,
@@ -115,10 +125,27 @@ static int collect_attestation(
 ) {
     memset(evidence, 0, sizeof(*evidence));
     evidence->devIdx = devIdx;
+
+    if (!nvmlDeviceGetArchitecture || !nvmlDeviceGetUUID) {
+        fprintf(stderr, "GPU %u: NVML device identity APIs are unavailable\n", devIdx);
+        return 1;
+    }
+    nvmlReturn_t ret = nvmlDeviceGetArchitecture(device, &evidence->architecture);
+    if (ret != NVML_SUCCESS) {
+        fprintf(stderr, "GPU %u: nvmlDeviceGetArchitecture: %d\n", devIdx, ret);
+        return ret;
+    }
+    ret = nvmlDeviceGetUUID(device, evidence->uuid, sizeof(evidence->uuid));
+    if (ret != NVML_SUCCESS || evidence->uuid[0] == '\0' ||
+        memchr(evidence->uuid, '\0', sizeof(evidence->uuid)) == NULL) {
+        fprintf(stderr, "GPU %u: nvmlDeviceGetUUID: %d (invalid UUID)\n", devIdx, ret);
+        return ret == NVML_SUCCESS ? 1 : ret;
+    }
+
     memcpy(evidence->report.nonce, nonce,
            nonceLen < NVML_CC_GPU_CEC_NONCE_SIZE ? nonceLen : NVML_CC_GPU_CEC_NONCE_SIZE);
 
-    nvmlReturn_t ret = nvmlDeviceGetAttReport(device, &evidence->report);
+    ret = nvmlDeviceGetAttReport(device, &evidence->report);
     if (ret != NVML_SUCCESS) {
         fprintf(stderr, "GPU %u: nvmlDeviceGetConfComputeGpuAttestationReport: %d\n", devIdx, ret);
         return ret;
@@ -169,8 +196,12 @@ static int write_attestation(const collectedAttestation_t *evidence) {
     uint32_t cecSize = report->isCecAttestationReportPresent
         ? report->cecAttestationReportSize
         : 0;
+    uint32_t uuidSize = (uint32_t)strlen(evidence->uuid);
 
     if (write_le32(evidence->devIdx) != 0 ||
+        write_le32(evidence->architecture) != 0 ||
+        write_le32(uuidSize) != 0 ||
+        fwrite(evidence->uuid, 1, uuidSize, stdout) != uuidSize ||
         write_le32(report->attestationReportSize) != 0 ||
         fwrite(report->attestationReport, 1, report->attestationReportSize, stdout)
             != report->attestationReportSize ||
@@ -206,6 +237,8 @@ int main(int argc, char **argv) {
     fn_deviceGetHandleByIndex nvmlDeviceGetHandle = dlsym(lib, "nvmlDeviceGetHandleByIndex_v2");
     fn_deviceGetCert nvmlDeviceGetCert = dlsym(lib, "nvmlDeviceGetConfComputeGpuCertificate");
     fn_deviceGetAttReport nvmlDeviceGetAttReport = dlsym(lib, "nvmlDeviceGetConfComputeGpuAttestationReport");
+    fn_deviceGetArchitecture nvmlDeviceGetArchitecture = dlsym(lib, "nvmlDeviceGetArchitecture");
+    fn_deviceGetUUID nvmlDeviceGetUUID = dlsym(lib, "nvmlDeviceGetUUID");
 
     if (!nvmlInit || !nvmlShutdown || !nvmlDeviceGetCount || !nvmlDeviceGetHandle) {
         fprintf(stderr, "failed to resolve core NVML symbols\n");
@@ -317,6 +350,8 @@ int main(int argc, char **argv) {
         int rc = collect_attestation(
             nvmlDeviceGetAttReport,
             nvmlDeviceGetCert,
+            nvmlDeviceGetArchitecture,
+            nvmlDeviceGetUUID,
             dev,
             idx,
             nonce,
@@ -367,6 +402,8 @@ int main(int argc, char **argv) {
             if (collect_attestation(
                     nvmlDeviceGetAttReport,
                     nvmlDeviceGetCert,
+                    nvmlDeviceGetArchitecture,
+                    nvmlDeviceGetUUID,
                     devices[i],
                     deviceIdxs[i],
                     nonce,

--- a/sidecar/attestation/nvml-helper/nvml_attestation.c
+++ b/sidecar/attestation/nvml-helper/nvml_attestation.c
@@ -23,6 +23,8 @@
  *     N bytes:    attestation report
  *     4 bytes LE: CEC report size (0 if not present)
  *     N bytes:    CEC report (omitted if size is 0)
+ *     4 bytes LE: certificate chain size
+ *     M bytes:    PEM-encoded certificate chain
  *   attest outputs exactly one device; attest-all outputs all CC-capable devices.
  *
  * Exit codes:
@@ -44,21 +46,27 @@ typedef int nvmlReturn_t;
 typedef void* nvmlDevice_t;
 
 #define NVML_SUCCESS 0
+#define MAX_GPU_DEVICES 64
+#define NVML_GPU_CERT_CHAIN_SIZE 0x1000
+#define NVML_GPU_ATTESTATION_CERT_CHAIN_SIZE 0x1400
+#define NVML_CC_GPU_ATTESTATION_REPORT_SIZE 0x2000
+#define NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE 0x1000
+#define NVML_CC_GPU_CEC_NONCE_SIZE 0x20
 
 typedef struct {
     uint32_t certChainSize;
     uint32_t attestationCertChainSize;
-    uint8_t  certChain[4096];
-    uint8_t  attestationCertChain[5120];
+    uint8_t  certChain[NVML_GPU_CERT_CHAIN_SIZE];
+    uint8_t  attestationCertChain[NVML_GPU_ATTESTATION_CERT_CHAIN_SIZE];
 } nvmlConfComputeGpuCertificate_t;
 
 typedef struct {
     uint32_t isCecAttestationReportPresent;
     uint32_t attestationReportSize;
     uint32_t cecAttestationReportSize;
-    uint8_t  nonce[32];
-    uint8_t  attestationReport[8192];
-    uint8_t  cecAttestationReport[4096];
+    uint8_t  nonce[NVML_CC_GPU_CEC_NONCE_SIZE];
+    uint8_t  attestationReport[NVML_CC_GPU_ATTESTATION_REPORT_SIZE];
+    uint8_t  cecAttestationReport[NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE];
 } nvmlConfComputeGpuAttestationReport_t;
 
 /* Function pointer types */
@@ -101,7 +109,8 @@ static int attest_device(
 ) {
     nvmlConfComputeGpuAttestationReport_t report;
     memset(&report, 0, sizeof(report));
-    memcpy(report.nonce, nonce, nonceLen < 32 ? nonceLen : 32);
+    memcpy(report.nonce, nonce,
+           nonceLen < NVML_CC_GPU_CEC_NONCE_SIZE ? nonceLen : NVML_CC_GPU_CEC_NONCE_SIZE);
 
     nvmlReturn_t ret = nvmlDeviceGetAttReport(device, &report);
     if (ret != NVML_SUCCESS) {
@@ -109,11 +118,18 @@ static int attest_device(
         return ret;
     }
 
-    /* Clamp driver-reported sizes to buffer bounds */
-    if (report.attestationReportSize > sizeof(report.attestationReport))
-        report.attestationReportSize = sizeof(report.attestationReport);
-    if (report.cecAttestationReportSize > sizeof(report.cecAttestationReport))
-        report.cecAttestationReportSize = sizeof(report.cecAttestationReport);
+    /* Driver-reported sizes are untrusted. Truncation would produce evidence
+     * that no longer matches the signed report, so reject it instead. */
+    if (report.attestationReportSize > sizeof(report.attestationReport)) {
+        fprintf(stderr, "GPU %u: attestation report size %u exceeds buffer size %zu\n",
+                devIdx, report.attestationReportSize, sizeof(report.attestationReport));
+        return 1;
+    }
+    if (report.cecAttestationReportSize > sizeof(report.cecAttestationReport)) {
+        fprintf(stderr, "GPU %u: CEC report size %u exceeds buffer size %zu\n",
+                devIdx, report.cecAttestationReportSize, sizeof(report.cecAttestationReport));
+        return 1;
+    }
 
     /* Write device index */
     write_le32(devIdx);
@@ -130,26 +146,29 @@ static int attest_device(
         write_le32(0);
     }
 
-    /* Append attestation cert chain if available.
-     * The cert chain is PEM-encoded and starts with "-----BEGIN CERTIFICATE-----".
-     * Tenants can split the report blob on this marker to extract it.
-     * If cert collection fails, we skip silently — the attestation report
-     * is still valid, just without an embedded cert chain. */
-    if (nvmlDeviceGetCert) {
-        nvmlConfComputeGpuCertificate_t cert;
-        memset(&cert, 0, sizeof(cert));
-        if (nvmlDeviceGetCert(device, &cert) == NVML_SUCCESS &&
-            cert.attestationCertChainSize > 0) {
-            if (cert.attestationCertChainSize > sizeof(cert.attestationCertChain))
-                cert.attestationCertChainSize = sizeof(cert.attestationCertChain);
-            write_le32(cert.attestationCertChainSize);
-            fwrite(cert.attestationCertChain, 1, cert.attestationCertChainSize, stdout);
-        } else {
-            write_le32(0);
-        }
-    } else {
-        write_le32(0);
+    /* Local verification requires the attestation certificate chain. A report
+     * without it cannot be authenticated, so fail instead of returning partial
+     * evidence that downstream code could accidentally accept. */
+    if (!nvmlDeviceGetCert) {
+        fprintf(stderr, "GPU %u: nvmlDeviceGetConfComputeGpuCertificate not available\n", devIdx);
+        return 1;
     }
+
+    nvmlConfComputeGpuCertificate_t cert;
+    memset(&cert, 0, sizeof(cert));
+    ret = nvmlDeviceGetCert(device, &cert);
+    if (ret != NVML_SUCCESS || cert.attestationCertChainSize == 0) {
+        fprintf(stderr, "GPU %u: nvmlDeviceGetConfComputeGpuCertificate: %d (size=%u)\n",
+                devIdx, ret, cert.attestationCertChainSize);
+        return 1;
+    }
+    if (cert.attestationCertChainSize > sizeof(cert.attestationCertChain)) {
+        fprintf(stderr, "GPU %u: certificate chain size %u exceeds buffer size %zu\n",
+                devIdx, cert.attestationCertChainSize, sizeof(cert.attestationCertChain));
+        return 1;
+    }
+    write_le32(cert.attestationCertChainSize);
+    fwrite(cert.attestationCertChain, 1, cert.attestationCertChainSize, stdout);
 
     return 0;
 }
@@ -193,19 +212,30 @@ int main(int argc, char **argv) {
         nvmlShutdown();
         return 3;
     }
+    if (count > MAX_GPU_DEVICES) {
+        fprintf(stderr, "GPU count %u exceeds helper maximum %u\n", count, MAX_GPU_DEVICES);
+        nvmlShutdown();
+        return 4;
+    }
 
     /* Build list of CC-capable devices */
-    nvmlDevice_t devices[64];
-    uint32_t     deviceIdxs[64];
+    nvmlDevice_t devices[MAX_GPU_DEVICES];
+    uint32_t     deviceIdxs[MAX_GPU_DEVICES];
     uint32_t     ccCount = 0;
 
-    for (uint32_t i = 0; i < count && ccCount < 64; i++) {
+    for (uint32_t i = 0; i < count; i++) {
         nvmlDevice_t d;
         if (nvmlDeviceGetHandle(i, &d) != NVML_SUCCESS) continue;
         if (nvmlDeviceGetCert) {
             nvmlConfComputeGpuCertificate_t cert;
             memset(&cert, 0, sizeof(cert));
             if (nvmlDeviceGetCert(d, &cert) == NVML_SUCCESS && cert.attestationCertChainSize > 0) {
+                if (cert.attestationCertChainSize > sizeof(cert.attestationCertChain)) {
+                    fprintf(stderr, "GPU %u: certificate chain size %u exceeds buffer size %zu\n",
+                            i, cert.attestationCertChainSize, sizeof(cert.attestationCertChain));
+                    nvmlShutdown();
+                    return 4;
+                }
                 devices[ccCount] = d;
                 deviceIdxs[ccCount] = i;
                 ccCount++;
@@ -254,10 +284,10 @@ int main(int argc, char **argv) {
             return 1;
         }
 
-        uint8_t nonce[32];
-        int nonceLen = hex2bytes(argv[2], nonce, 32);
-        if (nonceLen < 0) {
-            fprintf(stderr, "invalid nonce hex\n");
+        uint8_t nonce[NVML_CC_GPU_CEC_NONCE_SIZE];
+        int nonceLen = hex2bytes(argv[2], nonce, NVML_CC_GPU_CEC_NONCE_SIZE);
+        if (nonceLen != NVML_CC_GPU_CEC_NONCE_SIZE) {
+            fprintf(stderr, "nonce must be exactly 32 bytes\n");
             nvmlShutdown();
             return 1;
         }
@@ -293,10 +323,10 @@ int main(int argc, char **argv) {
             return 3;
         }
 
-        uint8_t nonce[32];
-        int nonceLen = hex2bytes(argv[2], nonce, 32);
-        if (nonceLen < 0) {
-            fprintf(stderr, "invalid nonce hex\n");
+        uint8_t nonce[NVML_CC_GPU_CEC_NONCE_SIZE];
+        int nonceLen = hex2bytes(argv[2], nonce, NVML_CC_GPU_CEC_NONCE_SIZE);
+        if (nonceLen != NVML_CC_GPU_CEC_NONCE_SIZE) {
+            fprintf(stderr, "nonce must be exactly 32 bytes\n");
             nvmlShutdown();
             return 1;
         }
@@ -338,9 +368,12 @@ int main(int argc, char **argv) {
             return 4;
         }
 
-        /* Clamp to buffer bound and write attestation cert chain */
-        if (cert.attestationCertChainSize > sizeof(cert.attestationCertChain))
-            cert.attestationCertChainSize = sizeof(cert.attestationCertChain);
+        if (cert.attestationCertChainSize > sizeof(cert.attestationCertChain)) {
+            fprintf(stderr, "certificate chain size %u exceeds buffer size %zu\n",
+                    cert.attestationCertChainSize, sizeof(cert.attestationCertChain));
+            nvmlShutdown();
+            return 4;
+        }
         fwrite(cert.attestationCertChain, 1, cert.attestationCertChainSize, stdout);
         nvmlShutdown();
         return 0;

--- a/sidecar/attestation/server.go
+++ b/sidecar/attestation/server.go
@@ -25,9 +25,14 @@ type QuoteRequest struct {
 }
 
 // GPUReportEntry holds attestation evidence for a single GPU in the response.
+// AttestationReport and CertificateChain map directly to Trustee's evidence and
+// certificate values after the tenant supplies the device architecture and UUID.
 type GPUReportEntry struct {
-	DeviceIndex uint32 `json:"device_index"`
-	Report      string `json:"report"` // base64
+	DeviceIndex       uint32 `json:"device_index"`
+	Report            string `json:"report"` // base64 legacy report || CEC || certificate chain
+	AttestationReport string `json:"attestation_report"`
+	CECReport         string `json:"cec_report,omitempty"`
+	CertificateChain  string `json:"certificate_chain,omitempty"`
 }
 
 // QuoteResponse is the response body for POST /quote.
@@ -39,8 +44,9 @@ type QuoteResponse struct {
 	TEEPlatform string `json:"tee_platform"` // "snp", "tdx", "snp-gpu", "tdx-gpu"
 	AuxBlob     string `json:"auxblob"`      // empty on NVIDIA-patched kernel
 
-	// GPUReports contains per-device attestation evidence for ALL CC-capable GPUs.
-	// Each entry includes the device index and its hardware-signed report.
+	// GPUReports contains separately framed attestation evidence for every
+	// CC-capable GPU. Report is retained as a legacy aggregate. The explicit
+	// fields are an additive protocol v4 extension.
 	GPUReports []GPUReportEntry `json:"gpu_reports,omitempty"`
 
 	// TLSBound indicates whether report_data was computed with TLS channel binding.
@@ -126,8 +132,11 @@ func quoteHandler(provider tee.Provider, binding *TLSBinding) http.HandlerFunc {
 			resp.GPUReports = make([]GPUReportEntry, len(report.GPUReports))
 			for i, gr := range report.GPUReports {
 				resp.GPUReports[i] = GPUReportEntry{
-					DeviceIndex: gr.DeviceIndex,
-					Report:      base64.StdEncoding.EncodeToString(gr.Report),
+					DeviceIndex:       gr.DeviceIndex,
+					Report:            base64.StdEncoding.EncodeToString(gr.Report),
+					AttestationReport: base64.StdEncoding.EncodeToString(gr.AttestationReport),
+					CECReport:         base64.StdEncoding.EncodeToString(gr.CECReport),
+					CertificateChain:  base64.StdEncoding.EncodeToString(gr.CertificateChain),
 				}
 			}
 		}

--- a/sidecar/attestation/server.go
+++ b/sidecar/attestation/server.go
@@ -25,10 +25,12 @@ type QuoteRequest struct {
 }
 
 // GPUReportEntry holds attestation evidence for a single GPU in the response.
-// AttestationReport and CertificateChain map directly to Trustee's evidence and
-// certificate values after the tenant supplies the device architecture and UUID.
+// Architecture and UUID are collected directly from NVML alongside the signed
+// evidence; callers must not replace them with tenant-provided metadata.
 type GPUReportEntry struct {
 	DeviceIndex       uint32 `json:"device_index"`
+	Architecture      string `json:"architecture"`
+	UUID              string `json:"uuid"`
 	Report            string `json:"report"` // base64 legacy report || CEC || certificate chain
 	AttestationReport string `json:"attestation_report"`
 	CECReport         string `json:"cec_report,omitempty"`
@@ -133,6 +135,8 @@ func quoteHandler(provider tee.Provider, binding *TLSBinding) http.HandlerFunc {
 			for i, gr := range report.GPUReports {
 				resp.GPUReports[i] = GPUReportEntry{
 					DeviceIndex:       gr.DeviceIndex,
+					Architecture:      gr.Architecture,
+					UUID:              gr.UUID,
 					Report:            base64.StdEncoding.EncodeToString(gr.Report),
 					AttestationReport: base64.StdEncoding.EncodeToString(gr.AttestationReport),
 					CECReport:         base64.StdEncoding.EncodeToString(gr.CECReport),

--- a/sidecar/attestation/server_test.go
+++ b/sidecar/attestation/server_test.go
@@ -66,6 +66,15 @@ func TestQuoteResponseSeparatesEveryGPUReportComponent(t *testing.T) {
 	if len(response.GPUReports) != 2 {
 		t.Fatalf("expected two GPU reports, got %d", len(response.GPUReports))
 	}
+	var rawResponse struct {
+		GPUReports []map[string]json.RawMessage `json:"gpu_reports"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &rawResponse); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := rawResponse.GPUReports[1]["cec_report"]; present {
+		t.Fatal("absent CEC report must be omitted from the JSON response")
+	}
 
 	want := []GPUReportEntry{
 		{

--- a/sidecar/attestation/server_test.go
+++ b/sidecar/attestation/server_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/akash-network/attestation-sidecar/tee"
+)
+
+type fixedQuoteProvider struct {
+	result *tee.QuoteResult
+}
+
+func (p fixedQuoteProvider) Name() string { return tee.NameSNPGPU }
+func (p fixedQuoteProvider) Available() bool {
+	return true
+}
+func (p fixedQuoteProvider) GetQuote(context.Context, [64]byte) (*tee.QuoteResult, error) {
+	return p.result, nil
+}
+
+func TestQuoteResponseSeparatesEveryGPUReportComponent(t *testing.T) {
+	provider := fixedQuoteProvider{result: &tee.QuoteResult{
+		Report: []byte("cpu-report"),
+		GPUReports: []tee.GPUDeviceReport{
+			{
+				DeviceIndex:       2,
+				Report:            []byte("gpu-2cec-2cert-2"),
+				AttestationReport: []byte("gpu-2"),
+				CECReport:         []byte("cec-2"),
+				CertificateChain:  []byte("cert-2"),
+			},
+			{
+				DeviceIndex:       7,
+				Report:            []byte("gpu-7cert-7"),
+				AttestationReport: []byte("gpu-7"),
+				CertificateChain:  []byte("cert-7"),
+			},
+		},
+	}}
+
+	body, err := json.Marshal(QuoteRequest{Nonce: base64.StdEncoding.EncodeToString(make([]byte, 64))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/quote", bytes.NewReader(body))
+	recorder := httptest.NewRecorder()
+	quoteHandler(provider, &TLSBinding{}).ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("unexpected status %d: %s", recorder.Code, recorder.Body.String())
+	}
+
+	var response QuoteResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if len(response.GPUReports) != 2 {
+		t.Fatalf("expected two GPU reports, got %d", len(response.GPUReports))
+	}
+
+	want := []GPUReportEntry{
+		{
+			DeviceIndex:       2,
+			Report:            base64.StdEncoding.EncodeToString([]byte("gpu-2cec-2cert-2")),
+			AttestationReport: base64.StdEncoding.EncodeToString([]byte("gpu-2")),
+			CECReport:         base64.StdEncoding.EncodeToString([]byte("cec-2")),
+			CertificateChain:  base64.StdEncoding.EncodeToString([]byte("cert-2")),
+		},
+		{
+			DeviceIndex:       7,
+			Report:            base64.StdEncoding.EncodeToString([]byte("gpu-7cert-7")),
+			AttestationReport: base64.StdEncoding.EncodeToString([]byte("gpu-7")),
+			CertificateChain:  base64.StdEncoding.EncodeToString([]byte("cert-7")),
+		},
+	}
+	for i := range want {
+		if response.GPUReports[i] != want[i] {
+			t.Fatalf("GPU report %d mismatch\nwant: %#v\n got: %#v", i, want[i], response.GPUReports[i])
+		}
+	}
+}

--- a/sidecar/attestation/server_test.go
+++ b/sidecar/attestation/server_test.go
@@ -30,6 +30,8 @@ func TestQuoteResponseSeparatesEveryGPUReportComponent(t *testing.T) {
 		GPUReports: []tee.GPUDeviceReport{
 			{
 				DeviceIndex:       2,
+				Architecture:      "BLACKWELL",
+				UUID:              "GPU-00000000-0000-0000-0000-000000000002",
 				Report:            []byte("gpu-2cec-2cert-2"),
 				AttestationReport: []byte("gpu-2"),
 				CECReport:         []byte("cec-2"),
@@ -37,6 +39,8 @@ func TestQuoteResponseSeparatesEveryGPUReportComponent(t *testing.T) {
 			},
 			{
 				DeviceIndex:       7,
+				Architecture:      "BLACKWELL",
+				UUID:              "GPU-00000000-0000-0000-0000-000000000007",
 				Report:            []byte("gpu-7cert-7"),
 				AttestationReport: []byte("gpu-7"),
 				CertificateChain:  []byte("cert-7"),
@@ -66,6 +70,8 @@ func TestQuoteResponseSeparatesEveryGPUReportComponent(t *testing.T) {
 	want := []GPUReportEntry{
 		{
 			DeviceIndex:       2,
+			Architecture:      "BLACKWELL",
+			UUID:              "GPU-00000000-0000-0000-0000-000000000002",
 			Report:            base64.StdEncoding.EncodeToString([]byte("gpu-2cec-2cert-2")),
 			AttestationReport: base64.StdEncoding.EncodeToString([]byte("gpu-2")),
 			CECReport:         base64.StdEncoding.EncodeToString([]byte("cec-2")),
@@ -73,6 +79,8 @@ func TestQuoteResponseSeparatesEveryGPUReportComponent(t *testing.T) {
 		},
 		{
 			DeviceIndex:       7,
+			Architecture:      "BLACKWELL",
+			UUID:              "GPU-00000000-0000-0000-0000-000000000007",
 			Report:            base64.StdEncoding.EncodeToString([]byte("gpu-7cert-7")),
 			AttestationReport: base64.StdEncoding.EncodeToString([]byte("gpu-7")),
 			CertificateChain:  base64.StdEncoding.EncodeToString([]byte("cert-7")),

--- a/sidecar/attestation/tee/mock.go
+++ b/sidecar/attestation/tee/mock.go
@@ -56,9 +56,11 @@ func (m *MockProvider) GetQuote(_ context.Context, reportData [64]byte) (*QuoteR
 		}
 		result.GPUReports = make([]GPUDeviceReport, gpuCount)
 		for i := 0; i < gpuCount; i++ {
+			report := buildMockGPUReport(reportData, i)
 			result.GPUReports[i] = GPUDeviceReport{
-				DeviceIndex: uint32(i), //nolint:gosec // mock device index
-				Report:      buildMockGPUReport(reportData, i),
+				DeviceIndex:       uint32(i), //nolint:gosec // mock device index
+				Report:            report,
+				AttestationReport: append([]byte(nil), report...),
 			}
 		}
 	}

--- a/sidecar/attestation/tee/mock.go
+++ b/sidecar/attestation/tee/mock.go
@@ -59,6 +59,8 @@ func (m *MockProvider) GetQuote(_ context.Context, reportData [64]byte) (*QuoteR
 			report := buildMockGPUReport(reportData, i)
 			result.GPUReports[i] = GPUDeviceReport{
 				DeviceIndex:       uint32(i), //nolint:gosec // mock device index
+				Architecture:      "BLACKWELL",
+				UUID:              fmt.Sprintf("GPU-00000000-0000-0000-0000-%012x", i),
 				Report:            report,
 				AttestationReport: append([]byte(nil), report...),
 			}

--- a/sidecar/attestation/tee/nvidia_gpu.go
+++ b/sidecar/attestation/tee/nvidia_gpu.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	nvmlHelperPath = "/usr/bin/nvml_attestation"
-	guestMountDir  = "/mnt/guest"
+	nvmlHelperPath           = "/usr/bin/nvml_attestation"
+	guestMountDir            = "/mnt/guest"
+	nvmlDeviceUUIDBufferSize = 80
 )
 
 // NvidiaGPUAttestor collects GPU attestation evidence via NVML for
@@ -83,6 +84,9 @@ func (n *NvidiaGPUAttestor) probe() (string, error) {
 //	4 bytes LE: device count
 //	Per device:
 //	  4 bytes LE: device index
+//	  4 bytes LE: NVML device architecture
+//	  4 bytes LE: device UUID size
+//	  N bytes:    device UUID reported by NVML
 //	  4 bytes LE: attestation report size
 //	  N bytes:    attestation report
 //	  4 bytes LE: CEC report size (0 if not present)
@@ -119,10 +123,10 @@ func parseMultiGPUOutput(data []byte) ([]GPUDeviceReport, error) {
 		return nil, fmt.Errorf("attest-all returned 0 device reports")
 	}
 
-	// Every device requires four uint32 fields even when all variable-length
+	// Every device requires six uint32 fields even when all variable-length
 	// fields are empty. Bound the count by the payload before allocating so an
 	// untrusted helper response cannot force an unreasonable allocation.
-	const minimumDeviceFrameSize = 4 * 4
+	const minimumDeviceFrameSize = 6 * 4
 	if uint64(deviceCount) > uint64((len(data)-4)/minimumDeviceFrameSize) {
 		return nil, fmt.Errorf("device count %d exceeds framed payload size", deviceCount)
 	}
@@ -141,6 +145,34 @@ func parseMultiGPUOutput(data []byte) ([]GPUDeviceReport, error) {
 			return nil, fmt.Errorf("duplicate device index %d", devIdx)
 		}
 		seenDeviceIndices[devIdx] = struct{}{}
+
+		architectureValue, next, err := readFrameUint32(data, off, fmt.Sprintf("device %d architecture", i))
+		if err != nil {
+			return nil, err
+		}
+		off = next
+		architecture, err := nvidiaArchitectureName(architectureValue)
+		if err != nil {
+			return nil, fmt.Errorf("device %d: %w", i, err)
+		}
+
+		uuidSize, next, err := readFrameUint32(data, off, fmt.Sprintf("device %d UUID size", i))
+		if err != nil {
+			return nil, err
+		}
+		if uuidSize == 0 || uuidSize >= nvmlDeviceUUIDBufferSize {
+			return nil, fmt.Errorf("device %d UUID has invalid size %d", i, uuidSize)
+		}
+		off = next
+		uuidBytes, next, err := readFrameBytes(data, off, uuidSize, fmt.Sprintf("device %d UUID", i))
+		if err != nil {
+			return nil, err
+		}
+		off = next
+		uuid := string(uuidBytes)
+		if !validNvidiaGPUUUID(uuid) {
+			return nil, fmt.Errorf("device %d has invalid NVML UUID", i)
+		}
 
 		reportSize, next, err := readFrameUint32(data, off, fmt.Sprintf("device %d report size", i))
 		if err != nil {
@@ -194,6 +226,8 @@ func parseMultiGPUOutput(data []byte) ([]GPUDeviceReport, error) {
 
 		reports = append(reports, GPUDeviceReport{
 			DeviceIndex:       devIdx,
+			Architecture:      architecture,
+			UUID:              uuid,
 			Report:            legacyReport,
 			AttestationReport: attestationReport,
 			CECReport:         cecReport,
@@ -206,6 +240,37 @@ func parseMultiGPUOutput(data []byte) ([]GPUDeviceReport, error) {
 	}
 
 	return reports, nil
+}
+
+func nvidiaArchitectureName(value uint32) (string, error) {
+	switch value {
+	case 9:
+		return "HOPPER", nil
+	case 10:
+		return "BLACKWELL", nil
+	default:
+		return "", fmt.Errorf("unsupported NVIDIA device architecture %d", value)
+	}
+}
+
+func validNvidiaGPUUUID(value string) bool {
+	const prefix = "GPU-"
+	if len(value) != len(prefix)+36 || !strings.HasPrefix(value, prefix) {
+		return false
+	}
+	for index, char := range value[len(prefix):] {
+		switch index {
+		case 8, 13, 18, 23:
+			if char != '-' {
+				return false
+			}
+		default:
+			if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func readFrameUint32(data []byte, off int, field string) (uint32, int, error) {

--- a/sidecar/attestation/tee/nvidia_gpu.go
+++ b/sidecar/attestation/tee/nvidia_gpu.go
@@ -115,68 +115,113 @@ func parseMultiGPUOutput(data []byte) ([]GPUDeviceReport, error) {
 	}
 
 	deviceCount := binary.LittleEndian.Uint32(data[0:4])
-	off := 4
-
-	reports := make([]GPUDeviceReport, 0, deviceCount)
-
-	for i := uint32(0); i < deviceCount; i++ {
-		if off+4 > len(data) {
-			return nil, fmt.Errorf("truncated output at device %d index", i)
-		}
-		devIdx := binary.LittleEndian.Uint32(data[off : off+4])
-		off += 4
-
-		if off+4 > len(data) {
-			return nil, fmt.Errorf("truncated output at device %d report size", i)
-		}
-		reportSize := binary.LittleEndian.Uint32(data[off : off+4])
-		off += 4
-
-		if off+int(reportSize) > len(data) {
-			return nil, fmt.Errorf("truncated output at device %d report data (need %d, have %d)", i, reportSize, len(data)-off)
-		}
-		report := make([]byte, reportSize)
-		copy(report, data[off:off+int(reportSize)])
-		off += int(reportSize)
-
-		// CEC report
-		if off+4 > len(data) {
-			return nil, fmt.Errorf("truncated output at device %d CEC size", i)
-		}
-		cecSize := binary.LittleEndian.Uint32(data[off : off+4])
-		off += 4
-
-		if cecSize > 0 {
-			if off+int(cecSize) > len(data) {
-				return nil, fmt.Errorf("truncated output at device %d CEC data", i)
-			}
-			// Append CEC report to the main report
-			report = append(report, data[off:off+int(cecSize)]...)
-			off += int(cecSize)
-		}
-
-		// Cert chain (optional absent in older helper builds)
-		if off+4 <= len(data) {
-			certSize := binary.LittleEndian.Uint32(data[off : off+4])
-			off += 4
-			if certSize > 0 && off+int(certSize) <= len(data) {
-				// Append cert chain to report tenants split on PEM marker
-				report = append(report, data[off:off+int(certSize)]...)
-				off += int(certSize)
-			}
-		}
-
-		reports = append(reports, GPUDeviceReport{
-			DeviceIndex: devIdx,
-			Report:      report,
-		})
-	}
-
-	if len(reports) == 0 {
+	if deviceCount == 0 {
 		return nil, fmt.Errorf("attest-all returned 0 device reports")
 	}
 
+	// Every device requires four uint32 fields even when all variable-length
+	// fields are empty. Bound the count by the payload before allocating so an
+	// untrusted helper response cannot force an unreasonable allocation.
+	const minimumDeviceFrameSize = 4 * 4
+	if uint64(deviceCount) > uint64((len(data)-4)/minimumDeviceFrameSize) {
+		return nil, fmt.Errorf("device count %d exceeds framed payload size", deviceCount)
+	}
+
+	off := 4
+	reports := make([]GPUDeviceReport, 0, deviceCount)
+	seenDeviceIndices := make(map[uint32]struct{}, deviceCount)
+
+	for i := uint32(0); i < deviceCount; i++ {
+		devIdx, next, err := readFrameUint32(data, off, fmt.Sprintf("device %d index", i))
+		if err != nil {
+			return nil, err
+		}
+		off = next
+		if _, duplicate := seenDeviceIndices[devIdx]; duplicate {
+			return nil, fmt.Errorf("duplicate device index %d", devIdx)
+		}
+		seenDeviceIndices[devIdx] = struct{}{}
+
+		reportSize, next, err := readFrameUint32(data, off, fmt.Sprintf("device %d report size", i))
+		if err != nil {
+			return nil, err
+		}
+		if reportSize == 0 {
+			return nil, fmt.Errorf("device %d attestation report is empty", i)
+		}
+		off = next
+		report, next, err := readFrameBytes(data, off, reportSize, fmt.Sprintf("device %d report data", i))
+		if err != nil {
+			return nil, err
+		}
+		off = next
+		attestationReport := append([]byte(nil), report...)
+
+		cecSize, next, err := readFrameUint32(data, off, fmt.Sprintf("device %d CEC size", i))
+		if err != nil {
+			return nil, err
+		}
+		off = next
+		cec, next, err := readFrameBytes(data, off, cecSize, fmt.Sprintf("device %d CEC data", i))
+		if err != nil {
+			return nil, err
+		}
+		off = next
+		cecReport := append([]byte(nil), cec...)
+
+		// The certificate-size word is mandatory, including when its value is
+		// zero. Without it, the next device index is indistinguishable from a
+		// certificate size in a multi-GPU payload.
+		certSize, next, err := readFrameUint32(data, off, fmt.Sprintf("device %d certificate size", i))
+		if err != nil {
+			return nil, err
+		}
+		if certSize == 0 {
+			return nil, fmt.Errorf("device %d certificate chain is empty", i)
+		}
+		off = next
+		cert, next, err := readFrameBytes(data, off, certSize, fmt.Sprintf("device %d certificate data", i))
+		if err != nil {
+			return nil, err
+		}
+		off = next
+		certificateChain := append([]byte(nil), cert...)
+
+		legacyReport := make([]byte, 0, len(attestationReport)+len(cecReport)+len(certificateChain))
+		legacyReport = append(legacyReport, attestationReport...)
+		legacyReport = append(legacyReport, cecReport...)
+		legacyReport = append(legacyReport, certificateChain...)
+
+		reports = append(reports, GPUDeviceReport{
+			DeviceIndex:       devIdx,
+			Report:            legacyReport,
+			AttestationReport: attestationReport,
+			CECReport:         cecReport,
+			CertificateChain:  certificateChain,
+		})
+	}
+
+	if off != len(data) {
+		return nil, fmt.Errorf("attest-all output has %d trailing bytes", len(data)-off)
+	}
+
 	return reports, nil
+}
+
+func readFrameUint32(data []byte, off int, field string) (uint32, int, error) {
+	if len(data)-off < 4 {
+		return 0, off, fmt.Errorf("truncated output at %s", field)
+	}
+	return binary.LittleEndian.Uint32(data[off : off+4]), off + 4, nil
+}
+
+func readFrameBytes(data []byte, off int, size uint32, field string) ([]byte, int, error) {
+	remaining := len(data) - off
+	if uint64(size) > uint64(remaining) {
+		return nil, off, fmt.Errorf("truncated output at %s (need %d, have %d)", field, size, remaining)
+	}
+	next := off + int(size)
+	return data[off:next], next, nil
 }
 
 // ensureMount prepares the chroot environment. Platform-specific setup

--- a/sidecar/attestation/tee/nvidia_gpu_helper_linux_test.go
+++ b/sidecar/attestation/tee/nvidia_gpu_helper_linux_test.go
@@ -1,0 +1,179 @@
+//go:build linux
+
+package tee
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const fakeNVMLSource = `
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef int nvmlReturn_t;
+typedef void* nvmlDevice_t;
+
+#define NVML_SUCCESS 0
+#define NVML_GPU_CERT_CHAIN_SIZE 0x1000
+#define NVML_GPU_ATTESTATION_CERT_CHAIN_SIZE 0x1400
+#define NVML_CC_GPU_ATTESTATION_REPORT_SIZE 0x2000
+#define NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE 0x1000
+#define NVML_CC_GPU_CEC_NONCE_SIZE 0x20
+
+typedef struct {
+    uint32_t certChainSize;
+    uint32_t attestationCertChainSize;
+    uint8_t certChain[NVML_GPU_CERT_CHAIN_SIZE];
+    uint8_t attestationCertChain[NVML_GPU_ATTESTATION_CERT_CHAIN_SIZE];
+} nvmlConfComputeGpuCertificate_t;
+
+typedef struct {
+    uint32_t isCecAttestationReportPresent;
+    uint32_t attestationReportSize;
+    uint32_t cecAttestationReportSize;
+    uint8_t nonce[NVML_CC_GPU_CEC_NONCE_SIZE];
+    uint8_t attestationReport[NVML_CC_GPU_ATTESTATION_REPORT_SIZE];
+    uint8_t cecAttestationReport[NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE];
+} nvmlConfComputeGpuAttestationReport_t;
+
+static uint32_t certificateCalls[3];
+
+nvmlReturn_t nvmlInit_v2(void) { return NVML_SUCCESS; }
+nvmlReturn_t nvmlShutdown(void) { return NVML_SUCCESS; }
+
+nvmlReturn_t nvmlDeviceGetCount_v2(uint32_t *count) {
+    *count = 2;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetHandleByIndex_v2(uint32_t index, nvmlDevice_t *device) {
+    *device = (void *)(uintptr_t)(index + 1);
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetConfComputeGpuCertificate(
+    nvmlDevice_t device,
+    nvmlConfComputeGpuCertificate_t *certificate
+) {
+    uint32_t index = (uint32_t)(uintptr_t)device;
+    certificateCalls[index]++;
+    if (index == 2 && certificateCalls[index] > 1 && getenv("FAKE_NVML_FAIL_SECOND_CERT")) {
+        return 999;
+    }
+
+    certificate->attestationCertChainSize = 5;
+    memcpy(certificate->attestationCertChain, index == 1 ? "cert0" : "cert1", 5);
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetConfComputeGpuAttestationReport(
+    nvmlDevice_t device,
+    nvmlConfComputeGpuAttestationReport_t *report
+) {
+    uint32_t index = (uint32_t)(uintptr_t)device;
+    report->attestationReportSize = 4;
+    memcpy(report->attestationReport, index == 1 ? "gpu0" : "gpu1", 4);
+    report->isCecAttestationReportPresent = 1;
+    report->cecAttestationReportSize = 4;
+    memcpy(report->cecAttestationReport, index == 1 ? "cec0" : "cec1", 4);
+    return NVML_SUCCESS;
+}
+`
+
+func buildFakeNVMLHelper(t *testing.T) (string, string) {
+	t.Helper()
+
+	gcc, err := exec.LookPath("gcc")
+	if err != nil {
+		t.Skip("gcc is required for the NVML helper integration test")
+	}
+
+	tmpDir := t.TempDir()
+	fakeSource := filepath.Join(tmpDir, "fake_nvml.c")
+	fakeLibrary := filepath.Join(tmpDir, "libnvidia-ml.so.1")
+	helper := filepath.Join(tmpDir, "nvml_attestation")
+	if err := os.WriteFile(fakeSource, []byte(fakeNVMLSource), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	helperSource, err := filepath.Abs(filepath.Join("..", "nvml-helper", "nvml_attestation.c"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compile := exec.Command(gcc, "-std=c11", "-Wall", "-Wextra", "-Werror", helperSource, "-ldl", "-o", helper)
+	output, err := compile.CombinedOutput()
+	if err != nil {
+		t.Fatalf("compile NVML helper: %v\n%s", err, output)
+	}
+
+	compile = exec.Command(gcc, "-std=c11", "-Wall", "-Wextra", "-Werror", "-shared", "-fPIC", fakeSource, "-o", fakeLibrary)
+	output, err = compile.CombinedOutput()
+	if err != nil {
+		t.Fatalf("compile fake NVML library: %v\n%s", err, output)
+	}
+
+	return helper, tmpDir
+}
+
+func TestNVMLHelperFramesTwoGPUs(t *testing.T) {
+	helper, libraryDir := buildFakeNVMLHelper(t)
+	cmd := exec.Command(helper, "attest-all", strings.Repeat("00", 32))
+	cmd.Env = append(os.Environ(), "LD_LIBRARY_PATH="+libraryDir)
+
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reports, err := parseMultiGPUOutput(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("got %d reports, want 2", len(reports))
+	}
+
+	want := []GPUDeviceReport{
+		{DeviceIndex: 0, AttestationReport: []byte("gpu0"), CECReport: []byte("cec0"), CertificateChain: []byte("cert0")},
+		{DeviceIndex: 1, AttestationReport: []byte("gpu1"), CECReport: []byte("cec1"), CertificateChain: []byte("cert1")},
+	}
+	for i := range want {
+		if reports[i].DeviceIndex != want[i].DeviceIndex ||
+			!bytes.Equal(reports[i].AttestationReport, want[i].AttestationReport) ||
+			!bytes.Equal(reports[i].CECReport, want[i].CECReport) ||
+			!bytes.Equal(reports[i].CertificateChain, want[i].CertificateChain) {
+			t.Errorf("report %d = %#v, want %#v", i, reports[i], want[i])
+		}
+	}
+}
+
+func TestNVMLHelperEmitsNothingWhenAnyGPUFails(t *testing.T) {
+	helper, libraryDir := buildFakeNVMLHelper(t)
+	cmd := exec.Command(helper, "attest-all", strings.Repeat("00", 32))
+	cmd.Env = append(
+		os.Environ(),
+		"LD_LIBRARY_PATH="+libraryDir,
+		"FAKE_NVML_FAIL_SECOND_CERT=1",
+	)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("attest-all succeeded after the second GPU certificate failed")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("failed batch emitted %d bytes of partial frame data", stdout.Len())
+	}
+	if !strings.Contains(stderr.String(), "GPU 1: nvmlDeviceGetConfComputeGpuCertificate") {
+		t.Fatalf("missing second-GPU error in stderr: %s", stderr.String())
+	}
+}

--- a/sidecar/attestation/tee/nvidia_gpu_helper_linux_test.go
+++ b/sidecar/attestation/tee/nvidia_gpu_helper_linux_test.go
@@ -13,6 +13,7 @@ import (
 
 const fakeNVMLSource = `
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -55,6 +56,18 @@ nvmlReturn_t nvmlDeviceGetCount_v2(uint32_t *count) {
 nvmlReturn_t nvmlDeviceGetHandleByIndex_v2(uint32_t index, nvmlDevice_t *device) {
     *device = (void *)(uintptr_t)(index + 1);
     return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetArchitecture(nvmlDevice_t device, uint32_t *architecture) {
+    (void)device;
+    *architecture = 10;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetUUID(nvmlDevice_t device, char *uuid, uint32_t length) {
+    uint32_t index = (uint32_t)(uintptr_t)device - 1;
+    int written = snprintf(uuid, length, "GPU-00000000-0000-0000-0000-%012u", index);
+    return written > 0 && (uint32_t)written < length ? NVML_SUCCESS : 999;
 }
 
 nvmlReturn_t nvmlDeviceGetConfComputeGpuCertificate(
@@ -140,11 +153,13 @@ func TestNVMLHelperFramesTwoGPUs(t *testing.T) {
 	}
 
 	want := []GPUDeviceReport{
-		{DeviceIndex: 0, AttestationReport: []byte("gpu0"), CECReport: []byte("cec0"), CertificateChain: []byte("cert0")},
-		{DeviceIndex: 1, AttestationReport: []byte("gpu1"), CECReport: []byte("cec1"), CertificateChain: []byte("cert1")},
+		{DeviceIndex: 0, Architecture: "BLACKWELL", UUID: "GPU-00000000-0000-0000-0000-000000000000", AttestationReport: []byte("gpu0"), CECReport: []byte("cec0"), CertificateChain: []byte("cert0")},
+		{DeviceIndex: 1, Architecture: "BLACKWELL", UUID: "GPU-00000000-0000-0000-0000-000000000001", AttestationReport: []byte("gpu1"), CECReport: []byte("cec1"), CertificateChain: []byte("cert1")},
 	}
 	for i := range want {
 		if reports[i].DeviceIndex != want[i].DeviceIndex ||
+			reports[i].Architecture != want[i].Architecture ||
+			reports[i].UUID != want[i].UUID ||
 			!bytes.Equal(reports[i].AttestationReport, want[i].AttestationReport) ||
 			!bytes.Equal(reports[i].CECReport, want[i].CECReport) ||
 			!bytes.Equal(reports[i].CertificateChain, want[i].CertificateChain) {

--- a/sidecar/attestation/tee/nvidia_gpu_test.go
+++ b/sidecar/attestation/tee/nvidia_gpu_test.go
@@ -1,0 +1,157 @@
+package tee
+
+import (
+	"bytes"
+	"encoding/binary"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type gpuFrame struct {
+	index  uint32
+	report []byte
+	cec    []byte
+	cert   []byte
+}
+
+func encodeGPUFrames(t *testing.T, frames ...gpuFrame) []byte {
+	t.Helper()
+
+	var out bytes.Buffer
+	if err := binary.Write(&out, binary.LittleEndian, uint32(len(frames))); err != nil {
+		t.Fatal(err)
+	}
+	for _, frame := range frames {
+		if err := binary.Write(&out, binary.LittleEndian, frame.index); err != nil {
+			t.Fatal(err)
+		}
+		if err := binary.Write(&out, binary.LittleEndian, uint32(len(frame.report))); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = out.Write(frame.report)
+		if err := binary.Write(&out, binary.LittleEndian, uint32(len(frame.cec))); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = out.Write(frame.cec)
+		if err := binary.Write(&out, binary.LittleEndian, uint32(len(frame.cert))); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = out.Write(frame.cert)
+	}
+	return out.Bytes()
+}
+
+func TestParseMultiGPUOutputValidMultiple(t *testing.T) {
+	data := encodeGPUFrames(t,
+		gpuFrame{index: 2, report: []byte("report-2"), cec: []byte("cec-2"), cert: []byte("cert-2")},
+		gpuFrame{index: 7, report: []byte("report-7"), cert: []byte("cert-7")},
+	)
+
+	reports, err := parseMultiGPUOutput(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []GPUDeviceReport{
+		{
+			DeviceIndex:       2,
+			Report:            []byte("report-2cec-2cert-2"),
+			AttestationReport: []byte("report-2"),
+			CECReport:         []byte("cec-2"),
+			CertificateChain:  []byte("cert-2"),
+		},
+		{
+			DeviceIndex:       7,
+			Report:            []byte("report-7cert-7"),
+			AttestationReport: []byte("report-7"),
+			CertificateChain:  []byte("cert-7"),
+		},
+	}
+	if !reflect.DeepEqual(want, reports) {
+		t.Fatalf("reports mismatch\nwant: %#v\n got: %#v", want, reports)
+	}
+}
+
+func TestParseMultiGPUOutputRejectsMalformedFraming(t *testing.T) {
+	valid := encodeGPUFrames(t, gpuFrame{index: 0, report: []byte("report"), cert: []byte("cert")})
+
+	withoutCertSize := encodeGPUFrames(t, gpuFrame{index: 0, report: []byte("report")})
+	missingCertSize := append([]byte(nil), withoutCertSize[:len(withoutCertSize)-4]...)
+	truncatedCert := append([]byte(nil), missingCertSize...)
+	var certHeader bytes.Buffer
+	if err := binary.Write(&certHeader, binary.LittleEndian, uint32(8)); err != nil {
+		t.Fatal(err)
+	}
+	truncatedCert = append(truncatedCert, certHeader.Bytes()...)
+	truncatedCert = append(truncatedCert, []byte("short")...)
+
+	missingCECSize := []byte{1, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0}
+	missingCECSize = append(missingCECSize, []byte("report-8")...)
+	truncatedCEC := append([]byte(nil), missingCECSize...)
+	var cecHeader bytes.Buffer
+	if err := binary.Write(&cecHeader, binary.LittleEndian, uint32(8)); err != nil {
+		t.Fatal(err)
+	}
+	truncatedCEC = append(truncatedCEC, cecHeader.Bytes()...)
+	truncatedCEC = append(truncatedCEC, []byte("short")...)
+
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr string
+	}{
+		{name: "zero devices", data: []byte{0, 0, 0, 0}, wantErr: "0 device reports"},
+		{name: "count exceeds frames", data: []byte{2, 0, 0, 0}, wantErr: "exceeds framed payload size"},
+		{name: "missing device index", data: []byte{1, 0, 0, 0}, wantErr: "exceeds framed payload size"},
+		{name: "missing report size", data: []byte{1, 0, 0, 0, 0, 0, 0, 0}, wantErr: "exceeds framed payload size"},
+		{name: "empty report", data: encodeGPUFrames(t, gpuFrame{index: 0}), wantErr: "attestation report is empty"},
+		{name: "empty certificate chain", data: withoutCertSize, wantErr: "certificate chain is empty"},
+		{name: "truncated report", data: append([]byte{1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0}, []byte("short-enough")...), wantErr: "report data"},
+		{name: "missing CEC size", data: missingCECSize, wantErr: "CEC size"},
+		{name: "truncated CEC", data: truncatedCEC, wantErr: "CEC data"},
+		{name: "missing required certificate size", data: missingCertSize, wantErr: "certificate size"},
+		{name: "truncated certificate", data: truncatedCert, wantErr: "certificate data"},
+		{name: "trailing bytes", data: append(append([]byte(nil), valid...), 0xff), wantErr: "trailing bytes"},
+		{name: "duplicate device index", data: encodeGPUFrames(t,
+			gpuFrame{index: 3, report: []byte("one"), cert: []byte("cert-one")},
+			gpuFrame{index: 3, report: []byte("two"), cert: []byte("cert-two")},
+		), wantErr: "duplicate device index"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseMultiGPUOutput(tt.data)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestParseMultiGPUOutputOwnsFramedData(t *testing.T) {
+	data := encodeGPUFrames(t, gpuFrame{
+		index:  1,
+		report: []byte("report"),
+		cec:    []byte("cec"),
+		cert:   []byte("cert"),
+	})
+
+	reports, err := parseMultiGPUOutput(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range data {
+		data[i] = 0
+	}
+
+	want := GPUDeviceReport{
+		DeviceIndex:       1,
+		Report:            []byte("reportceccert"),
+		AttestationReport: []byte("report"),
+		CECReport:         []byte("cec"),
+		CertificateChain:  []byte("cert"),
+	}
+	if !reflect.DeepEqual(want, reports[0]) {
+		t.Fatalf("report aliases input\nwant: %#v\n got: %#v", want, reports[0])
+	}
+}

--- a/sidecar/attestation/tee/nvidia_gpu_test.go
+++ b/sidecar/attestation/tee/nvidia_gpu_test.go
@@ -3,6 +3,7 @@ package tee
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,6 +11,8 @@ import (
 
 type gpuFrame struct {
 	index  uint32
+	arch   uint32
+	uuid   string
 	report []byte
 	cec    []byte
 	cert   []byte
@@ -23,9 +26,22 @@ func encodeGPUFrames(t *testing.T, frames ...gpuFrame) []byte {
 		t.Fatal(err)
 	}
 	for _, frame := range frames {
+		if frame.arch == 0 {
+			frame.arch = 10
+		}
+		if frame.uuid == "" {
+			frame.uuid = fmt.Sprintf("GPU-00000000-0000-0000-0000-%012x", frame.index)
+		}
 		if err := binary.Write(&out, binary.LittleEndian, frame.index); err != nil {
 			t.Fatal(err)
 		}
+		if err := binary.Write(&out, binary.LittleEndian, frame.arch); err != nil {
+			t.Fatal(err)
+		}
+		if err := binary.Write(&out, binary.LittleEndian, uint32(len(frame.uuid))); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = out.WriteString(frame.uuid)
 		if err := binary.Write(&out, binary.LittleEndian, uint32(len(frame.report))); err != nil {
 			t.Fatal(err)
 		}
@@ -55,6 +71,8 @@ func TestParseMultiGPUOutputValidMultiple(t *testing.T) {
 	want := []GPUDeviceReport{
 		{
 			DeviceIndex:       2,
+			Architecture:      "BLACKWELL",
+			UUID:              "GPU-00000000-0000-0000-0000-000000000002",
 			Report:            []byte("report-2cec-2cert-2"),
 			AttestationReport: []byte("report-2"),
 			CECReport:         []byte("cec-2"),
@@ -62,6 +80,8 @@ func TestParseMultiGPUOutputValidMultiple(t *testing.T) {
 		},
 		{
 			DeviceIndex:       7,
+			Architecture:      "BLACKWELL",
+			UUID:              "GPU-00000000-0000-0000-0000-000000000007",
 			Report:            []byte("report-7cert-7"),
 			AttestationReport: []byte("report-7"),
 			CertificateChain:  []byte("cert-7"),
@@ -74,6 +94,8 @@ func TestParseMultiGPUOutputValidMultiple(t *testing.T) {
 
 func TestParseMultiGPUOutputRejectsMalformedFraming(t *testing.T) {
 	valid := encodeGPUFrames(t, gpuFrame{index: 0, report: []byte("report"), cert: []byte("cert")})
+	const defaultUUID = "GPU-00000000-0000-0000-0000-000000000000"
+	const frameHeaderSize = 4 + 4 + 4 + 4 + len(defaultUUID)
 
 	withoutCertSize := encodeGPUFrames(t, gpuFrame{index: 0, report: []byte("report")})
 	missingCertSize := append([]byte(nil), withoutCertSize[:len(withoutCertSize)-4]...)
@@ -85,15 +107,18 @@ func TestParseMultiGPUOutputRejectsMalformedFraming(t *testing.T) {
 	truncatedCert = append(truncatedCert, certHeader.Bytes()...)
 	truncatedCert = append(truncatedCert, []byte("short")...)
 
-	missingCECSize := []byte{1, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0}
-	missingCECSize = append(missingCECSize, []byte("report-8")...)
-	truncatedCEC := append([]byte(nil), missingCECSize...)
-	var cecHeader bytes.Buffer
-	if err := binary.Write(&cecHeader, binary.LittleEndian, uint32(8)); err != nil {
-		t.Fatal(err)
-	}
-	truncatedCEC = append(truncatedCEC, cecHeader.Bytes()...)
-	truncatedCEC = append(truncatedCEC, []byte("short")...)
+	reportSizeOffset := frameHeaderSize
+	truncatedReport := append([]byte(nil), valid[:reportSizeOffset+4]...)
+	binary.LittleEndian.PutUint32(truncatedReport[reportSizeOffset:reportSizeOffset+4], 100)
+	truncatedReport = append(truncatedReport, []byte("short")...)
+
+	cecSizeOffset := reportSizeOffset + 4 + len("report")
+	missingCECSize := append([]byte(nil), valid[:cecSizeOffset]...)
+	truncatedCEC := encodeGPUFrames(t, gpuFrame{
+		index: 0, report: []byte("report"), cec: []byte("short"), cert: []byte("cert"),
+	})
+	truncatedCEC = append([]byte(nil), truncatedCEC[:cecSizeOffset+4+len("short")]...)
+	binary.LittleEndian.PutUint32(truncatedCEC[cecSizeOffset:cecSizeOffset+4], 8)
 
 	tests := []struct {
 		name    string
@@ -106,7 +131,13 @@ func TestParseMultiGPUOutputRejectsMalformedFraming(t *testing.T) {
 		{name: "missing report size", data: []byte{1, 0, 0, 0, 0, 0, 0, 0}, wantErr: "exceeds framed payload size"},
 		{name: "empty report", data: encodeGPUFrames(t, gpuFrame{index: 0}), wantErr: "attestation report is empty"},
 		{name: "empty certificate chain", data: withoutCertSize, wantErr: "certificate chain is empty"},
-		{name: "truncated report", data: append([]byte{1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0}, []byte("short-enough")...), wantErr: "report data"},
+		{name: "unsupported architecture", data: encodeGPUFrames(t,
+			gpuFrame{index: 0, arch: 8, report: []byte("report"), cert: []byte("cert")},
+		), wantErr: "unsupported NVIDIA device architecture"},
+		{name: "invalid UUID", data: encodeGPUFrames(t,
+			gpuFrame{index: 0, uuid: "GPU-not-a-uuid", report: []byte("report"), cert: []byte("cert")},
+		), wantErr: "invalid NVML UUID"},
+		{name: "truncated report", data: truncatedReport, wantErr: "report data"},
 		{name: "missing CEC size", data: missingCECSize, wantErr: "CEC size"},
 		{name: "truncated CEC", data: truncatedCEC, wantErr: "CEC data"},
 		{name: "missing required certificate size", data: missingCertSize, wantErr: "certificate size"},
@@ -128,6 +159,26 @@ func TestParseMultiGPUOutputRejectsMalformedFraming(t *testing.T) {
 	}
 }
 
+func TestNvidiaArchitectureName(t *testing.T) {
+	tests := []struct {
+		value uint32
+		want  string
+	}{
+		{value: 9, want: "HOPPER"},
+		{value: 10, want: "BLACKWELL"},
+	}
+
+	for _, tt := range tests {
+		got, err := nvidiaArchitectureName(tt.value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tt.want {
+			t.Fatalf("architecture %d: want %q, got %q", tt.value, tt.want, got)
+		}
+	}
+}
+
 func TestParseMultiGPUOutputOwnsFramedData(t *testing.T) {
 	data := encodeGPUFrames(t, gpuFrame{
 		index:  1,
@@ -146,6 +197,8 @@ func TestParseMultiGPUOutputOwnsFramedData(t *testing.T) {
 
 	want := GPUDeviceReport{
 		DeviceIndex:       1,
+		Architecture:      "BLACKWELL",
+		UUID:              "GPU-00000000-0000-0000-0000-000000000001",
 		Report:            []byte("reportceccert"),
 		AttestationReport: []byte("report"),
 		CECReport:         []byte("cec"),

--- a/sidecar/attestation/tee/tee.go
+++ b/sidecar/attestation/tee/tee.go
@@ -15,10 +15,15 @@ const (
 	NameTDXGPU = "tdx-gpu"
 )
 
-// GPUDeviceReport holds attestation evidence for a single GPU.
+// GPUDeviceReport holds the separately framed attestation evidence for one GPU.
+// Report retains the legacy concatenated representation for protocol clients
+// that have not migrated to the explicit fields.
 type GPUDeviceReport struct {
-	DeviceIndex uint32 `json:"device_index"`
-	Report      []byte `json:"report"`
+	DeviceIndex       uint32 `json:"device_index"`
+	Report            []byte `json:"report"`
+	AttestationReport []byte `json:"attestation_report"`
+	CECReport         []byte `json:"cec_report,omitempty"`
+	CertificateChain  []byte `json:"certificate_chain,omitempty"`
 }
 
 // QuoteResult holds the raw hardware-signed attestation evidence.

--- a/sidecar/attestation/tee/tee.go
+++ b/sidecar/attestation/tee/tee.go
@@ -20,6 +20,8 @@ const (
 // that have not migrated to the explicit fields.
 type GPUDeviceReport struct {
 	DeviceIndex       uint32 `json:"device_index"`
+	Architecture      string `json:"architecture"`
+	UUID              string `json:"uuid"`
 	Report            []byte `json:"report"`
 	AttestationReport []byte `json:"attestation_report"`
 	CECReport         []byte `json:"cec_report,omitempty"`


### PR DESCRIPTION
Why

The NVIDIA helper framed each device attestation report, optional CEC report, and certificate chain, but the Go parser concatenated them. Splitting on a PEM marker is ambiguous when CEC evidence is present and is unsuitable for multiple Blackwell GPUs. Architecture and physical identity must be sourced from NVML, not tenant metadata.

What changed

- retain the legacy aggregate for compatibility
- expose report, CEC report, and certificate chain separately per device
- collect and frame NVML architecture and physical GPU UUID
- support NVIDIA Hopper and Blackwell architecture values
- reject zero, duplicate, truncated, trailing, oversized, certificate-less, unknown-architecture, or malformed-UUID frames
- validate the complete batch before writing stdout
- use NVIDIA-documented NVML buffer sizes and require an exact 32-byte nonce
- add two-device, identity, atomic-output, and malformed-frame tests

Validation

- full root Go test suite passes with the race detector
- sidecar Go tests pass with the race detector
- sidecar go vet passes
- C helper compiles with -std=c11 -Wall -Wextra -Werror -fsyntax-only
- NVIDIA C++ SDK source confirms architecture values 9 for Hopper and 10 for Blackwell and an 80-byte UUID buffer

Follow-up

akash-network/chain-sdk#351 carries the additive fields through the public protobuf. Provider gateway forwarding is isolated in akash-network/provider#428. Real two-GPU guest validation of this optional quote API is still required.