### PR TITLE
feat: ngf http options via snippet filters

### DIFF
--- a/_docs/kustomize/akash-operator-hostname/cluster-roles.yaml
+++ b/_docs/kustomize/akash-operator-hostname/cluster-roles.yaml
@@ -34,6 +34,18 @@ rules:
       - deletecollection
       - watch
   - apiGroups:
+      - gateway.nginx.org
+    resources:
+      - snippetsfilters
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - watch
+  - apiGroups:
       - gateway.networking.k8s.io
     resources:
       - gateways

--- a/_docs/kustomize/nginx-gateway-fabric/kustomization.yaml
+++ b/_docs/kustomize/nginx-gateway-fabric/kustomization.yaml
@@ -8,3 +8,31 @@ resources:
   - gateway.yaml
 patches:
   - path: nodeport-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: nginx-gateway
+      namespace: nginx-gateway
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --snippets-filters
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: nginx-gateway
+    patch: |-
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups: ["gateway.nginx.org"]
+          resources: ["snippetsfilters"]
+          verbs: ["list", "watch"]
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups: ["gateway.nginx.org"]
+          resources: ["snippetsfilters/status"]
+          verbs: ["update"]

--- a/cluster/kube/client_gateway_test.go
+++ b/cluster/kube/client_gateway_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"cosmossdk.io/log"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -34,110 +33,32 @@ func TestNginxGatewayHTTPRouteSpec(t *testing.T) {
 		directive,
 	)
 
-	// Verify parent refs
 	require.Len(t, spec.ParentRefs, 1)
-	assert.Equal(t, gatewayv1.ObjectName("test-gateway"), spec.ParentRefs[0].Name)
-	assert.Equal(t, gatewayv1.Namespace("test-namespace"), *spec.ParentRefs[0].Namespace)
+	require.Equal(t, gatewayv1.ObjectName("test-gateway"), spec.ParentRefs[0].Name)
+	require.Equal(t, gatewayv1.Namespace("test-namespace"), *spec.ParentRefs[0].Namespace)
 
-	// Verify hostnames
 	require.Len(t, spec.Hostnames, 1)
-	assert.Equal(t, gatewayv1.Hostname("test.example.com"), spec.Hostnames[0])
+	require.Equal(t, gatewayv1.Hostname("test.example.com"), spec.Hostnames[0])
 
-	// Verify rules
 	require.Len(t, spec.Rules, 1)
 	rule := spec.Rules[0]
 
-	// Verify that timeouts are NOT in the spec (they're in annotations instead)
-	assert.Nil(t, rule.Timeouts, "Timeouts should not be in HTTPRoute spec (not supported by NGINX Gateway Fabric)")
+	// NGF does not support timeouts in the HTTPRoute spec. http_options are applied
+	// via a per-route SnippetsFilter referenced by an ExtensionRef filter instead.
+	require.Nil(t, rule.Timeouts)
+	require.Len(t, rule.Filters, 1)
+	require.Equal(t, gatewayv1.HTTPRouteFilterExtensionRef, rule.Filters[0].Type)
+	require.NotNil(t, rule.Filters[0].ExtensionRef)
+	require.Equal(t, gatewayv1.Kind("SnippetsFilter"), rule.Filters[0].ExtensionRef.Kind)
+	require.Equal(t, gatewayv1.ObjectName("test.example.com"), rule.Filters[0].ExtensionRef.Name)
 
-	// Verify path matching
 	require.Len(t, rule.Matches, 1)
 	match := rule.Matches[0]
 	require.NotNil(t, match.Path)
-	assert.Equal(t, gatewayv1.PathMatchPathPrefix, *match.Path.Type)
-	assert.Equal(t, "/", *match.Path.Value)
+	require.Equal(t, gatewayv1.PathMatchPathPrefix, *match.Path.Type)
+	require.Equal(t, "/", *match.Path.Value)
 
-	// Verify backend refs
 	require.Len(t, rule.BackendRefs, 1)
-	backendRef := rule.BackendRefs[0]
-	assert.Equal(t, gatewayv1.ObjectName("test-service"), backendRef.Name)
-	assert.Equal(t, gatewayv1.PortNumber(8080), *backendRef.Port)
-}
-
-func TestNginxGatewayAnnotations(t *testing.T) {
-	impl := gateway.NewNginxGateway(log.NewNopLogger())
-
-	directive := chostname.ConnectToDeploymentDirective{
-		Hostname:    "test.example.com",
-		LeaseID:     mtypes.LeaseID{},
-		ServiceName: "test-service",
-		ServicePort: 8080,
-		ReadTimeout: 60000,
-		SendTimeout: 60000,
-		NextTimeout: 30000,
-		MaxBodySize: 1048576,
-		NextTries:   3,
-		NextCases:   []string{"error", "timeout"},
-	}
-
-	annotations := impl.BuildAnnotations(directive)
-
-	// Verify NGINX-specific annotations
-	assert.Equal(t, "1048576", annotations["nginx.org/client-max-body-size"])
-	assert.Equal(t, "60", annotations["nginx.org/proxy-read-timeout"])
-	assert.Equal(t, "60", annotations["nginx.org/proxy-send-timeout"])
-	assert.Equal(t, "30s", annotations["nginx.org/proxy-next-upstream-timeout"])
-	assert.Equal(t, "3", annotations["nginx.org/proxy-next-upstream-tries"])
-	assert.Equal(t, "error timeout", annotations["nginx.org/proxy-next-upstream"])
-}
-
-func TestNginxGatewayAnnotationsWithHTTPCodes(t *testing.T) {
-	impl := gateway.NewNginxGateway(log.NewNopLogger())
-
-	directive := chostname.ConnectToDeploymentDirective{
-		Hostname:    "test.example.com",
-		LeaseID:     mtypes.LeaseID{},
-		ServiceName: "test-service",
-		ServicePort: 8080,
-		ReadTimeout: 30000,
-		SendTimeout: 30000,
-		NextTimeout: 0,
-		MaxBodySize: 2097152,
-		NextTries:   5,
-		NextCases:   []string{"error", "502", "503", "504"},
-	}
-
-	annotations := impl.BuildAnnotations(directive)
-
-	assert.Equal(t, "2097152", annotations["nginx.org/client-max-body-size"])
-	assert.Equal(t, "5", annotations["nginx.org/proxy-next-upstream-tries"])
-	assert.Equal(t, "error http_502 http_503 http_504", annotations["nginx.org/proxy-next-upstream"])
-
-	_, hasNextTimeout := annotations["nginx.org/proxy-next-upstream-timeout"]
-	assert.False(t, hasNextTimeout, "Should not set next-upstream-timeout when NextTimeout is 0")
-}
-
-func TestNginxGatewayAnnotationsMinimal(t *testing.T) {
-	impl := gateway.NewNginxGateway(log.NewNopLogger())
-
-	directive := chostname.ConnectToDeploymentDirective{
-		Hostname:    "test.example.com",
-		LeaseID:     mtypes.LeaseID{},
-		ServiceName: "test-service",
-		ServicePort: 8080,
-		ReadTimeout: 10000,
-		SendTimeout: 10000,
-		NextTimeout: 0,
-		MaxBodySize: 1024,
-		NextTries:   1,
-		NextCases:   []string{},
-	}
-
-	annotations := impl.BuildAnnotations(directive)
-
-	assert.Equal(t, "1024", annotations["nginx.org/client-max-body-size"])
-	assert.Equal(t, "1", annotations["nginx.org/proxy-next-upstream-tries"])
-
-	_, hasNextUpstream := annotations["nginx.org/proxy-next-upstream"]
-	assert.False(t, hasNextUpstream, "Should not set proxy-next-upstream when NextCases is empty")
+	require.Equal(t, gatewayv1.ObjectName("test-service"), rule.BackendRefs[0].Name)
+	require.Equal(t, gatewayv1.PortNumber(8080), *rule.BackendRefs[0].Port)
 }

--- a/cluster/kube/gateway/gateway.go
+++ b/cluster/kube/gateway/gateway.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	chostname "github.com/akash-network/provider/cluster/types/v1beta3/clients/hostname"
@@ -31,4 +32,9 @@ type GatewayProvider interface {
 		servicePort int32,
 		directive chostname.ConnectToDeploymentDirective,
 	) gatewayv1.HTTPRouteSpec
+
+	// BuildRouteExtensions returns auxiliary CRD objects to apply alongside the
+	// HTTPRoute (e.g. an NGF SnippetsFilter). They are applied owner-referenced to
+	// the HTTPRoute so they are garbage-collected with it. Returns nil when none.
+	BuildRouteExtensions(namespace, routeName string, directive chostname.ConnectToDeploymentDirective) []*unstructured.Unstructured
 }

--- a/cluster/kube/gateway/httproute.go
+++ b/cluster/kube/gateway/httproute.go
@@ -3,14 +3,19 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/pager"
+	"k8s.io/client-go/util/retry"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/akash-network/provider/cluster/kube/builder"
@@ -49,6 +54,14 @@ func (NoopHTTPRouteObserver) OnDelete(error) {}
 
 // CreateOrUpdateHTTPRoute creates or updates an HTTPRoute for a hostname directive.
 // It uses the provided Provider to build annotations and the HTTPRoute spec.
+//
+// Route extensions (an NGF SnippetsFilter) are applied before the HTTPRoute
+// publishes its ExtensionRef to them. A route that references a missing
+// SnippetsFilter makes NGF set ResolvedRefs=False and serve HTTP 500 for that
+// rule, so an existing route keeps its working spec until the filter is applied.
+// The SnippetsFilter is owner-referenced to the route for garbage collection, so
+// a brand-new route is created without the filter first to mint a UID, then the
+// filter is applied and only then is the reference added.
 func CreateOrUpdateHTTPRoute(
 	ctx context.Context,
 	dc dynamic.Interface,
@@ -73,38 +86,200 @@ func CreateOrUpdateHTTPRoute(
 		directive,
 	)
 
-	obj := &gatewayv1.HTTPRoute{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "gateway.networking.k8s.io/v1",
-			Kind:       "HTTPRoute",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        routeName,
-			Labels:      labels,
-			Annotations: annotations,
-		},
-		Spec: spec,
+	exts := config.Provider.BuildRouteExtensions(ns, routeName, directive)
+
+	toUnstructured := func(s gatewayv1.HTTPRouteSpec) (*unstructured.Unstructured, error) {
+		obj := &gatewayv1.HTTPRoute{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "gateway.networking.k8s.io/v1",
+				Kind:       "HTTPRoute",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        routeName,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Spec: s,
+		}
+		m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert HTTPRoute to unstructured: %w", err)
+		}
+		return &unstructured.Unstructured{Object: m}, nil
 	}
 
-	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	routes := dc.Resource(HTTPRouteGVR).Namespace(ns)
+	existing, getErr := routes.Get(ctx, routeName, metav1.GetOptions{})
+	if getErr != nil && !kerrors.IsNotFound(getErr) {
+		return getErr
+	}
+	routeExists := getErr == nil
+
+	var ownerUID types.UID
+	createdBare := false
+	if routeExists {
+		ownerUID = existing.GetUID()
+	} else if len(exts) > 0 {
+		bareSpec := spec
+		bareSpec.Rules = rulesWithoutFilters(spec.Rules)
+		bare, err := toUnstructured(bareSpec)
+		if err != nil {
+			return err
+		}
+		created, err := routes.Create(ctx, bare, metav1.CreateOptions{})
+		if err != nil {
+			observer.OnCreate(err)
+			return err
+		}
+		ownerUID = created.GetUID()
+		createdBare = true
+	}
+
+	if err := applyRouteExtensions(ctx, dc, ns, routeName, ownerUID, exts); err != nil {
+		return err
+	}
+
+	u, err := toUnstructured(spec)
 	if err != nil {
-		return fmt.Errorf("failed to convert HTTPRoute to unstructured: %w", err)
+		return err
 	}
-	u := &unstructured.Unstructured{Object: unstructuredObj}
 
-	existing, err := dc.Resource(HTTPRouteGVR).Namespace(ns).Get(ctx, routeName, metav1.GetOptions{})
+	// Brand-new route with no extensions: nothing was created above, so create it.
+	if !routeExists && !createdBare {
+		_, err = routes.Create(ctx, u, metav1.CreateOptions{})
+		observer.OnCreate(err)
+		return err
+	}
 
-	switch {
-	case err == nil:
-		u.SetResourceVersion(existing.GetResourceVersion())
-		_, err = dc.Resource(HTTPRouteGVR).Namespace(ns).Update(ctx, u, metav1.UpdateOptions{})
+	// The route already exists, or we just created a bare one. Publish the final
+	// spec, re-reading the resourceVersion on each attempt: NGF writes route status
+	// between our earlier reads and this update, so a cached resourceVersion can be
+	// stale and 409, which would otherwise leave the route without its filter.
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, gErr := routes.Get(ctx, routeName, metav1.GetOptions{})
+		if gErr != nil {
+			return gErr
+		}
+		u.SetResourceVersion(current.GetResourceVersion())
+		_, uErr := routes.Update(ctx, u, metav1.UpdateOptions{})
+		return uErr
+	})
+	if routeExists {
 		observer.OnUpdate(err)
-	case kerrors.IsNotFound(err):
-		_, err = dc.Resource(HTTPRouteGVR).Namespace(ns).Create(ctx, u, metav1.CreateOptions{})
+	} else {
 		observer.OnCreate(err)
 	}
-
 	return err
+}
+
+// rulesWithoutFilters returns a copy of rules with per-rule Filters cleared,
+// leaving the input untouched. Used to create a new HTTPRoute without its
+// ExtensionRef so the referenced SnippetsFilter can be applied first.
+func rulesWithoutFilters(rules []gatewayv1.HTTPRouteRule) []gatewayv1.HTTPRouteRule {
+	out := make([]gatewayv1.HTTPRouteRule, len(rules))
+	copy(out, rules)
+	for i := range out {
+		out[i].Filters = nil
+	}
+	return out
+}
+
+// applyRouteExtensions upserts auxiliary CRD objects (e.g. an NGF SnippetsFilter)
+// owner-referenced to the HTTPRoute so they are garbage-collected with it.
+func applyRouteExtensions(ctx context.Context, dc dynamic.Interface, ns, routeName string, ownerUID types.UID, exts []*unstructured.Unstructured) error {
+	controller := true
+	for _, ext := range exts {
+		ext.SetOwnerReferences([]metav1.OwnerReference{{
+			APIVersion: "gateway.networking.k8s.io/v1",
+			Kind:       "HTTPRoute",
+			Name:       routeName,
+			UID:        ownerUID,
+			Controller: &controller,
+		}})
+
+		gvk := ext.GroupVersionKind()
+		gvr := schema.GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: strings.ToLower(gvk.Kind) + "s",
+		}
+
+		existing, err := dc.Resource(gvr).Namespace(ns).Get(ctx, ext.GetName(), metav1.GetOptions{})
+		var applied *unstructured.Unstructured
+		switch {
+		case err == nil:
+			ext.SetResourceVersion(existing.GetResourceVersion())
+			applied, err = dc.Resource(gvr).Namespace(ns).Update(ctx, ext, metav1.UpdateOptions{})
+		case kerrors.IsNotFound(err):
+			applied, err = dc.Resource(gvr).Namespace(ns).Create(ctx, ext, metav1.CreateOptions{})
+		}
+		if err != nil {
+			return fmt.Errorf("failed to apply route extension %s %q: %w", gvk.Kind, ext.GetName(), err)
+		}
+
+		// Wait for the gateway controller to accept the extension before the caller
+		// publishes the HTTPRoute reference to it. NGF watches HTTPRoutes and
+		// SnippetsFilters through independent caches, so publishing the reference
+		// first lets NGF reconcile the route before it observes the filter, set
+		// ResolvedRefs=False, and serve HTTP 500 until the caches converge. Blocking
+		// here keeps an existing route on its previous working config until the
+		// filter is ready; if the controller never accepts, the caller retries and
+		// the route stays filter-less rather than serving 500.
+		if err := waitForExtensionAccepted(ctx, dc, gvr, ns, ext.GetName(), applied.GetGeneration()); err != nil {
+			return fmt.Errorf("route extension %s %q not accepted by the gateway: %w", gvk.Kind, ext.GetName(), err)
+		}
+	}
+	return nil
+}
+
+// routeExtensionAcceptTimeout bounds the wait for the gateway controller to
+// accept a route extension; on timeout applyRouteExtensions returns an error for
+// the caller to retry.
+var (
+	routeExtensionAcceptTimeout = 15 * time.Second
+	routeExtensionPollInterval  = 250 * time.Millisecond
+)
+
+// waitForExtensionAccepted polls the extension until the gateway controller
+// reports Accepted=True at or beyond the applied generation.
+func waitForExtensionAccepted(ctx context.Context, dc dynamic.Interface, gvr schema.GroupVersionResource, ns, name string, generation int64) error {
+	return wait.PollUntilContextTimeout(ctx, routeExtensionPollInterval, routeExtensionAcceptTimeout, true, func(ctx context.Context) (bool, error) {
+		obj, err := dc.Resource(gvr).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return extensionAccepted(obj, generation), nil
+	})
+}
+
+// extensionAccepted reports whether the gateway controller has set Accepted=True
+// on the extension for at least the given generation. A missing or zero
+// observedGeneration is tolerated so it works across controllers that do not
+// stamp it.
+func extensionAccepted(obj *unstructured.Unstructured, generation int64) bool {
+	controllers, _, _ := unstructured.NestedSlice(obj.Object, "status", "controllers")
+	for _, c := range controllers {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		conditions, _, _ := unstructured.NestedSlice(cm, "conditions")
+		for _, cond := range conditions {
+			condm, ok := cond.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			typ, _, _ := unstructured.NestedString(condm, "type")
+			status, _, _ := unstructured.NestedString(condm, "status")
+			if typ != "Accepted" || status != "True" {
+				continue
+			}
+			if obsGen, found, _ := unstructured.NestedInt64(condm, "observedGeneration"); !found || obsGen == 0 || obsGen >= generation {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // DeleteHTTPRoute removes an HTTPRoute by hostname.

--- a/cluster/kube/gateway/httproute.go
+++ b/cluster/kube/gateway/httproute.go
@@ -60,8 +60,9 @@ func (NoopHTTPRouteObserver) OnDelete(error) {}
 // SnippetsFilter makes NGF set ResolvedRefs=False and serve HTTP 500 for that
 // rule, so an existing route keeps its working spec until the filter is applied.
 // The SnippetsFilter is owner-referenced to the route for garbage collection, so
-// a brand-new route is created without the filter first to mint a UID, then the
-// filter is applied and only then is the reference added.
+// a brand-new route is first created as a detached placeholder (no ParentRefs or
+// rules) to mint a UID; its routable spec is attached only after the filter is
+// accepted, so a failed reconcile never exposes the backend without its options.
 func CreateOrUpdateHTTPRoute(
 	ctx context.Context,
 	dc dynamic.Interface,
@@ -116,23 +117,26 @@ func CreateOrUpdateHTTPRoute(
 	routeExists := getErr == nil
 
 	var ownerUID types.UID
-	createdBare := false
+	createdPlaceholder := false
 	if routeExists {
 		ownerUID = existing.GetUID()
 	} else if len(exts) > 0 {
-		bareSpec := spec
-		bareSpec.Rules = rulesWithoutFilters(spec.Rules)
-		bare, err := toUnstructured(bareSpec)
+		// Create a detached placeholder with an empty spec (no ParentRefs, hostnames,
+		// or rules) purely to mint a UID for the SnippetsFilter owner reference. It
+		// must not be routable: if the filter apply, its acceptance, or the final
+		// update fails, the backend must not be exposed without its http_options. The
+		// routable spec is attached below, only after the filter is accepted.
+		placeholder, err := toUnstructured(gatewayv1.HTTPRouteSpec{})
 		if err != nil {
 			return err
 		}
-		created, err := routes.Create(ctx, bare, metav1.CreateOptions{})
+		created, err := routes.Create(ctx, placeholder, metav1.CreateOptions{})
 		if err != nil {
 			observer.OnCreate(err)
 			return err
 		}
 		ownerUID = created.GetUID()
-		createdBare = true
+		createdPlaceholder = true
 	}
 
 	if err := applyRouteExtensions(ctx, dc, ns, routeName, ownerUID, exts); err != nil {
@@ -145,7 +149,7 @@ func CreateOrUpdateHTTPRoute(
 	}
 
 	// Brand-new route with no extensions: nothing was created above, so create it.
-	if !routeExists && !createdBare {
+	if !routeExists && !createdPlaceholder {
 		_, err = routes.Create(ctx, u, metav1.CreateOptions{})
 		observer.OnCreate(err)
 		return err
@@ -170,18 +174,6 @@ func CreateOrUpdateHTTPRoute(
 		observer.OnCreate(err)
 	}
 	return err
-}
-
-// rulesWithoutFilters returns a copy of rules with per-rule Filters cleared,
-// leaving the input untouched. Used to create a new HTTPRoute without its
-// ExtensionRef so the referenced SnippetsFilter can be applied first.
-func rulesWithoutFilters(rules []gatewayv1.HTTPRouteRule) []gatewayv1.HTTPRouteRule {
-	out := make([]gatewayv1.HTTPRouteRule, len(rules))
-	copy(out, rules)
-	for i := range out {
-		out[i].Filters = nil
-	}
-	return out
 }
 
 // applyRouteExtensions upserts auxiliary CRD objects (e.g. an NGF SnippetsFilter)

--- a/cluster/kube/gateway/httproute_test.go
+++ b/cluster/kube/gateway/httproute_test.go
@@ -37,10 +37,9 @@ func newFakeDC() *dynamicfake.FakeDynamicClient {
 func acceptSnippetsFilters(dc *dynamicfake.FakeDynamicClient) {
 	accept := func(action clienttesting.Action) (bool, runtime.Object, error) {
 		var obj *unstructured.Unstructured
-		switch a := action.(type) {
-		case clienttesting.CreateAction:
-			obj, _ = a.GetObject().(*unstructured.Unstructured)
-		case clienttesting.UpdateAction:
+		// clienttesting.CreateAction embeds UpdateAction, so this single case
+		// matches both create and update actions (both expose GetObject).
+		if a, ok := action.(clienttesting.UpdateAction); ok {
 			obj, _ = a.GetObject().(*unstructured.Unstructured)
 		}
 		if obj != nil {
@@ -181,4 +180,29 @@ func TestExtensionAccepted(t *testing.T) {
 	require.False(t, extensionAccepted(sf("Accepted", "False", 2), 2), "not accepted")
 	require.False(t, extensionAccepted(sf("Programmed", "True", 2), 2), "wrong condition type")
 	require.False(t, extensionAccepted(&unstructured.Unstructured{Object: map[string]interface{}{}}, 2), "no status")
+}
+
+// TestCreateOrUpdateHTTPRouteNewRoutePlaceholderNotRoutable asserts that when the
+// SnippetsFilter cannot be applied for a brand-new route, the placeholder left
+// behind is detached (no ParentRefs, no rules), so the backend is never exposed
+// without its http_options.
+func TestCreateOrUpdateHTTPRouteNewRoutePlaceholderNotRoutable(t *testing.T) {
+	dc := newFakeDC()
+	directive := routeDirective()
+	ns := builder.LidNS(directive.LeaseID)
+
+	dc.PrependReactor("create", "snippetsfilters", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("boom")
+	})
+
+	err := CreateOrUpdateHTTPRoute(context.Background(), dc, routeConfig(), directive, NoopHTTPRouteObserver{})
+	require.Error(t, err, "SnippetsFilter apply failure must fail the reconcile")
+
+	route, err := dc.Resource(HTTPRouteGVR).Namespace(ns).Get(context.Background(), directive.Hostname, metav1.GetOptions{})
+	require.NoError(t, err, "the placeholder route should still exist")
+
+	parentRefs, _, _ := unstructured.NestedSlice(route.Object, "spec", "parentRefs")
+	require.Empty(t, parentRefs, "placeholder must have no parentRefs (not attached to the gateway)")
+	rules, _, _ := unstructured.NestedSlice(route.Object, "spec", "rules")
+	require.Empty(t, rules, "placeholder must have no rules (backend not exposed)")
 }

--- a/cluster/kube/gateway/httproute_test.go
+++ b/cluster/kube/gateway/httproute_test.go
@@ -1,0 +1,184 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"cosmossdk.io/log"
+	"github.com/stretchr/testify/require"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/akash-network/provider/cluster/kube/builder"
+	chostname "github.com/akash-network/provider/cluster/types/v1beta3/clients/hostname"
+	mtypes "pkg.akt.dev/go/node/market/v1"
+)
+
+var sfGVR = schema.GroupVersionResource{Group: "gateway.nginx.org", Version: "v1alpha1", Resource: "snippetsfilters"}
+
+func newFakeDC() *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			HTTPRouteGVR: "HTTPRouteList",
+			sfGVR:        "SnippetsFilterList",
+		},
+	)
+}
+
+// acceptSnippetsFilters makes the fake client stamp Accepted=True on created or
+// updated SnippetsFilters, mimicking NGF, so waitForExtensionAccepted returns.
+func acceptSnippetsFilters(dc *dynamicfake.FakeDynamicClient) {
+	accept := func(action clienttesting.Action) (bool, runtime.Object, error) {
+		var obj *unstructured.Unstructured
+		switch a := action.(type) {
+		case clienttesting.CreateAction:
+			obj, _ = a.GetObject().(*unstructured.Unstructured)
+		case clienttesting.UpdateAction:
+			obj, _ = a.GetObject().(*unstructured.Unstructured)
+		}
+		if obj != nil {
+			_ = unstructured.SetNestedSlice(obj.Object, []interface{}{
+				map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{"type": "Accepted", "status": "True", "observedGeneration": int64(1)},
+					},
+				},
+			}, "status", "controllers")
+		}
+		return false, nil, nil
+	}
+	dc.PrependReactor("create", "snippetsfilters", accept)
+	dc.PrependReactor("update", "snippetsfilters", accept)
+}
+
+func routeDirective() chostname.ConnectToDeploymentDirective {
+	return chostname.ConnectToDeploymentDirective{
+		Hostname:    "route.example.com",
+		LeaseID:     mtypes.LeaseID{},
+		ServiceName: "web",
+		ServicePort: 80,
+		MaxBodySize: 2097152,
+	}
+}
+
+func routeConfig() HTTPRouteConfig {
+	return HTTPRouteConfig{
+		GatewayName:      "gw",
+		GatewayNamespace: "gwns",
+		Provider:         NewNginxGateway(log.NewNopLogger()),
+	}
+}
+
+// extensionRefName returns the first ExtensionRef filter name across the route's
+// rules, or "" if the route references no extension.
+func extensionRefName(t *testing.T, route *unstructured.Unstructured) string {
+	t.Helper()
+	rules, found, err := unstructured.NestedSlice(route.Object, "spec", "rules")
+	require.NoError(t, err)
+	if !found {
+		return ""
+	}
+	for _, r := range rules {
+		rm, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		filters, ok, err := unstructured.NestedSlice(rm, "filters")
+		require.NoError(t, err)
+		if !ok {
+			continue
+		}
+		for _, f := range filters {
+			fm, ok := f.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if name, _, _ := unstructured.NestedString(fm, "extensionRef", "name"); name != "" {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+// TestCreateOrUpdateHTTPRouteAppliesFilterBeforeReference asserts a new route ends
+// up referencing a SnippetsFilter that actually exists and is owned by the route,
+// so NGF never sees a dangling ExtensionRef.
+func TestCreateOrUpdateHTTPRouteAppliesFilterBeforeReference(t *testing.T) {
+	dc := newFakeDC()
+	acceptSnippetsFilters(dc)
+	directive := routeDirective()
+	ns := builder.LidNS(directive.LeaseID)
+
+	require.NoError(t, CreateOrUpdateHTTPRoute(context.Background(), dc, routeConfig(), directive, NoopHTTPRouteObserver{}))
+
+	sf, err := dc.Resource(sfGVR).Namespace(ns).Get(context.Background(), directive.Hostname, metav1.GetOptions{})
+	require.NoError(t, err, "SnippetsFilter must exist")
+
+	owners := sf.GetOwnerReferences()
+	require.Len(t, owners, 1)
+	require.Equal(t, "HTTPRoute", owners[0].Kind)
+	require.Equal(t, directive.Hostname, owners[0].Name)
+
+	route, err := dc.Resource(HTTPRouteGVR).Namespace(ns).Get(context.Background(), directive.Hostname, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, directive.Hostname, extensionRefName(t, route), "route must reference the SnippetsFilter")
+}
+
+// TestCreateOrUpdateHTTPRouteDoesNotDangleOnExtensionFailure asserts that when the
+// SnippetsFilter cannot be applied, an existing route is not updated to reference
+// it, so live traffic never hits a missing-filter 500.
+func TestCreateOrUpdateHTTPRouteDoesNotDangleOnExtensionFailure(t *testing.T) {
+	dc := newFakeDC()
+	directive := routeDirective()
+	ns := builder.LidNS(directive.LeaseID)
+
+	existing := &unstructured.Unstructured{}
+	existing.SetAPIVersion("gateway.networking.k8s.io/v1")
+	existing.SetKind("HTTPRoute")
+	existing.SetNamespace(ns)
+	existing.SetName(directive.Hostname)
+	_, err := dc.Resource(HTTPRouteGVR).Namespace(ns).Create(context.Background(), existing, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	dc.PrependReactor("create", "snippetsfilters", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("boom")
+	})
+
+	err = CreateOrUpdateHTTPRoute(context.Background(), dc, routeConfig(), directive, NoopHTTPRouteObserver{})
+	require.Error(t, err, "SnippetsFilter apply failure must fail the reconcile")
+
+	route, err := dc.Resource(HTTPRouteGVR).Namespace(ns).Get(context.Background(), directive.Hostname, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Empty(t, extensionRefName(t, route), "existing route must not reference a SnippetsFilter that failed to apply")
+
+	_, err = dc.Resource(sfGVR).Namespace(ns).Get(context.Background(), directive.Hostname, metav1.GetOptions{})
+	require.True(t, kerrors.IsNotFound(err), "no SnippetsFilter should have been persisted")
+}
+
+// TestExtensionAccepted asserts the Accepted-condition parse used to gate
+// publishing the route reference.
+func TestExtensionAccepted(t *testing.T) {
+	sf := func(condType, status string, obsGen int64) *unstructured.Unstructured {
+		o := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		_ = unstructured.SetNestedSlice(o.Object, []interface{}{
+			map[string]interface{}{"conditions": []interface{}{
+				map[string]interface{}{"type": condType, "status": status, "observedGeneration": obsGen},
+			}},
+		}, "status", "controllers")
+		return o
+	}
+	require.True(t, extensionAccepted(sf("Accepted", "True", 2), 2))
+	require.True(t, extensionAccepted(sf("Accepted", "True", 3), 2), "newer generation counts")
+	require.False(t, extensionAccepted(sf("Accepted", "True", 1), 2), "stale generation does not count")
+	require.False(t, extensionAccepted(sf("Accepted", "False", 2), 2), "not accepted")
+	require.False(t, extensionAccepted(sf("Programmed", "True", 2), 2), "wrong condition type")
+	require.False(t, extensionAccepted(&unstructured.Unstructured{Object: map[string]interface{}{}}, 2), "no status")
+}

--- a/cluster/kube/gateway/nginx_gateway.go
+++ b/cluster/kube/gateway/nginx_gateway.go
@@ -2,13 +2,11 @@ package gateway
 
 import (
 	"fmt"
-	"math"
-	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/spf13/viper"
-
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"cosmossdk.io/log"
@@ -17,9 +15,16 @@ import (
 	providerflags "github.com/akash-network/provider/cmd/provider-services/cmd/flags"
 )
 
+const (
+	snippetsFilterAPIVersion = "gateway.nginx.org/v1alpha1"
+	snippetsFilterGroup      = "gateway.nginx.org"
+	snippetsFilterKind       = "SnippetsFilter"
+)
+
 // nginxGateway implements the Gateway API interface for NGINX Gateway Fabric.
-// It uses NGINX-specific annotations for configuration since HTTPRoute timeouts
-// are not yet supported by NGINX Gateway Fabric (see https://github.com/nginx/nginx-gateway-fabric/issues/2164)
+// NGF does not consume nginx.org/* annotations (those belong to the NGINX Ingress
+// Controller). The http_options are applied as a per-route SnippetsFilter carrying
+// raw nginx directives. NGF must run with --snippets for this to take effect.
 type nginxGateway struct {
 	log log.Logger
 }
@@ -34,9 +39,10 @@ func (n *nginxGateway) Name() string {
 	return "nginx"
 }
 
-// BuildHTTPRouteSpec builds the HTTPRoute spec using standard Gateway API features.
-// Timeouts are configured via NGINX-specific annotations (see BuildAnnotations)
-// because HTTPRoute.Spec.Rules[].Timeouts is not supported by NGINX Gateway Fabric.
+// BuildHTTPRouteSpec builds the HTTPRoute spec. When the directive carries any
+// http_options, the rule references a per-route SnippetsFilter (built by
+// BuildRouteExtensions) via an ExtensionRef filter so NGF injects the directives
+// into the location for this route.
 func (n *nginxGateway) BuildHTTPRouteSpec(
 	gatewayName string,
 	gatewayNamespace string,
@@ -45,7 +51,6 @@ func (n *nginxGateway) BuildHTTPRouteSpec(
 	servicePort int32,
 	directive chostname.ConnectToDeploymentDirective,
 ) gatewayv1.HTTPRouteSpec {
-	// Build parent reference to the Gateway
 	parentRefs := []gatewayv1.ParentReference{
 		{
 			Group:     (*gatewayv1.Group)(&gatewayv1.GroupVersion.Group),
@@ -55,9 +60,22 @@ func (n *nginxGateway) BuildHTTPRouteSpec(
 		},
 	}
 
-	// Build HTTP route rules
 	pathType := gatewayv1.PathMatchPathPrefix
 	backendPort := gatewayv1.PortNumber(servicePort)
+
+	var filters []gatewayv1.HTTPRouteFilter
+	if httpOptionsSnippet(directive, proxyBufferSize()) != "" {
+		filters = []gatewayv1.HTTPRouteFilter{
+			{
+				Type: gatewayv1.HTTPRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group(snippetsFilterGroup),
+					Kind:  gatewayv1.Kind(snippetsFilterKind),
+					Name:  gatewayv1.ObjectName(hostname),
+				},
+			},
+		}
+	}
 
 	rules := []gatewayv1.HTTPRouteRule{
 		{
@@ -69,6 +87,7 @@ func (n *nginxGateway) BuildHTTPRouteSpec(
 					},
 				},
 			},
+			Filters: filters,
 			BackendRefs: []gatewayv1.HTTPBackendRef{
 				{
 					BackendRef: gatewayv1.BackendRef{
@@ -82,7 +101,6 @@ func (n *nginxGateway) BuildHTTPRouteSpec(
 		},
 	}
 
-	// Return the complete HTTPRoute spec
 	return gatewayv1.HTTPRouteSpec{
 		CommonRouteSpec: gatewayv1.CommonRouteSpec{
 			ParentRefs: parentRefs,
@@ -92,82 +110,123 @@ func (n *nginxGateway) BuildHTTPRouteSpec(
 	}
 }
 
-// BuildAnnotations creates NGINX-specific annotations for features not available
-// in the standard Gateway API v1 spec.
-//
-// Annotations used:
-// - nginx.org/client-max-body-size: Request body size limit (no standard equivalent)
-// - nginx.org/proxy-read-timeout: Read timeout (client to gateway)
-// - nginx.org/proxy-send-timeout: Send timeout (gateway to backend)
-// - nginx.org/proxy-next-upstream-timeout: Retry timeout (retry policies experimental in Gateway API)
-// - nginx.org/proxy-next-upstream-tries: Maximum retry attempts
-// - nginx.org/proxy-next-upstream: Conditions for retrying requests
-//
-// Note: HTTPRoute.Spec.Rules[].Timeouts is not used because NGINX Gateway Fabric
-// does not support it yet (see https://github.com/nginx/nginx-gateway-fabric/issues/2164)
-func (n *nginxGateway) BuildAnnotations(directive chostname.ConnectToDeploymentDirective) map[string]string {
-	annotations := make(map[string]string)
+func (n *nginxGateway) BuildAnnotations(_ chostname.ConnectToDeploymentDirective) map[string]string {
+	return nil
+}
 
-	// Client max body size - no standard Gateway API equivalent
-	// This controls the maximum size of the client request body
-	annotations["nginx.org/client-max-body-size"] = strconv.Itoa(int(directive.MaxBodySize))
-
-	// Timeout configuration - using annotations because HTTPRoute timeouts are not supported
-	// ReadTimeout maps to proxy-read-timeout (client to gateway)
-	// SendTimeout maps to proxy-send-timeout (gateway to backend)
-	readTimeout := math.Ceil(float64(directive.ReadTimeout) / 1000.0)
-	sendTimeout := math.Ceil(float64(directive.SendTimeout) / 1000.0)
-	annotations["nginx.org/proxy-read-timeout"] = fmt.Sprintf("%d", int(readTimeout))
-	annotations["nginx.org/proxy-send-timeout"] = fmt.Sprintf("%d", int(sendTimeout))
-
-	// Retry/next upstream configuration - not in Gateway API v1 standard
-	// Gateway API has experimental retry policies, but they're not widely supported yet
-	nextTimeout := 0
-	if directive.NextTimeout > 0 {
-		nextTimeout = int(math.Ceil(float64(directive.NextTimeout) / 1000.0))
+// BuildRouteExtensions returns the auxiliary CRD objects to apply for a route. For
+// NGF that is a SnippetsFilter named after the route, carrying the http_options as
+// raw nginx directives at the location context. Returns nil when nothing is set.
+func (n *nginxGateway) BuildRouteExtensions(namespace, routeName string, directive chostname.ConnectToDeploymentDirective) []*unstructured.Unstructured {
+	snippet := httpOptionsSnippet(directive, proxyBufferSize())
+	if snippet == "" {
+		return nil
 	}
 
-	if nextTimeout > 0 {
-		annotations["nginx.org/proxy-next-upstream-timeout"] = fmt.Sprintf("%ds", nextTimeout)
+	sf := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": snippetsFilterAPIVersion,
+		"kind":       snippetsFilterKind,
+		"metadata": map[string]interface{}{
+			"name":      routeName,
+			"namespace": namespace,
+		},
+		"spec": map[string]interface{}{
+			"snippets": []interface{}{
+				map[string]interface{}{
+					"context": "http.server.location",
+					"value":   snippet,
+				},
+			},
+		},
+	}}
+
+	return []*unstructured.Unstructured{sf}
+}
+
+// proxyBufferSize returns the provider-wide proxy buffer size (nginx size string,
+// e.g. "16k") from the --proxy-buffer-size flag, preserved from the previous
+// annotation-based plumbing.
+func proxyBufferSize() string {
+	return viper.GetString(providerflags.FlagProxyBufferSize)
+}
+
+// httpOptionsSnippet renders the directive's http_options (plus the provider-wide
+// proxyBufferSize) as nginx directives for the location context. Returns "" when
+// nothing is set. Timeouts are emitted in milliseconds to preserve the manifest's
+// precision (nginx accepts an ms suffix).
+func httpOptionsSnippet(d chostname.ConnectToDeploymentDirective, proxyBufferSize string) string {
+	var b strings.Builder
+	line := func(format string, args ...interface{}) {
+		fmt.Fprintf(&b, format+"\n", args...)
 	}
 
-	annotations["nginx.org/proxy-next-upstream-tries"] = strconv.Itoa(int(directive.NextTries))
-
-	// Build next-upstream cases (error, timeout, http_500, etc.)
-	if len(directive.NextCases) > 0 {
-		strBuilder := strings.Builder{}
-		for i, v := range directive.NextCases {
-			if isValidHTTPStatusCode(v) {
-				strBuilder.WriteString("http_")
-			}
-			strBuilder.WriteString(v)
-
-			if i != len(directive.NextCases)-1 {
-				strBuilder.WriteRune(' ')
+	if d.MaxBodySize > 0 {
+		line("client_max_body_size %d;", d.MaxBodySize)
+	}
+	if d.ReadTimeout > 0 {
+		line("proxy_read_timeout %dms;", d.ReadTimeout)
+	}
+	if d.SendTimeout > 0 {
+		line("proxy_send_timeout %dms;", d.SendTimeout)
+	}
+	if proxyBufferSize != "" {
+		// proxy_buffer_size alone makes nginx's default proxy_busy_buffers_size
+		// (2x) exceed the default proxy_buffers pool, so the config is rejected on
+		// reload. Pair it with a matching proxy_buffers so it is valid for any size.
+		line("proxy_buffer_size %s;", proxyBufferSize)
+		line("proxy_buffers 8 %s;", proxyBufferSize)
+	}
+	if d.NextTries > 0 {
+		line("proxy_next_upstream_tries %d;", d.NextTries)
+	}
+	if d.NextTimeout > 0 {
+		line("proxy_next_upstream_timeout %dms;", d.NextTimeout)
+	}
+	if len(d.NextCases) > 0 {
+		cases := make([]string, 0, len(d.NextCases))
+		for _, c := range d.NextCases {
+			if tok, ok := normalizeNextCase(c); ok {
+				cases = append(cases, tok)
 			}
 		}
-		annotations["nginx.org/proxy-next-upstream"] = strBuilder.String()
+		if len(cases) > 0 {
+			line("proxy_next_upstream %s;", strings.Join(cases, " "))
+		}
 	}
 
-	// TODO(temporary): read proxy-buffer-size from viper directly to avoid
-	// plumbing through GatewayConfig; move to GatewayConfig when more settings need it.
-	if v := viper.GetString(providerflags.FlagProxyBufferSize); v != "" {
-		annotations["nginx.org/proxy-buffer-size"] = v
-	}
-
-	return annotations
+	return b.String()
 }
 
 // strPtr returns a pointer to the given string.
-// TODO: go 1.26 makes this helper unnecessary.
 func strPtr(s string) *string {
 	return &s
 }
 
-func isValidHTTPStatusCode(codeStr string) bool {
-	code, err := strconv.Atoi(codeStr)
-	if err != nil {
-		return false
+// validProxyNextUpstreamTokens is the closed set of tokens nginx accepts for
+// proxy_next_upstream. next_cases comes from the tenant SDL and is rendered into
+// a raw nginx snippet, so each value is validated against this set (bare status
+// codes normalized to the http_ form first) before it reaches the config. Values
+// outside the set are dropped, so a semicolon, newline, or brace cannot inject
+// directives or break the shared nginx configuration.
+var validProxyNextUpstreamTokens = map[string]struct{}{
+	"error":          {},
+	"timeout":        {},
+	"invalid_header": {},
+	"http_500":       {},
+	"http_502":       {},
+	"http_503":       {},
+	"http_504":       {},
+	"http_403":       {},
+	"http_404":       {},
+	"http_429":       {},
+	"non_idempotent": {},
+	"off":            {},
+}
+
+func normalizeNextCase(c string) (string, bool) {
+	if _, err := strconv.Atoi(c); err == nil {
+		c = "http_" + c
 	}
-	return http.StatusText(code) != ""
+	_, ok := validProxyNextUpstreamTokens[c]
+	return c, ok
 }

--- a/cluster/kube/gateway/nginx_gateway_test.go
+++ b/cluster/kube/gateway/nginx_gateway_test.go
@@ -1,0 +1,120 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	chostname "github.com/akash-network/provider/cluster/types/v1beta3/clients/hostname"
+)
+
+func testDirective() chostname.ConnectToDeploymentDirective {
+	return chostname.ConnectToDeploymentDirective{
+		Hostname:    "hello.localhost",
+		ServiceName: "web",
+		ServicePort: 80,
+		MaxBodySize: 2097152,
+		ReadTimeout: 60000,
+		SendTimeout: 60000,
+		NextTries:   3,
+		NextCases:   []string{"off"},
+	}
+}
+
+// TestHTTPOptionsSnippet asserts the directive plus the provider-wide buffer size
+// render to the expected nginx directives (ms rounded to whole seconds).
+func TestHTTPOptionsSnippet(t *testing.T) {
+	snip := httpOptionsSnippet(testDirective(), "16k")
+
+	for _, want := range []string{
+		"client_max_body_size 2097152;",
+		"proxy_read_timeout 60000ms;",
+		"proxy_send_timeout 60000ms;",
+		"proxy_buffer_size 16k;",
+		"proxy_buffers 8 16k;",
+		"proxy_next_upstream_tries 3;",
+		"proxy_next_upstream off;",
+	} {
+		require.Containsf(t, snip, want, "snippet missing %q", want)
+	}
+}
+
+// TestHTTPOptionsSnippetEmpty asserts an unset directive with no buffer size
+// produces no snippet, so no SnippetsFilter and no filter are emitted.
+func TestHTTPOptionsSnippetEmpty(t *testing.T) {
+	require.Empty(t, httpOptionsSnippet(chostname.ConnectToDeploymentDirective{}, ""))
+}
+
+// TestHTTPOptionsSnippetBufferOnly asserts the provider-wide buffer size alone
+// still yields a snippet (preserving the old global proxy-buffer-size behaviour).
+func TestHTTPOptionsSnippetBufferOnly(t *testing.T) {
+	require.Equal(t, "proxy_buffer_size 16k;\nproxy_buffers 8 16k;\n", httpOptionsSnippet(chostname.ConnectToDeploymentDirective{}, "16k"))
+}
+
+// TestHTTPOptionsSnippetNextCasesValidation asserts next_cases values outside the
+// closed proxy_next_upstream token set are dropped, so tenant input cannot inject
+// nginx directives, while valid tokens and status codes still render.
+func TestHTTPOptionsSnippetNextCasesValidation(t *testing.T) {
+	d := chostname.ConnectToDeploymentDirective{
+		NextCases: []string{"error", "500", "http_503", "off; } location /x { proxy_pass http://evil;", "bogus", "400", ""},
+	}
+	snip := httpOptionsSnippet(d, "")
+	require.Equal(t, "proxy_next_upstream error http_500 http_503;\n", snip)
+	require.NotContains(t, snip, "evil")
+	require.NotContains(t, snip, "}")
+}
+
+// TestHTTPOptionsSnippetNextCasesAllInvalid asserts the directive is omitted
+// entirely when no next_cases value survives validation.
+func TestHTTPOptionsSnippetNextCasesAllInvalid(t *testing.T) {
+	d := chostname.ConnectToDeploymentDirective{NextCases: []string{"; drop;", "nonsense"}}
+	require.Empty(t, httpOptionsSnippet(d, ""))
+}
+
+// TestBuildRouteExtensionsSnippetsFilter asserts BuildRouteExtensions emits a
+// SnippetsFilter named after the route carrying the snippet at the location
+// context, and nil when nothing is set (viper is unset in tests, so no buffer).
+func TestBuildRouteExtensionsSnippetsFilter(t *testing.T) {
+	gw := NewNginxGateway(log.NewNopLogger())
+
+	require.Nil(t, gw.BuildRouteExtensions("ns1", "hello.localhost", chostname.ConnectToDeploymentDirective{}))
+
+	exts := gw.BuildRouteExtensions("ns1", "hello.localhost", testDirective())
+	require.Len(t, exts, 1)
+	sf := exts[0]
+	require.Equal(t, "gateway.nginx.org/v1alpha1", sf.GetAPIVersion())
+	require.Equal(t, "SnippetsFilter", sf.GetKind())
+	require.Equal(t, "hello.localhost", sf.GetName())
+	require.Equal(t, "ns1", sf.GetNamespace())
+
+	snippets, found, err := unstructured.NestedSlice(sf.Object, "spec", "snippets")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, snippets, 1)
+	first, ok := snippets[0].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "http.server.location", first["context"])
+	require.Contains(t, first["value"], "client_max_body_size 2097152;")
+}
+
+// TestBuildHTTPRouteSpecExtensionRef asserts the rule gains an ExtensionRef filter
+// to the route's SnippetsFilter when http_options are set, and none when unset.
+func TestBuildHTTPRouteSpecExtensionRef(t *testing.T) {
+	gw := NewNginxGateway(log.NewNopLogger())
+
+	bare := gw.BuildHTTPRouteSpec("gw", "gwns", "hello.localhost", "web", 80, chostname.ConnectToDeploymentDirective{})
+	require.Empty(t, bare.Rules[0].Filters)
+
+	spec := gw.BuildHTTPRouteSpec("gw", "gwns", "hello.localhost", "web", 80, testDirective())
+	require.Len(t, spec.Rules[0].Filters, 1)
+	f := spec.Rules[0].Filters[0]
+	require.Equal(t, gatewayv1.HTTPRouteFilterExtensionRef, f.Type)
+	require.NotNil(t, f.ExtensionRef)
+	require.Equal(t, gatewayv1.Kind("SnippetsFilter"), f.ExtensionRef.Kind)
+	require.Equal(t, gatewayv1.Group("gateway.nginx.org"), f.ExtensionRef.Group)
+	require.Equal(t, gatewayv1.ObjectName("hello.localhost"), f.ExtensionRef.Name)
+}

--- a/cmd/provider-services/cmd/flags/flags.go
+++ b/cmd/provider-services/cmd/flags/flags.go
@@ -1,5 +1,11 @@
 package flags
 
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
 const (
 	FlagK8sManifestNS      = "k8s-manifest-ns"
 	FlagListenAddress      = "listen"
@@ -9,3 +15,28 @@ const (
 	FlagKubeConfig         = "kubeconfig"
 	FlagProxyBufferSize    = "proxy-buffer-size"
 )
+
+// nginxSizeRe matches an nginx size value: a positive integer with an optional
+// k/K (kilobytes) or m/M (megabytes) suffix, e.g. 512, 16k, 1m. That is the grammar
+// nginx accepts for proxy_buffer_size, so "16kb" and "16g" are invalid.
+var nginxSizeRe = regexp.MustCompile(`^([0-9]+)([kKmM]?)$`)
+
+// ValidateProxyBufferSize returns an error unless the value is empty (unset) or a
+// valid positive nginx size. The value is inserted verbatim into a per-route
+// SnippetsFilter, and NGF marks a structurally valid filter Accepted=True without
+// parsing its nginx contents, so a bad value such as "16kb" would only surface
+// later at nginx -t and block the data plane from applying the config. Rejecting
+// it at startup fails fast instead.
+func ValidateProxyBufferSize(value string) error {
+	if value == "" {
+		return nil
+	}
+	m := nginxSizeRe.FindStringSubmatch(value)
+	if m == nil {
+		return fmt.Errorf("invalid %s %q: expected a positive nginx size such as 16k, 512k, or 1m", FlagProxyBufferSize, value)
+	}
+	if n, err := strconv.ParseUint(m[1], 10, 64); err != nil || n == 0 {
+		return fmt.Errorf("invalid %s %q: size must be greater than zero", FlagProxyBufferSize, value)
+	}
+	return nil
+}

--- a/cmd/provider-services/cmd/flags/flags_test.go
+++ b/cmd/provider-services/cmd/flags/flags_test.go
@@ -1,0 +1,20 @@
+package flags
+
+import "testing"
+
+func TestValidateProxyBufferSize(t *testing.T) {
+	valid := []string{"", "16k", "16K", "1m", "1M", "512k", "1024", "8k"}
+	for _, v := range valid {
+		if err := ValidateProxyBufferSize(v); err != nil {
+			t.Errorf("ValidateProxyBufferSize(%q) = %v, want nil", v, err)
+		}
+	}
+
+	// "16kb" is the operator typo from the review; the rest are other bad forms.
+	invalid := []string{"16kb", "16g", "16G", "abc", "0", "0k", "-5", "16 k", "1.5m", "k", "16m2"}
+	for _, v := range invalid {
+		if err := ValidateProxyBufferSize(v); err == nil {
+			t.Errorf("ValidateProxyBufferSize(%q) = nil, want error", v)
+		}
+	}
+}

--- a/cmd/provider-services/cmd/run.go
+++ b/cmd/provider-services/cmd/run.go
@@ -227,6 +227,10 @@ func RunCmd() *cobra.Command {
 				return fmt.Errorf(`flag "%s" value must be > "%s"`, FlagMonitorRetryPeriod, 4*time.Second) // nolint: err113
 			}
 
+			if err := providerflags.ValidateProxyBufferSize(viper.GetString(providerflags.FlagProxyBufferSize)); err != nil {
+				return err
+			}
+
 			pconfigBackend := viper.GetString(FlagPersistentConfigBackend)
 			pconfigPath := viper.GetString(FlagPersistentConfigPath)
 

--- a/integration/gateway_api_test.go
+++ b/integration/gateway_api_test.go
@@ -38,6 +38,12 @@ var httpRouteGVR = schema.GroupVersionResource{
 	Resource: "httproutes",
 }
 
+var snippetsFilterGVR = schema.GroupVersionResource{
+	Group:    "gateway.nginx.org",
+	Version:  "v1alpha1",
+	Resource: "snippetsfilters",
+}
+
 // E2EGatewayAPI is the test suite for Gateway API integration tests.
 // It embeds IntegrationTestSuite with gatewayAPIMode enabled.
 type E2EGatewayAPI struct {
@@ -164,8 +170,8 @@ func (s *E2EGatewayAPI) TestE2EGatewayAPIHTTPRouteCreation() {
 		s.verifyHTTPRouteParentRef(ns, "gateway-test.localhost", "akash-gateway", "akash-gateway")
 	})
 
-	s.T().Run("HTTPRoute has correct annotations", func(t *testing.T) {
-		s.verifyHTTPRouteAnnotations(ns, "gateway-test.localhost")
+	s.T().Run("HTTPRoute references SnippetsFilter with http_options", func(t *testing.T) {
+		s.verifyHTTPRouteSnippet(ns, "gateway-test.localhost")
 	})
 
 	// Verify provider status
@@ -403,14 +409,17 @@ func (s *E2EGatewayAPI) verifyHTTPRouteParentRef(namespace, routeName, gatewayNa
 	}
 }
 
-// verifyHTTPRouteAnnotations checks that the HTTPRoute has correct annotations for HTTP options.
-// Expected annotations based on deployment-v2-gateway-api.yaml http_options:
-//   - read_timeout: 60000 (ms) -> nginx.org/proxy-read-timeout: "60" (seconds)
-//   - send_timeout: 60000 (ms) -> nginx.org/proxy-send-timeout: "60" (seconds)
-//   - max_body_size: 2097152 -> nginx.org/client-max-body-size: "2097152"
-//   - next_tries: 3 -> nginx.org/proxy-next-upstream-tries: "3"
-//   - next_timeout: 30000 (ms) -> nginx.org/proxy-next-upstream-timeout: "30s"
-func (s *E2EGatewayAPI) verifyHTTPRouteAnnotations(namespace, routeName string) {
+// verifyHTTPRouteSnippet checks that the HTTPRoute references a per-route
+// SnippetsFilter through an ExtensionRef filter, and that the SnippetsFilter
+// carries the SDL http_options as nginx directives. NGF applies http_options via
+// SnippetsFilters, not nginx.org/* annotations. Directives from
+// deployment-v2-gateway-api.yaml http_options (timeouts in milliseconds):
+//   - max_body_size: 2097152 -> client_max_body_size 2097152;
+//   - read_timeout: 60000 -> proxy_read_timeout 60000ms;
+//   - send_timeout: 60000 -> proxy_send_timeout 60000ms;
+//   - next_tries: 3 -> proxy_next_upstream_tries 3;
+//   - next_timeout: 30000 -> proxy_next_upstream_timeout 30000ms;
+func (s *E2EGatewayAPI) verifyHTTPRouteSnippet(namespace, routeName string) {
 	if s.dc == nil {
 		s.T().Skip("dynamic client not available")
 		return
@@ -422,29 +431,48 @@ func (s *E2EGatewayAPI) verifyHTTPRouteAnnotations(namespace, routeName string) 
 	route, err := s.dc.Resource(httpRouteGVR).Namespace(namespace).Get(ctx, routeName, metav1.GetOptions{})
 	require.NoError(s.T(), err)
 
-	annotations := route.GetAnnotations()
-	s.T().Logf("HTTPRoute annotations: %v", annotations)
+	spec, ok := route.Object["spec"].(map[string]interface{})
+	require.True(s.T(), ok, "HTTPRoute should have spec")
+	rules, ok := spec["rules"].([]interface{})
+	require.True(s.T(), ok, "HTTPRoute should have rules")
+	require.NotEmpty(s.T(), rules)
+	rule := rules[0].(map[string]interface{})
+	filters, ok := rule["filters"].([]interface{})
+	require.True(s.T(), ok, "rule should have an ExtensionRef filter")
+	require.NotEmpty(s.T(), filters)
 
-	// Verify NGINX Gateway Fabric annotations match http_options from SDL
-	// read_timeout: 60000ms -> 60s
-	assert.Equal(s.T(), "60", annotations["nginx.org/proxy-read-timeout"],
-		"read_timeout should be converted to seconds")
+	filter := filters[0].(map[string]interface{})
+	assert.Equal(s.T(), "ExtensionRef", filter["type"], "filter should be an ExtensionRef")
+	extRef, ok := filter["extensionRef"].(map[string]interface{})
+	require.True(s.T(), ok, "filter should have extensionRef")
+	assert.Equal(s.T(), "gateway.nginx.org", extRef["group"])
+	assert.Equal(s.T(), "SnippetsFilter", extRef["kind"])
+	assert.Equal(s.T(), routeName, extRef["name"], "ExtensionRef should reference the route's SnippetsFilter")
 
-	// send_timeout: 60000ms -> 60s
-	assert.Equal(s.T(), "60", annotations["nginx.org/proxy-send-timeout"],
-		"send_timeout should be converted to seconds")
+	sf, err := s.dc.Resource(snippetsFilterGVR).Namespace(namespace).Get(ctx, routeName, metav1.GetOptions{})
+	require.NoError(s.T(), err, "SnippetsFilter %s should exist", routeName)
 
-	// max_body_size: 2097152 bytes
-	assert.Equal(s.T(), "2097152", annotations["nginx.org/client-max-body-size"],
-		"max_body_size should be set")
+	sfSpec, ok := sf.Object["spec"].(map[string]interface{})
+	require.True(s.T(), ok, "SnippetsFilter should have spec")
+	snippets, ok := sfSpec["snippets"].([]interface{})
+	require.True(s.T(), ok, "SnippetsFilter should have snippets")
+	require.NotEmpty(s.T(), snippets)
+	snippet := snippets[0].(map[string]interface{})
+	assert.Equal(s.T(), "http.server.location", snippet["context"])
 
-	// next_tries: 3
-	assert.Equal(s.T(), "3", annotations["nginx.org/proxy-next-upstream-tries"],
-		"next_tries should be set")
+	value, ok := snippet["value"].(string)
+	require.True(s.T(), ok, "snippet should have a value")
+	s.T().Logf("SnippetsFilter value:\n%s", value)
 
-	// next_timeout: 30000ms -> 30s
-	assert.Equal(s.T(), "30s", annotations["nginx.org/proxy-next-upstream-timeout"],
-		"next_timeout should be converted to seconds with 's' suffix")
+	for _, want := range []string{
+		"client_max_body_size 2097152;",
+		"proxy_read_timeout 60000ms;",
+		"proxy_send_timeout 60000ms;",
+		"proxy_next_upstream_tries 3;",
+		"proxy_next_upstream_timeout 30000ms;",
+	} {
+		assert.Contains(s.T(), value, want, "snippet should contain %q", want)
+	}
 }
 
 // TestGatewayAPISuite runs the Gateway API e2e test suite

--- a/operator/hostname/cmd.go
+++ b/operator/hostname/cmd.go
@@ -26,6 +26,10 @@ func Cmd() *cobra.Command {
 
 			ns := viper.GetString(providerflags.FlagK8sManifestNS)
 
+			if err := providerflags.ValidateProxyBufferSize(viper.GetString(providerflags.FlagProxyBufferSize)); err != nil {
+				return err
+			}
+
 			config := common.GetOperatorConfigFromViper()
 
 			logger := common.OpenLogger().With("op", "hostname")


### PR DESCRIPTION
Providers to create `SnippetFilter` for options on Gateway providers

## Test evidence

```
1. All filters emitted and reaching the data plane. The provider's SnippetsFilter and the rendered nginx include are identical, and nginx -t accepts them:

$ nginx -t
nginx: configuration file /etc/nginx/nginx.conf test is successful

$ cat .../SnippetsFilter_http.server.location_<ns>_hello.localhost.conf
client_max_body_size 2097152;
proxy_read_timeout 60000ms;
proxy_send_timeout 60000ms;
proxy_buffer_size 16k;
proxy_buffers 8 16k;
proxy_next_upstream_tries 3;
proxy_next_upstream off;

2. Programmed and resolved (no dangling reference).

HTTPRoute hello.localhost:  Accepted=True  ResolvedRefs=True
SnippetsFilter hello.localhost: Accepted=True
Gateway akash-gateway:  Accepted=True  Programmed=True

3. client_max_body_size enforced end to end (curl through the gateway).

[GET /]                 -> 200     # route serves
[POST 3MB > 2MB limit]  -> 413     # nginx rejects, per client_max_body_size
[POST 1MB < 2MB limit]  -> 405     # under limit: passed nginx to the backend (405 = app rejects POST)

nginx confirms the cause of the 413:

[error] client intended to send too large body: 3145728 bytes, server: hello.localhost, request: "POST / HTTP/1.1"
```